### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "battery-pack"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "bphelper-build"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bphelper-manifest",
  "cargo_metadata",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "bphelper-cli"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bphelper-manifest",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "bphelper-manifest"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "expect-test",
  "serde",
@@ -353,7 +353,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "cli-battery-pack"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "battery-pack",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "error-battery-pack"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "battery-pack",
@@ -1401,7 +1401,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "logging-battery-pack"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "battery-pack",
  "tracing",

--- a/battery-packs/cli-battery-pack/CHANGELOG.md
+++ b/battery-packs/cli-battery-pack/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/battery-pack-rs/battery-pack/compare/cli-battery-pack-v0.4.1...cli-battery-pack-v0.4.2) - 2026-03-05
+
+### Other
+
+- *(files)* move battery-packs into their own directory to make filesystem better
+
 ## [0.4.1](https://github.com/battery-pack-rs/battery-pack/compare/cli-battery-pack-v0.4.0...cli-battery-pack-v0.4.1) - 2026-03-03
 
 ### Added

--- a/battery-packs/cli-battery-pack/Cargo.toml
+++ b/battery-packs/cli-battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli-battery-pack"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 description = "Battery pack for building CLI applications in Rust"
 license = "MIT OR Apache-2.0"

--- a/battery-packs/error-battery-pack/CHANGELOG.md
+++ b/battery-packs/error-battery-pack/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2](https://github.com/battery-pack-rs/battery-pack/compare/error-battery-pack-v0.5.1...error-battery-pack-v0.5.2) - 2026-03-05
+
+### Other
+
+- *(files)* move battery-packs into their own directory to make filesystem better
+
 ## [0.5.1](https://github.com/battery-pack-rs/battery-pack/compare/error-battery-pack-v0.5.0...error-battery-pack-v0.5.1) - 2026-03-03
 
 ### Added

--- a/battery-packs/error-battery-pack/Cargo.toml
+++ b/battery-packs/error-battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "error-battery-pack"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 description = "Error handling done well — anyhow for apps, thiserror for libraries"
 license = "MIT OR Apache-2.0"

--- a/battery-packs/logging-battery-pack/CHANGELOG.md
+++ b/battery-packs/logging-battery-pack/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/battery-pack-rs/battery-pack/compare/logging-battery-pack-v0.4.1...logging-battery-pack-v0.4.2) - 2026-03-05
+
+### Other
+
+- *(files)* move battery-packs into their own directory to make filesystem better
+
 ## [0.4.1](https://github.com/battery-pack-rs/battery-pack/compare/logging-battery-pack-v0.4.0...logging-battery-pack-v0.4.1) - 2026-03-03
 
 ### Added

--- a/battery-packs/logging-battery-pack/Cargo.toml
+++ b/battery-packs/logging-battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logging-battery-pack"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 description = "Battery pack for logging and tracing in Rust"
 license = "MIT OR Apache-2.0"

--- a/src/battery-pack/CHANGELOG.md
+++ b/src/battery-pack/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.5](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.4.4...battery-pack-v0.4.5) - 2026-03-05
+
+### Added
+
+- add with_template authoring template
+- add --define flag to cargo bp new for setting placeholder values
+- replace cargo-generate with MiniJinja template engine
+- validate templates in cargo bp validate
+
+### Fixed
+
+- accept exact name "battery-pack" in validate_spec ([#40](https://github.com/battery-pack-rs/battery-pack/pull/40))
+
+### Other
+
+- remove stale hooks ignore from default template config
+- tighten template engine visibility and improve bp-template.toml handling
+- add unit tests for template engine core logic
+
 ## [0.4.4](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.4.3...battery-pack-v0.4.4) - 2026-03-03
 
 ### Added

--- a/src/battery-pack/Cargo.toml
+++ b/src/battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "battery-pack"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2024"
 description = "Curated crate bundles with docs, templates, and agentic skills"
 license = "MIT OR Apache-2.0"
@@ -30,9 +30,9 @@ name = "cargo-bp"
 path = "src/main.rs"
 
 [dependencies]
-bphelper-build = { path = "bphelper-build", version = "0.4.1" }
-bphelper-cli = { path = "bphelper-cli", version = "0.4.1" }
-bphelper-manifest = { path = "bphelper-manifest", version = "0.5.0" }
+bphelper-build = { path = "bphelper-build", version = "0.4.2" }
+bphelper-cli = { path = "bphelper-cli", version = "0.5.0" }
+bphelper-manifest = { path = "bphelper-manifest", version = "0.5.1" }
 anyhow.workspace = true
 
 [dev-dependencies]

--- a/src/battery-pack/bphelper-build/CHANGELOG.md
+++ b/src/battery-pack/bphelper-build/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-build-v0.4.1...bphelper-build-v0.4.2) - 2026-03-05
+
+### Other
+
+- updated the following local packages: bphelper-manifest
+
 ## [0.4.1](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-build-v0.3.0...bphelper-build-v0.4.1) - 2026-03-02
 
 ### Added

--- a/src/battery-pack/bphelper-build/Cargo.toml
+++ b/src/battery-pack/bphelper-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bphelper-build"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 description = "Build-time documentation generation for battery packs"
 license = "MIT OR Apache-2.0"
@@ -8,7 +8,7 @@ repository = "https://github.com/battery-pack-rs/battery-pack"
 keywords = ["battery-pack"]
 
 [dependencies]
-bphelper-manifest = { path = "../bphelper-manifest", version = "0.5.0" }
+bphelper-manifest = { path = "../bphelper-manifest", version = "0.5.1" }
 handlebars.workspace = true
 cargo_metadata.workspace = true
 serde.workspace = true

--- a/src/battery-pack/bphelper-cli/CHANGELOG.md
+++ b/src/battery-pack/bphelper-cli/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.4.1...bphelper-cli-v0.5.0) - 2026-03-05
+
+### Added
+
+- add --define flag to cargo bp new for setting placeholder values
+- replace cargo-generate with MiniJinja template engine
+- validate templates in cargo bp validate
+
+### Other
+
+- tighten template engine visibility and improve bp-template.toml handling
+- add unit tests for template engine core logic
+
 ## [0.4.1](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.4.0...bphelper-cli-v0.4.1) - 2026-03-02
 
 ### Added

--- a/src/battery-pack/bphelper-cli/Cargo.toml
+++ b/src/battery-pack/bphelper-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bphelper-cli"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2024"
 description = "CLI for creating and managing battery packs"
 license = "MIT OR Apache-2.0"
@@ -8,7 +8,7 @@ repository = "https://github.com/battery-pack-rs/battery-pack"
 keywords = ["battery-pack", "cli", "cargo"]
 
 [dependencies]
-bphelper-manifest = { path = "../bphelper-manifest", version = "0.5.0" }
+bphelper-manifest = { path = "../bphelper-manifest", version = "0.5.1" }
 clap.workspace = true
 minijinja.workspace = true
 walkdir = "2"

--- a/src/battery-pack/bphelper-manifest/CHANGELOG.md
+++ b/src/battery-pack/bphelper-manifest/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-manifest-v0.5.0...bphelper-manifest-v0.5.1) - 2026-03-05
+
+### Added
+
+- replace cargo-generate with MiniJinja template engine
+
+### Fixed
+
+- accept exact name "battery-pack" in validate_spec ([#40](https://github.com/battery-pack-rs/battery-pack/pull/40))
+
 ## [0.5.0](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-manifest-v0.4.1...bphelper-manifest-v0.5.0) - 2026-03-02
 
 ### Added

--- a/src/battery-pack/bphelper-manifest/Cargo.toml
+++ b/src/battery-pack/bphelper-manifest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bphelper-manifest"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 description = "Shared battery pack manifest parsing"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `bphelper-manifest`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `bphelper-cli`: 0.4.1 -> 0.5.0 (⚠ API breaking changes)
* `battery-pack`: 0.4.4 -> 0.4.5 (✓ API compatible changes)
* `cli-battery-pack`: 0.4.1 -> 0.4.2 (✓ API compatible changes)
* `error-battery-pack`: 0.5.1 -> 0.5.2 (✓ API compatible changes)
* `logging-battery-pack`: 0.4.1 -> 0.4.2 (✓ API compatible changes)
* `bphelper-build`: 0.4.1 -> 0.4.2

### ⚠ `bphelper-cli` breaking changes

```text
--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field define of variant BpCommands::New in /tmp/.tmp6V7Bto/battery-pack/src/battery-pack/bphelper-cli/src/lib.rs:82
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `bphelper-manifest`

<blockquote>

## [0.5.1](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-manifest-v0.5.0...bphelper-manifest-v0.5.1) - 2026-03-05

### Added

- replace cargo-generate with MiniJinja template engine

### Fixed

- accept exact name "battery-pack" in validate_spec ([#40](https://github.com/battery-pack-rs/battery-pack/pull/40))
</blockquote>

## `bphelper-cli`

<blockquote>

## [0.5.0](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.4.1...bphelper-cli-v0.5.0) - 2026-03-05

### Added

- add --define flag to cargo bp new for setting placeholder values
- replace cargo-generate with MiniJinja template engine
- validate templates in cargo bp validate

### Other

- tighten template engine visibility and improve bp-template.toml handling
- add unit tests for template engine core logic
</blockquote>

## `battery-pack`

<blockquote>

## [0.4.5](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.4.4...battery-pack-v0.4.5) - 2026-03-05

### Added

- add with_template authoring template
- add --define flag to cargo bp new for setting placeholder values
- replace cargo-generate with MiniJinja template engine
- validate templates in cargo bp validate

### Fixed

- accept exact name "battery-pack" in validate_spec ([#40](https://github.com/battery-pack-rs/battery-pack/pull/40))

### Other

- remove stale hooks ignore from default template config
- tighten template engine visibility and improve bp-template.toml handling
- add unit tests for template engine core logic
</blockquote>

## `cli-battery-pack`

<blockquote>

## [0.4.2](https://github.com/battery-pack-rs/battery-pack/compare/cli-battery-pack-v0.4.1...cli-battery-pack-v0.4.2) - 2026-03-05

### Other

- *(files)* move battery-packs into their own directory to make filesystem better
</blockquote>

## `error-battery-pack`

<blockquote>

## [0.5.2](https://github.com/battery-pack-rs/battery-pack/compare/error-battery-pack-v0.5.1...error-battery-pack-v0.5.2) - 2026-03-05

### Other

- *(files)* move battery-packs into their own directory to make filesystem better
</blockquote>

## `logging-battery-pack`

<blockquote>

## [0.4.2](https://github.com/battery-pack-rs/battery-pack/compare/logging-battery-pack-v0.4.1...logging-battery-pack-v0.4.2) - 2026-03-05

### Other

- *(files)* move battery-packs into their own directory to make filesystem better
</blockquote>

## `bphelper-build`

<blockquote>

## [0.4.2](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-build-v0.4.1...bphelper-build-v0.4.2) - 2026-03-05

### Other

- updated the following local packages: bphelper-manifest
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).