### PR TITLE
feat(cli + error + logging): expose validate() function

### DIFF
--- a/src/cli-battery-pack/Cargo.toml
+++ b/src/cli-battery-pack/Cargo.toml
@@ -11,7 +11,11 @@ keywords = ["battery-pack", "cli", "clap", "terminal"]
 simple = { path = "templates/simple", description = "Minimal CLI with argument parsing" }
 subcmds = { path = "templates/subcmds", description = "CLI with subcommands" }
 
+[package.metadata.battery-pack]
+hidden = ["battery-pack"]
+
 [dependencies]
+battery-pack = { workspace = true }
 anyhow = { version = "1", optional = true }
 clap = { version = "4", features = ["derive"], optional = true }
 console = { version = "0.15", optional = true }

--- a/src/cli-battery-pack/src/lib.rs
+++ b/src/cli-battery-pack/src/lib.rs
@@ -1,1 +1,13 @@
 #![doc = include_str!(concat!(env!("OUT_DIR"), "/docs.md"))]
+
+/// Validate that the consumer's dependencies match this battery pack's specs.
+///
+/// Call from the consumer's `build.rs`:
+/// ```rust,ignore
+/// fn main() {
+///     cli_battery_pack::validate();
+/// }
+/// ```
+pub fn validate() {
+    battery_pack::validate(include_str!("../Cargo.toml"));
+}

--- a/src/error-battery-pack/Cargo.toml
+++ b/src/error-battery-pack/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 keywords = ["battery-pack", "error-handling", "anyhow", "thiserror"]
 
 [dependencies]
+battery-pack = { workspace = true }
 anyhow = { version = "1", optional = true }
 thiserror = { version = "2", optional = true }
 
@@ -17,3 +18,6 @@ battery-pack.workspace = true
 
 [features]
 default = ["anyhow", "thiserror"]
+
+[package.metadata.battery-pack]
+hidden = ["battery-pack"]

--- a/src/error-battery-pack/src/lib.rs
+++ b/src/error-battery-pack/src/lib.rs
@@ -1,1 +1,13 @@
 #![doc = include_str!(concat!(env!("OUT_DIR"), "/docs.md"))]
+
+/// Validate that the consumer's dependencies match this battery pack's specs.
+///
+/// Call from the consumer's `build.rs`:
+/// ```rust,ignore
+/// fn main() {
+///     error_battery_pack::validate();
+/// }
+/// ```
+pub fn validate() {
+    battery_pack::validate(include_str!("../Cargo.toml"));
+}

--- a/src/logging-battery-pack/Cargo.toml
+++ b/src/logging-battery-pack/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/battery-pack-rs/battery-pack"
 keywords = ["battery-pack", "logging", "tracing"]
 
 [dependencies]
+battery-pack = { workspace = true }
 tracing = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 
@@ -16,3 +17,6 @@ battery-pack.workspace = true
 
 [features]
 default = ["tracing", "tracing-subscriber"]
+
+[package.metadata.battery-pack]
+hidden = ["battery-pack"]

--- a/src/logging-battery-pack/src/lib.rs
+++ b/src/logging-battery-pack/src/lib.rs
@@ -1,1 +1,13 @@
 #![doc = include_str!(concat!(env!("OUT_DIR"), "/docs.md"))]
+
+/// Validate that the consumer's dependencies match this battery pack's specs.
+///
+/// Call from the consumer's `build.rs`:
+/// ```rust,ignore
+/// fn main() {
+///     logging_battery_pack::validate();
+/// }
+/// ```
+pub fn validate() {
+    battery_pack::validate(include_str!("../Cargo.toml"));
+}


### PR DESCRIPTION
Add battery-pack as a regular dependency (in addition to the existing build-dependency) to all three battery packs and export a validate() function that consumers can call from their build.rs to check for dependency drift.

Missed this when modernizing them during resurrection.