### PR TITLE
feat(battery-pack): add validate() to authoring template

### DIFF
--- a/src/battery-pack/templates/default/Cargo.toml.liquid
+++ b/src/battery-pack/templates/default/Cargo.toml.liquid
@@ -8,6 +8,7 @@ readme = "README.md"
 keywords = ["battery-pack"]
 
 [dependencies]
+battery-pack = "0.4"
 # Add your curated dependencies here:
 # clap = { version = "4", features = ["derive"] }
 # serde = { version = "1", features = ["derive"] }

--- a/src/battery-pack/templates/default/src/lib.rs
+++ b/src/battery-pack/templates/default/src/lib.rs
@@ -1,1 +1,13 @@
 #![doc = include_str!(concat!(env!("OUT_DIR"), "/docs.md"))]
+
+/// Validate that the consumer's dependencies match this battery pack's specs.
+///
+/// Call from the consumer's `build.rs`:
+/// ```rust,ignore
+/// fn main() {
+///     {{crate_name}}::validate();
+/// }
+/// ```
+pub fn validate() {
+    battery_pack::validate(include_str!("../Cargo.toml"));
+}


### PR DESCRIPTION
The battery-pack authoring template only had battery-pack as a build-dependency (for docgen). Add it as a regular dependency too and export a validate() function in lib.rs, so battery packs created from the template can be validated by consumers' build.rs.