### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "battery-pack"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -438,7 +438,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "cli-battery-pack"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "battery-pack",
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "error-battery-pack"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "battery-pack",
@@ -1973,7 +1973,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "logging-battery-pack"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "battery-pack",
  "tracing",

--- a/src/battery-pack/CHANGELOG.md
+++ b/src/battery-pack/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.4.3...battery-pack-v0.4.4) - 2026-03-03
+
+### Added
+
+- *(battery-pack)* add validate() to authoring template
+
 ## [0.4.3](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.4.2...battery-pack-v0.4.3) - 2026-03-02
 
 ### Added

--- a/src/battery-pack/Cargo.toml
+++ b/src/battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "battery-pack"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 description = "Curated crate bundles with docs, templates, and agentic skills"
 license = "MIT OR Apache-2.0"

--- a/src/cli-battery-pack/CHANGELOG.md
+++ b/src/cli-battery-pack/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.4.1](https://github.com/battery-pack-rs/battery-pack/compare/cli-battery-pack-v0.4.0...cli-battery-pack-v0.4.1) - 2026-03-03
+
+### Added
+
+- *(cli + error + logging)* expose validate() function

--- a/src/cli-battery-pack/Cargo.toml
+++ b/src/cli-battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli-battery-pack"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 description = "Battery pack for building CLI applications in Rust"
 license = "MIT OR Apache-2.0"

--- a/src/error-battery-pack/CHANGELOG.md
+++ b/src/error-battery-pack/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/battery-pack-rs/battery-pack/compare/error-battery-pack-v0.5.0...error-battery-pack-v0.5.1) - 2026-03-03
+
+### Added
+
+- *(cli + error + logging)* expose validate() function
+
 ## [0.5.0](https://github.com/battery-pack-rs/battery-pack/compare/error-battery-pack-v0.4.0...error-battery-pack-v0.5.0) - 2026-03-03
 
 ### Other

--- a/src/error-battery-pack/Cargo.toml
+++ b/src/error-battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "error-battery-pack"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 description = "Error handling done well — anyhow for apps, thiserror for libraries"
 license = "MIT OR Apache-2.0"

--- a/src/logging-battery-pack/CHANGELOG.md
+++ b/src/logging-battery-pack/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.4.1](https://github.com/battery-pack-rs/battery-pack/compare/logging-battery-pack-v0.4.0...logging-battery-pack-v0.4.1) - 2026-03-03
+
+### Added
+
+- *(cli + error + logging)* expose validate() function

--- a/src/logging-battery-pack/Cargo.toml
+++ b/src/logging-battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logging-battery-pack"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 description = "Battery pack for logging and tracing in Rust"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `battery-pack`: 0.4.3 -> 0.4.4 (✓ API compatible changes)
* `cli-battery-pack`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `error-battery-pack`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `logging-battery-pack`: 0.4.0 -> 0.4.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `battery-pack`

<blockquote>

## [0.4.4](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.4.3...battery-pack-v0.4.4) - 2026-03-03

### Added

- *(battery-pack)* add validate() to authoring template
</blockquote>

## `cli-battery-pack`

<blockquote>

## [0.4.1](https://github.com/battery-pack-rs/battery-pack/compare/cli-battery-pack-v0.4.0...cli-battery-pack-v0.4.1) - 2026-03-03

### Added

- *(cli + error + logging)* expose validate() function
</blockquote>

## `error-battery-pack`

<blockquote>

## [0.5.1](https://github.com/battery-pack-rs/battery-pack/compare/error-battery-pack-v0.5.0...error-battery-pack-v0.5.1) - 2026-03-03

### Added

- *(cli + error + logging)* expose validate() function
</blockquote>

## `logging-battery-pack`

<blockquote>

## [0.4.1](https://github.com/battery-pack-rs/battery-pack/compare/logging-battery-pack-v0.4.0...logging-battery-pack-v0.4.1) - 2026-03-03

### Added

- *(cli + error + logging)* expose validate() function
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).