### PR TITLE
fix(tui): fix terminal exit

### DIFF
--- a/src/battery-pack/bphelper-cli/src/tui.rs
+++ b/src/battery-pack/bphelper-cli/src/tui.rs
@@ -7,7 +7,7 @@ use crate::{
 use anyhow::Result;
 use bphelper_manifest::DepKind;
 use std::collections::{BTreeMap, BTreeSet};
-use crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
 use ratatui::{
     Frame,
     layout::{Constraint, Flex, Layout, Position, Rect},
@@ -730,6 +730,12 @@ impl App {
                 if let Event::Key(key) = event::read()? {
                     // Windows compatibility: only handle Press events
                     if key.kind == KeyEventKind::Press {
+                        // Ctrl+C quits immediately
+                        if key.modifiers.contains(KeyModifiers::CONTROL)
+                            && key.code == KeyCode::Char('c')
+                        {
+                            break;
+                        }
                         self.handle_key(key.code);
                     }
                 }


### PR DESCRIPTION
This was bugging me:

## Fix terminal restore on TUI exit && add Ctrl+C handler

### Summary

The TUI could leave the terminal in a broken state (raw mode, hidden cursor) on error exits, panics, or Ctrl+C.

Two root causes:
- `ratatui::restore()` was only called in the happy path — any `?` propagation skipped it
- `ratatui::restore()` disables raw mode and leaves the alternate screen, but does **not** re-show the cursor

Additionally, Ctrl+C was silently ignored because crossterm's raw mode intercepts SIGINT and delivers it as a key event, which the TUI wasn't handling.

### Changes

- Ensure terminal and cursor are always restored on exit, including error paths and panics
- Handle Ctrl+C as a quit signal in the event loop

### Testing

Manually verified cursor is visible and terminal is clean after:
- `cargo bp list` → open in browser (fails) → "Press Enter" prompt
- Ctrl+C from the above prompt
- Ctrl+C from within the TUI
