### PR TITLE
fix: disable release-plz for *-battery-pack crates

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -12,7 +12,17 @@ changelog_include = [
     "bphelper-build",
     "bphelper-cli",
     "bphelper-manifest",
-    "cli-battery-pack",
-    "error-battery-pack",
-    "logging-battery-pack",
 ]
+
+# TODO: re-enable once trusted publishing is set up
+[[package]]
+name = "cli-battery-pack"
+release = false
+
+[[package]]
+name = "error-battery-pack"
+release = false
+
+[[package]]
+name = "logging-battery-pack"
+release = false


### PR DESCRIPTION
release-plz fails trying to package historical versions of these crates because workspace dependency versions have moved on since they were resurrected. Disable them until trusted publishing is set up.