### PR TITLE
chore: release v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "bphelper-build"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "expect-test",
  "serde",
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "bphelper-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "cargo-generate",
@@ -366,7 +366,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "cli-battery-pack"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "battery-pack",
  "clap",
@@ -718,7 +718,7 @@ dependencies = [
 
 [[package]]
 name = "error-battery-pack"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "battery-pack",
@@ -1814,7 +1814,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "logging-battery-pack"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "battery-pack",
  "tracing",

--- a/src/battery-pack/CHANGELOG.md
+++ b/src/battery-pack/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/battery-pack-rs/battery-pack/releases/tag/battery-pack-v0.2.0) - 2026-01-23
+
+### Added
+
+- show examples in `cargo bp show` with --path support
+- auto-generate battery pack documentation from cargo metadata
+- interactive template selection for `cargo bp new`
+- add interactive TUI for `cargo bp list` and `cargo bp show`
+- add search and show commands to cargo bp CLI
+- cargo bp new downloads from crates.io CDN
+
+### Other
+
+- fmt, bump versions
+- rename `cargo bp search` to `cargo bp list`
+- update cargo-toml metadata

--- a/src/battery-pack/Cargo.toml
+++ b/src/battery-pack/Cargo.toml
@@ -12,8 +12,8 @@ name = "cargo-bp"
 path = "src/main.rs"
 
 [dependencies]
-bphelper-build = { path = "bphelper-build", version = "0.1.1" }
-bphelper-cli = { path = "bphelper-cli", version = "0.1.0" }
+bphelper-build = { path = "bphelper-build", version = "0.2.0" }
+bphelper-cli = { path = "bphelper-cli", version = "0.2.0" }
 anyhow.workspace = true
 
 [dev-dependencies]

--- a/src/battery-pack/bphelper-build/CHANGELOG.md
+++ b/src/battery-pack/bphelper-build/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/battery-pack-rs/battery-pack/releases/tag/bphelper-build-v0.2.0) - 2026-01-23
+
+### Added
+
+- auto-generate battery pack documentation from cargo metadata
+
+### Other
+
+- fmt, bump versions
+- update cargo-toml metadata

--- a/src/battery-pack/bphelper-cli/CHANGELOG.md
+++ b/src/battery-pack/bphelper-cli/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/battery-pack-rs/battery-pack/releases/tag/bphelper-cli-v0.2.0) - 2026-01-23
+
+### Added
+
+- show examples in `cargo bp show` with --path support
+- interactive template selection for `cargo bp new`
+- add interactive TUI for `cargo bp list` and `cargo bp show`
+- add search and show commands to cargo bp CLI
+- cargo bp new downloads from crates.io CDN
+
+### Other
+
+- fmt, bump versions
+- rename `cargo bp search` to `cargo bp list`
+- update cargo-toml metadata

--- a/src/cli-battery-pack/CHANGELOG.md
+++ b/src/cli-battery-pack/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/battery-pack-rs/battery-pack/releases/tag/cli-battery-pack-v0.2.0) - 2026-01-23
+
+### Added
+
+- auto-generate battery pack documentation from cargo metadata
+
+### Other
+
+- fmt, bump versions
+- update cargo-toml metadata

--- a/src/error-battery-pack/CHANGELOG.md
+++ b/src/error-battery-pack/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/battery-pack-rs/battery-pack/releases/tag/error-battery-pack-v0.2.0) - 2026-01-23
+
+### Other
+
+- fmt, bump versions
+- update cargo-toml metadata

--- a/src/logging-battery-pack/CHANGELOG.md
+++ b/src/logging-battery-pack/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/battery-pack-rs/battery-pack/releases/tag/logging-battery-pack-v0.2.0) - 2026-01-23
+
+### Other
+
+- fmt, bump versions
+- update cargo-toml metadata


### PR DESCRIPTION



## 🤖 New release

* `bphelper-build`: 0.2.0
* `bphelper-cli`: 0.2.0
* `battery-pack`: 0.2.0
* `error-battery-pack`: 0.2.0
* `logging-battery-pack`: 0.2.0
* `cli-battery-pack`: 0.2.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `bphelper-build`

<blockquote>

## [0.2.0](https://github.com/battery-pack-rs/battery-pack/releases/tag/bphelper-build-v0.2.0) - 2026-01-23

### Added

- auto-generate battery pack documentation from cargo metadata

### Other

- fmt, bump versions
- update cargo-toml metadata
</blockquote>

## `bphelper-cli`

<blockquote>

## [0.2.0](https://github.com/battery-pack-rs/battery-pack/releases/tag/bphelper-cli-v0.2.0) - 2026-01-23

### Added

- show examples in `cargo bp show` with --path support
- interactive template selection for `cargo bp new`
- add interactive TUI for `cargo bp list` and `cargo bp show`
- add search and show commands to cargo bp CLI
- cargo bp new downloads from crates.io CDN

### Other

- fmt, bump versions
- rename `cargo bp search` to `cargo bp list`
- update cargo-toml metadata
</blockquote>

## `battery-pack`

<blockquote>

## [0.2.0](https://github.com/battery-pack-rs/battery-pack/releases/tag/battery-pack-v0.2.0) - 2026-01-23

### Added

- show examples in `cargo bp show` with --path support
- auto-generate battery pack documentation from cargo metadata
- interactive template selection for `cargo bp new`
- add interactive TUI for `cargo bp list` and `cargo bp show`
- add search and show commands to cargo bp CLI
- cargo bp new downloads from crates.io CDN

### Other

- fmt, bump versions
- rename `cargo bp search` to `cargo bp list`
- update cargo-toml metadata
</blockquote>

## `error-battery-pack`

<blockquote>

## [0.2.0](https://github.com/battery-pack-rs/battery-pack/releases/tag/error-battery-pack-v0.2.0) - 2026-01-23

### Other

- fmt, bump versions
- update cargo-toml metadata
</blockquote>

## `logging-battery-pack`

<blockquote>

## [0.2.0](https://github.com/battery-pack-rs/battery-pack/releases/tag/logging-battery-pack-v0.2.0) - 2026-01-23

### Other

- fmt, bump versions
- update cargo-toml metadata
</blockquote>

## `cli-battery-pack`

<blockquote>

## [0.2.0](https://github.com/battery-pack-rs/battery-pack/releases/tag/cli-battery-pack-v0.2.0) - 2026-01-23

### Added

- auto-generate battery pack documentation from cargo metadata

### Other

- fmt, bump versions
- update cargo-toml metadata
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).