### PR TITLE
fix(ci): add contents write permission for release asset uploads

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -10,6 +10,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Build ${{ matrix.target }}


### PR DESCRIPTION
Partially addresses: #25 

Note that this only runs when we cut a release (or manual dispatch), this isn't exposing write permissions to PR targets.