### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "battery-pack"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "bphelper-build",
@@ -214,7 +214,7 @@ dependencies = [
 
 [[package]]
 name = "bphelper-manifest"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "expect-test",
  "serde",

--- a/src/battery-pack/CHANGELOG.md
+++ b/src/battery-pack/CHANGELOG.md
@@ -7,6 +7,62 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.4.2...battery-pack-v0.4.3) - 2026-03-02
+
+### Added
+
+- Add aliases for `List`, `Show`, and `Status` subcommands.
+- *(tui)* handle Ctrl+C as quit
+- --path flag for sync/status, bare `cargo bp` launches TUI
+- error screen for network failures in TUI
+- dep_kind cycling and feature-dependency toggle constraint
+- implement docgen with bphelper-build crate and 14 tests
+- implement cargo bp status with version warnings
+- wire --crate-source through all discovery subcommands
+- implement --crate-source flag for local workspace discovery
+- add repository warning to validate, plus tests
+- implement cross-pack crate merging
+- add cli.validate.* spec paragraphs and integration tests
+- add cargo bp validate and rewrite spec/manifest layer
+- implement option 3 — sync-based battery packs with sets
+
+### Fixed
+
+- fix a lot of clippy lints
+- *(tui)* restore terminal and cursor on error exit and panic
+- propagate cargo bp sync errors instead of silently discarding
+- correct pre-existing test failures in bphelper-manifest
+- remove .clone() on Copy type, use BTreeSet for feature lookup
+- metadata location abstraction + dep-kind routing + hidden filtering
+- repair 5 invalid tracey references, coverage 39%→41%
+- give clear error when cargo bp validate runs from workspace root
+- handle empty parent path in find_workspace_manifest
+
+### Other
+
+- *(typos)* fix typos
+- Merge pull request #4 from jlizen/fix-terminal-exit
+- TUI polish — dedup render/test helpers, iterator for selectable_items
+- extract CrateEntry::new constructor (2 copies)
+- extract wait_for_enter helper (3 copies)
+- extract list_nav helper for non-wrapping ListState movement
+- TUI code review cleanup — dedup, idiom fixes, test helpers
+- TUI code review cleanup — dedup, idiom fixes, test helpers
+- tests andsuch
+- review fixes — merge non-additive spec rules, fix bugs, dedup
+- Add missing [verify] tags for spec coverage
+- eliminate CargoManifest, reuse BatteryPackSpec from bphelper-manifest
+- shared reqwest client via OnceLock
+- deduplicate workspace ref and dep writing patterns
+- single read-modify-write for workspace Cargo.toml in add_battery_pack
+- add group2 add tests and list integration tests
+- add [impl] tags + [verify] tests for 4 existing rules, fix 2 invalid refs
+- sync behavior — add [impl] tags + tests
+- TOML preservation round-trip tests
+- add tracey [impl] tags for format and cli spec rules
+- rename 'set' to 'feature' in CLI, remove error-battery-pack
+- clean up cargo bp add TUI and interactive picker
+
 ## [0.3.0](https://github.com/battery-pack-rs/battery-pack/releases/tag/battery-pack-v0.3.0) - 2026-01-23
 
 ### Added

--- a/src/battery-pack/Cargo.toml
+++ b/src/battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "battery-pack"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 description = "Curated crate bundles with docs, templates, and agentic skills"
 license = "MIT OR Apache-2.0"
@@ -31,7 +31,7 @@ path = "src/main.rs"
 [dependencies]
 bphelper-build = { path = "bphelper-build", version = "0.4.1" }
 bphelper-cli = { path = "bphelper-cli", version = "0.4.1" }
-bphelper-manifest = { path = "bphelper-manifest", version = "0.4.1" }
+bphelper-manifest = { path = "bphelper-manifest", version = "0.5.0" }
 anyhow.workspace = true
 
 [dev-dependencies]

--- a/src/battery-pack/bphelper-build/CHANGELOG.md
+++ b/src/battery-pack/bphelper-build/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.4.1](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-build-v0.3.0...bphelper-build-v0.4.1) - 2026-03-02
+
+### Added
+
+- implement docgen with bphelper-build crate and 14 tests
+- implement option 3 — sync-based battery packs with sets
+
+### Other
+
+- tests andsuch

--- a/src/battery-pack/bphelper-build/Cargo.toml
+++ b/src/battery-pack/bphelper-build/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/battery-pack-rs/battery-pack"
 keywords = ["battery-pack"]
 
 [dependencies]
-bphelper-manifest = { path = "../bphelper-manifest", version = "0.4.1" }
+bphelper-manifest = { path = "../bphelper-manifest", version = "0.5.0" }
 handlebars.workspace = true
 cargo_metadata.workspace = true
 serde.workspace = true

--- a/src/battery-pack/bphelper-cli/CHANGELOG.md
+++ b/src/battery-pack/bphelper-cli/CHANGELOG.md
@@ -7,6 +7,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.4.0...bphelper-cli-v0.4.1) - 2026-03-02
+
+### Added
+
+- Add aliases for `List`, `Show`, and `Status` subcommands.
+- *(tui)* handle Ctrl+C as quit
+- --path flag for sync/status, bare `cargo bp` launches TUI
+- error screen for network failures in TUI
+- dep_kind cycling and feature-dependency toggle constraint
+- implement cargo bp status with version warnings
+- wire --crate-source through all discovery subcommands
+- implement --crate-source flag for local workspace discovery
+- add repository warning to validate, plus tests
+- implement cross-pack crate merging
+- add cli.validate.* spec paragraphs and integration tests
+- add cargo bp validate and rewrite spec/manifest layer
+
+### Fixed
+
+- fix a lot of clippy lints
+- *(tui)* restore terminal and cursor on error exit and panic
+- propagate cargo bp sync errors instead of silently discarding
+- remove .clone() on Copy type, use BTreeSet for feature lookup
+- metadata location abstraction + dep-kind routing + hidden filtering
+- repair 5 invalid tracey references, coverage 39%→41%
+- give clear error when cargo bp validate runs from workspace root
+- handle empty parent path in find_workspace_manifest
+
+### Other
+
+- *(typos)* fix typos
+- TUI polish — dedup render/test helpers, iterator for selectable_items
+- extract CrateEntry::new constructor (2 copies)
+- extract wait_for_enter helper (3 copies)
+- extract list_nav helper for non-wrapping ListState movement
+- TUI code review cleanup — dedup, idiom fixes, test helpers
+- TUI code review cleanup — dedup, idiom fixes, test helpers
+- review fixes — merge non-additive spec rules, fix bugs, dedup
+- Add missing [verify] tags for spec coverage
+- eliminate CargoManifest, reuse BatteryPackSpec from bphelper-manifest
+- shared reqwest client via OnceLock
+- deduplicate workspace ref and dep writing patterns
+- single read-modify-write for workspace Cargo.toml in add_battery_pack
+- add group2 add tests and list integration tests
+- add [impl] tags + [verify] tests for 4 existing rules, fix 2 invalid refs
+- sync behavior — add [impl] tags + tests
+- TOML preservation round-trip tests
+- add tracey [impl] tags for format and cli spec rules
+- rename 'set' to 'feature' in CLI, remove error-battery-pack
+- clean up cargo bp add TUI and interactive picker
+
 ## [0.3.0](https://github.com/battery-pack-rs/battery-pack/releases/tag/bphelper-cli-v0.3.0) - 2026-01-23
 
 ### Added

--- a/src/battery-pack/bphelper-cli/Cargo.toml
+++ b/src/battery-pack/bphelper-cli/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/battery-pack-rs/battery-pack"
 keywords = ["battery-pack", "cli", "cargo"]
 
 [dependencies]
-bphelper-manifest = { path = "../bphelper-manifest", version = "0.4.1" }
+bphelper-manifest = { path = "../bphelper-manifest", version = "0.5.0" }
 clap.workspace = true
 cargo-generate.workspace = true
 cargo_metadata.workspace = true

--- a/src/battery-pack/bphelper-manifest/CHANGELOG.md
+++ b/src/battery-pack/bphelper-manifest/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.0](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-manifest-v0.4.1...bphelper-manifest-v0.5.0) - 2026-03-02
+
+### Added
+
+- implement cargo bp status with version warnings
+- implement cross-pack crate merging
+- add cargo bp validate and rewrite spec/manifest layer
+
+### Fixed
+
+- fix a lot of clippy lints
+- correct pre-existing test failures in bphelper-manifest
+- metadata location abstraction + dep-kind routing + hidden filtering
+
+### Other
+
+- review fixes — merge non-additive spec rules, fix bugs, dedup
+- eliminate CargoManifest, reuse BatteryPackSpec from bphelper-manifest
+- sync behavior — add [impl] tags + tests
+- add tracey [impl] tags for format and cli spec rules
+- clean up cargo bp add TUI and interactive picker

--- a/src/battery-pack/bphelper-manifest/Cargo.toml
+++ b/src/battery-pack/bphelper-manifest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bphelper-manifest"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2024"
 description = "Shared battery pack manifest parsing"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `bphelper-manifest`: 0.4.1 -> 0.5.0 (⚠ API breaking changes)
* `bphelper-build`: 0.3.0 -> 0.4.1
* `bphelper-cli`: 0.4.0 -> 0.4.1
* `battery-pack`: 0.4.2 -> 0.4.3 (✓ API compatible changes)

### ⚠ `bphelper-manifest` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field BatteryPackSpec.description in /tmp/.tmpMN6ccX/battery-pack/src/battery-pack/bphelper-manifest/src/lib.rs:161
  field BatteryPackSpec.repository in /tmp/.tmpMN6ccX/battery-pack/src/battery-pack/bphelper-manifest/src/lib.rs:163
  field BatteryPackSpec.keywords in /tmp/.tmpMN6ccX/battery-pack/src/battery-pack/bphelper-manifest/src/lib.rs:165
  field BatteryPackSpec.crates in /tmp/.tmpMN6ccX/battery-pack/src/battery-pack/bphelper-manifest/src/lib.rs:168
  field BatteryPackSpec.features in /tmp/.tmpMN6ccX/battery-pack/src/battery-pack/bphelper-manifest/src/lib.rs:171
  field BatteryPackSpec.hidden in /tmp/.tmpMN6ccX/battery-pack/src/battery-pack/bphelper-manifest/src/lib.rs:174
  field BatteryPackSpec.templates in /tmp/.tmpMN6ccX/battery-pack/src/battery-pack/bphelper-manifest/src/lib.rs:176

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function bphelper_manifest::assert_no_regular_deps, previously in file /tmp/.tmpxwT11I/bphelper-manifest/src/lib.rs:395
  function bphelper_manifest::check_drift, previously in file /tmp/.tmpxwT11I/bphelper-manifest/src/lib.rs:326
  function bphelper_manifest::parse_user_manifest, previously in file /tmp/.tmpxwT11I/bphelper-manifest/src/lib.rs:207

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct bphelper_manifest::UserManifest, previously in file /tmp/.tmpxwT11I/bphelper-manifest/src/lib.rs:126
  struct bphelper_manifest::SetSpec, previously in file /tmp/.tmpxwT11I/bphelper-manifest/src/lib.rs:33
  struct bphelper_manifest::SetCrateSpec, previously in file /tmp/.tmpxwT11I/bphelper-manifest/src/lib.rs:39
  struct bphelper_manifest::DepSpec, previously in file /tmp/.tmpxwT11I/bphelper-manifest/src/lib.rs:26

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field dev_dependencies of struct BatteryPackSpec, previously in file /tmp/.tmpxwT11I/bphelper-manifest/src/lib.rs:19
  field default_crates of struct BatteryPackSpec, previously in file /tmp/.tmpxwT11I/bphelper-manifest/src/lib.rs:20
  field sets of struct BatteryPackSpec, previously in file /tmp/.tmpxwT11I/bphelper-manifest/src/lib.rs:21
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `bphelper-manifest`

<blockquote>

## [0.5.0](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-manifest-v0.4.1...bphelper-manifest-v0.5.0) - 2026-03-02

### Added

- implement cargo bp status with version warnings
- implement cross-pack crate merging
- add cargo bp validate and rewrite spec/manifest layer

### Fixed

- fix a lot of clippy lints
- correct pre-existing test failures in bphelper-manifest
- metadata location abstraction + dep-kind routing + hidden filtering

### Other

- review fixes — merge non-additive spec rules, fix bugs, dedup
- eliminate CargoManifest, reuse BatteryPackSpec from bphelper-manifest
- sync behavior — add [impl] tags + tests
- add tracey [impl] tags for format and cli spec rules
- clean up cargo bp add TUI and interactive picker
</blockquote>

## `bphelper-build`

<blockquote>

## [0.4.1](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-build-v0.3.0...bphelper-build-v0.4.1) - 2026-03-02

### Added

- implement docgen with bphelper-build crate and 14 tests
- implement option 3 — sync-based battery packs with sets

### Other

- tests andsuch
</blockquote>

## `bphelper-cli`

<blockquote>

## [0.4.1](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.4.0...bphelper-cli-v0.4.1) - 2026-03-02

### Added

- Add aliases for `List`, `Show`, and `Status` subcommands.
- *(tui)* handle Ctrl+C as quit
- --path flag for sync/status, bare `cargo bp` launches TUI
- error screen for network failures in TUI
- dep_kind cycling and feature-dependency toggle constraint
- implement cargo bp status with version warnings
- wire --crate-source through all discovery subcommands
- implement --crate-source flag for local workspace discovery
- add repository warning to validate, plus tests
- implement cross-pack crate merging
- add cli.validate.* spec paragraphs and integration tests
- add cargo bp validate and rewrite spec/manifest layer

### Fixed

- fix a lot of clippy lints
- *(tui)* restore terminal and cursor on error exit and panic
- propagate cargo bp sync errors instead of silently discarding
- remove .clone() on Copy type, use BTreeSet for feature lookup
- metadata location abstraction + dep-kind routing + hidden filtering
- repair 5 invalid tracey references, coverage 39%→41%
- give clear error when cargo bp validate runs from workspace root
- handle empty parent path in find_workspace_manifest

### Other

- *(typos)* fix typos
- TUI polish — dedup render/test helpers, iterator for selectable_items
- extract CrateEntry::new constructor (2 copies)
- extract wait_for_enter helper (3 copies)
- extract list_nav helper for non-wrapping ListState movement
- TUI code review cleanup — dedup, idiom fixes, test helpers
- TUI code review cleanup — dedup, idiom fixes, test helpers
- review fixes — merge non-additive spec rules, fix bugs, dedup
- Add missing [verify] tags for spec coverage
- eliminate CargoManifest, reuse BatteryPackSpec from bphelper-manifest
- shared reqwest client via OnceLock
- deduplicate workspace ref and dep writing patterns
- single read-modify-write for workspace Cargo.toml in add_battery_pack
- add group2 add tests and list integration tests
- add [impl] tags + [verify] tests for 4 existing rules, fix 2 invalid refs
- sync behavior — add [impl] tags + tests
- TOML preservation round-trip tests
- add tracey [impl] tags for format and cli spec rules
- rename 'set' to 'feature' in CLI, remove error-battery-pack
- clean up cargo bp add TUI and interactive picker
</blockquote>

## `battery-pack`

<blockquote>

## [0.4.3](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.4.2...battery-pack-v0.4.3) - 2026-03-02

### Added

- Add aliases for `List`, `Show`, and `Status` subcommands.
- *(tui)* handle Ctrl+C as quit
- --path flag for sync/status, bare `cargo bp` launches TUI
- error screen for network failures in TUI
- dep_kind cycling and feature-dependency toggle constraint
- implement docgen with bphelper-build crate and 14 tests
- implement cargo bp status with version warnings
- wire --crate-source through all discovery subcommands
- implement --crate-source flag for local workspace discovery
- add repository warning to validate, plus tests
- implement cross-pack crate merging
- add cli.validate.* spec paragraphs and integration tests
- add cargo bp validate and rewrite spec/manifest layer
- implement option 3 — sync-based battery packs with sets

### Fixed

- fix a lot of clippy lints
- *(tui)* restore terminal and cursor on error exit and panic
- propagate cargo bp sync errors instead of silently discarding
- correct pre-existing test failures in bphelper-manifest
- remove .clone() on Copy type, use BTreeSet for feature lookup
- metadata location abstraction + dep-kind routing + hidden filtering
- repair 5 invalid tracey references, coverage 39%→41%
- give clear error when cargo bp validate runs from workspace root
- handle empty parent path in find_workspace_manifest

### Other

- *(typos)* fix typos
- Merge pull request #4 from jlizen/fix-terminal-exit
- TUI polish — dedup render/test helpers, iterator for selectable_items
- extract CrateEntry::new constructor (2 copies)
- extract wait_for_enter helper (3 copies)
- extract list_nav helper for non-wrapping ListState movement
- TUI code review cleanup — dedup, idiom fixes, test helpers
- TUI code review cleanup — dedup, idiom fixes, test helpers
- tests andsuch
- review fixes — merge non-additive spec rules, fix bugs, dedup
- Add missing [verify] tags for spec coverage
- eliminate CargoManifest, reuse BatteryPackSpec from bphelper-manifest
- shared reqwest client via OnceLock
- deduplicate workspace ref and dep writing patterns
- single read-modify-write for workspace Cargo.toml in add_battery_pack
- add group2 add tests and list integration tests
- add [impl] tags + [verify] tests for 4 existing rules, fix 2 invalid refs
- sync behavior — add [impl] tags + tests
- TOML preservation round-trip tests
- add tracey [impl] tags for format and cli spec rules
- rename 'set' to 'feature' in CLI, remove error-battery-pack
- clean up cargo bp add TUI and interactive picker
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).