### PR TITLE
fix(ci): use RELEASE_PLZ_TOKEN for release asset uploads

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -82,6 +82,8 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: cargo-bp-${{ matrix.target }}-${{ steps.version.outputs.version }}.${{ matrix.archive }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
 
       - name: Upload artifact (for workflow_dispatch)
         if: github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
Attempt 2 on #25

The release is created by release-plz using RELEASE_PLZ_TOKEN (a PAT). The default GITHUB_TOKEN in the triggered workflow cannot update a release created by a different token, causing "Resource not accessible by integration" errors.