### PR TITLE
fix(ci): sequence release-plz PR job after release job

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -33,8 +33,9 @@ jobs:
 
   release-plz-pr:
     name: Release-plz PR
+    needs: release-plz-release
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'battery-pack-rs' }}
+    if: ${{ !failure() && github.repository_owner == 'battery-pack-rs' }}
     permissions:
       pull-requests: write
       contents: write


### PR DESCRIPTION
The release-pr job compares against the last published version on crates.io. When both jobs ran in parallel, the PR job could see stale registry state, causing cargo package to fail on cross-crate version mismatches.

Add `needs: release-plz-release` so the PR job always sees the latest crates.io state. Use `!failure()` so the PR job still runs when the release job is skipped (nothing to publish) but skips when it fails.