### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "battery-pack"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "bphelper-cli"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "bphelper-manifest",

--- a/src/battery-pack/CHANGELOG.md
+++ b/src/battery-pack/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.6](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.4.5...battery-pack-v0.4.6) - 2026-03-12
+
+### Added
+
+- template preview — render and display templates without generating a project ([#45](https://github.com/battery-pack-rs/battery-pack/pull/45))
+
+### Fixed
+
+- remove unused variables param from render_template_dir ([#46](https://github.com/battery-pack-rs/battery-pack/pull/46))
+
 ## [0.4.5](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.4.4...battery-pack-v0.4.5) - 2026-03-05
 
 ### Added

--- a/src/battery-pack/Cargo.toml
+++ b/src/battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "battery-pack"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2024"
 description = "Curated crate bundles with docs, templates, and agentic skills"
 license = "MIT OR Apache-2.0"
@@ -31,7 +31,7 @@ path = "src/main.rs"
 
 [dependencies]
 bphelper-build = { path = "bphelper-build", version = "0.4.2" }
-bphelper-cli = { path = "bphelper-cli", version = "0.5.0" }
+bphelper-cli = { path = "bphelper-cli", version = "0.6.0" }
 bphelper-manifest = { path = "bphelper-manifest", version = "0.5.1" }
 anyhow.workspace = true
 

--- a/src/battery-pack/bphelper-cli/CHANGELOG.md
+++ b/src/battery-pack/bphelper-cli/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.5.0...bphelper-cli-v0.6.0) - 2026-03-12
+
+### Added
+
+- template preview — render and display templates without generating a project ([#45](https://github.com/battery-pack-rs/battery-pack/pull/45))
+
+### Fixed
+
+- remove unused variables param from render_template_dir ([#46](https://github.com/battery-pack-rs/battery-pack/pull/46))
+
 ## [0.5.0](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.4.1...bphelper-cli-v0.5.0) - 2026-03-05
 
 ### Added

--- a/src/battery-pack/bphelper-cli/Cargo.toml
+++ b/src/battery-pack/bphelper-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bphelper-cli"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 description = "CLI for creating and managing battery packs"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `bphelper-cli`: 0.5.0 -> 0.6.0 (⚠ API breaking changes)
* `battery-pack`: 0.4.5 -> 0.4.6 (✓ API compatible changes)

### ⚠ `bphelper-cli` breaking changes

```text
--- failure enum_struct_variant_changed_kind: An enum struct variant changed kind ---

Description:
A pub enum's struct variant with at least one pub field has changed to a different kind of enum variant, breaking access to its pub fields.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_struct_variant_changed_kind.ron

Failed in:
  variant BpCommands::New in /tmp/.tmpSMQLV7/battery-pack/src/battery-pack/bphelper-cli/src/lib.rs:126
  variant BpCommands::Add in /tmp/.tmpSMQLV7/battery-pack/src/battery-pack/bphelper-cli/src/lib.rs:133

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_parameter_count_changed.ron

Failed in:
  bphelper_cli::add_battery_pack now takes 3 parameters instead of 9, in /tmp/.tmpSMQLV7/battery-pack/src/battery-pack/bphelper-cli/src/lib.rs:604
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `bphelper-cli`

<blockquote>

## [0.6.0](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.5.0...bphelper-cli-v0.6.0) - 2026-03-12

### Added

- template preview — render and display templates without generating a project ([#45](https://github.com/battery-pack-rs/battery-pack/pull/45))

### Fixed

- remove unused variables param from render_template_dir ([#46](https://github.com/battery-pack-rs/battery-pack/pull/46))
</blockquote>

## `battery-pack`

<blockquote>

## [0.4.6](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.4.5...battery-pack-v0.4.6) - 2026-03-12

### Added

- template preview — render and display templates without generating a project ([#45](https://github.com/battery-pack-rs/battery-pack/pull/45))

### Fixed

- remove unused variables param from render_template_dir ([#46](https://github.com/battery-pack-rs/battery-pack/pull/46))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).