### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "battery-pack"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -184,7 +184,7 @@ dependencies = [
 
 [[package]]
 name = "bphelper-build"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "bphelper-manifest",
  "cargo_metadata",
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "bphelper-cli"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "bphelper-manifest",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "bphelper-manifest"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "expect-test",
  "serde",

--- a/src/battery-pack/CHANGELOG.md
+++ b/src/battery-pack/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.7](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.4.6...battery-pack-v0.4.7) - 2026-03-12
+
+### Added
+
+- with_template uses bp-managed, move discovery to bphelper-manifest
+- wire bp-managed resolution into template generation
+- implement bp-managed dependency resolution
+
+### Fixed
+
+- reject any extra keys alongside bp-managed, not just version
+
+### Other
+
+- *(template)* Use dotted key syntax for `bp-managed` dependencies ([#56](https://github.com/battery-pack-rs/battery-pack/pull/56))
+- remove unused resolve_bp_managed file-walking wrapper
+- resolve bp-managed in all Cargo.toml files within project dir
+- use expect-test snapshots for bp-managed resolution output
+- verify preview resolves bp-managed deps
+- move bp-managed resolution into shared render pipeline
+- write bp metadata as inline tables instead of dotted sub-tables
+- add managed-battery-pack fixture with bp-managed deps
+
 ## [0.4.6](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.4.5...battery-pack-v0.4.6) - 2026-03-12
 
 ### Added

--- a/src/battery-pack/Cargo.toml
+++ b/src/battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "battery-pack"
-version = "0.4.6"
+version = "0.4.7"
 edition = "2024"
 description = "Curated crate bundles with docs, templates, and agentic skills"
 license = "MIT OR Apache-2.0"
@@ -30,9 +30,9 @@ name = "cargo-bp"
 path = "src/main.rs"
 
 [dependencies]
-bphelper-build = { path = "bphelper-build", version = "0.4.2" }
-bphelper-cli = { path = "bphelper-cli", version = "0.6.0" }
-bphelper-manifest = { path = "bphelper-manifest", version = "0.5.1" }
+bphelper-build = { path = "bphelper-build", version = "0.4.3" }
+bphelper-cli = { path = "bphelper-cli", version = "0.6.1" }
+bphelper-manifest = { path = "bphelper-manifest", version = "0.5.2" }
 anyhow.workspace = true
 
 [dev-dependencies]

--- a/src/battery-pack/bphelper-build/CHANGELOG.md
+++ b/src/battery-pack/bphelper-build/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-build-v0.4.2...bphelper-build-v0.4.3) - 2026-03-12
+
+### Other
+
+- updated the following local packages: bphelper-manifest
+
 ## [0.4.2](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-build-v0.4.1...bphelper-build-v0.4.2) - 2026-03-05
 
 ### Other

--- a/src/battery-pack/bphelper-build/Cargo.toml
+++ b/src/battery-pack/bphelper-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bphelper-build"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 description = "Build-time documentation generation for battery packs"
 license = "MIT OR Apache-2.0"
@@ -8,7 +8,7 @@ repository = "https://github.com/battery-pack-rs/battery-pack"
 keywords = ["battery-pack"]
 
 [dependencies]
-bphelper-manifest = { path = "../bphelper-manifest", version = "0.5.1" }
+bphelper-manifest = { path = "../bphelper-manifest", version = "0.5.2" }
 handlebars.workspace = true
 cargo_metadata.workspace = true
 serde.workspace = true

--- a/src/battery-pack/bphelper-cli/CHANGELOG.md
+++ b/src/battery-pack/bphelper-cli/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.6.0...bphelper-cli-v0.6.1) - 2026-03-12
+
+### Added
+
+- with_template uses bp-managed, move discovery to bphelper-manifest
+- wire bp-managed resolution into template generation
+- implement bp-managed dependency resolution
+
+### Fixed
+
+- reject any extra keys alongside bp-managed, not just version
+
+### Other
+
+- *(template)* Use dotted key syntax for `bp-managed` dependencies ([#56](https://github.com/battery-pack-rs/battery-pack/pull/56))
+- remove unused resolve_bp_managed file-walking wrapper
+- resolve bp-managed in all Cargo.toml files within project dir
+- use expect-test snapshots for bp-managed resolution output
+- verify preview resolves bp-managed deps
+- move bp-managed resolution into shared render pipeline
+- write bp metadata as inline tables instead of dotted sub-tables
+
 ## [0.6.0](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.5.0...bphelper-cli-v0.6.0) - 2026-03-12
 
 ### Added

--- a/src/battery-pack/bphelper-cli/Cargo.toml
+++ b/src/battery-pack/bphelper-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bphelper-cli"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 description = "CLI for creating and managing battery packs"
 license = "MIT OR Apache-2.0"
@@ -8,7 +8,7 @@ repository = "https://github.com/battery-pack-rs/battery-pack"
 keywords = ["battery-pack", "cli", "cargo"]
 
 [dependencies]
-bphelper-manifest = { path = "../bphelper-manifest", version = "0.5.1" }
+bphelper-manifest = { path = "../bphelper-manifest", version = "0.5.2" }
 clap.workspace = true
 minijinja.workspace = true
 walkdir = "2"

--- a/src/battery-pack/bphelper-manifest/CHANGELOG.md
+++ b/src/battery-pack/bphelper-manifest/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-manifest-v0.5.1...bphelper-manifest-v0.5.2) - 2026-03-12
+
+### Added
+
+- with_template uses bp-managed, move discovery to bphelper-manifest
+
+### Other
+
+- add managed-battery-pack fixture with bp-managed deps
+
 ## [0.5.1](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-manifest-v0.5.0...bphelper-manifest-v0.5.1) - 2026-03-05
 
 ### Added

--- a/src/battery-pack/bphelper-manifest/Cargo.toml
+++ b/src/battery-pack/bphelper-manifest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bphelper-manifest"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 description = "Shared battery pack manifest parsing"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `bphelper-manifest`: 0.5.1 -> 0.5.2 (✓ API compatible changes)
* `bphelper-cli`: 0.6.0 -> 0.6.1 (✓ API compatible changes)
* `battery-pack`: 0.4.6 -> 0.4.7 (✓ API compatible changes)
* `bphelper-build`: 0.4.2 -> 0.4.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `bphelper-manifest`

<blockquote>

## [0.5.2](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-manifest-v0.5.1...bphelper-manifest-v0.5.2) - 2026-03-12

### Added

- with_template uses bp-managed, move discovery to bphelper-manifest

### Other

- add managed-battery-pack fixture with bp-managed deps
</blockquote>

## `bphelper-cli`

<blockquote>

## [0.6.1](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.6.0...bphelper-cli-v0.6.1) - 2026-03-12

### Added

- with_template uses bp-managed, move discovery to bphelper-manifest
- wire bp-managed resolution into template generation
- implement bp-managed dependency resolution

### Fixed

- reject any extra keys alongside bp-managed, not just version

### Other

- *(template)* Use dotted key syntax for `bp-managed` dependencies ([#56](https://github.com/battery-pack-rs/battery-pack/pull/56))
- remove unused resolve_bp_managed file-walking wrapper
- resolve bp-managed in all Cargo.toml files within project dir
- use expect-test snapshots for bp-managed resolution output
- verify preview resolves bp-managed deps
- move bp-managed resolution into shared render pipeline
- write bp metadata as inline tables instead of dotted sub-tables
</blockquote>

## `battery-pack`

<blockquote>

## [0.4.7](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.4.6...battery-pack-v0.4.7) - 2026-03-12

### Added

- with_template uses bp-managed, move discovery to bphelper-manifest
- wire bp-managed resolution into template generation
- implement bp-managed dependency resolution

### Fixed

- reject any extra keys alongside bp-managed, not just version

### Other

- *(template)* Use dotted key syntax for `bp-managed` dependencies ([#56](https://github.com/battery-pack-rs/battery-pack/pull/56))
- remove unused resolve_bp_managed file-walking wrapper
- resolve bp-managed in all Cargo.toml files within project dir
- use expect-test snapshots for bp-managed resolution output
- verify preview resolves bp-managed deps
- move bp-managed resolution into shared render pipeline
- write bp metadata as inline tables instead of dotted sub-tables
- add managed-battery-pack fixture with bp-managed deps
</blockquote>

## `bphelper-build`

<blockquote>

## [0.4.3](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-build-v0.4.2...bphelper-build-v0.4.3) - 2026-03-12

### Other

- updated the following local packages: bphelper-manifest
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).