### PR TITLE
feat: Add aliases for `List`, `Show`, and `Status` subcommands.

### DIFF
--- a/src/battery-pack/bphelper-cli/src/lib.rs
+++ b/src/battery-pack/bphelper-cli/src/lib.rs
@@ -137,6 +137,7 @@ pub enum BpCommands {
     },
 
     /// List available battery packs on crates.io
+    #[command(visible_alias = "ls")]
     List {
         /// Filter by name (omit to list all battery packs)
         filter: Option<String>,
@@ -147,6 +148,7 @@ pub enum BpCommands {
     },
 
     /// Show detailed information about a battery pack
+    #[command(visible_alias = "info")]
     Show {
         /// Name of the battery pack (e.g., "cli" resolves to "cli-battery-pack")
         battery_pack: String,
@@ -161,6 +163,7 @@ pub enum BpCommands {
     },
 
     /// Show status of installed battery packs and version warnings
+    #[command(visible_alias = "stat")]
     Status {
         // [impl cli.path.subcommands]
         /// Use a local path instead of downloading from crates.io


### PR DESCRIPTION
add shorthand aliases for the List, Show, and Status subcommands to improve CLI usability and reduce typing.