### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "battery-pack"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "bphelper-cli"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "bphelper-manifest",
@@ -379,7 +379,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "cli-battery-pack"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "battery-pack",
@@ -738,7 +738,7 @@ dependencies = [
 
 [[package]]
 name = "error-battery-pack"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "battery-pack",
@@ -1438,7 +1438,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "logging-battery-pack"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "battery-pack",
  "tracing",

--- a/battery-packs/cli-battery-pack/CHANGELOG.md
+++ b/battery-packs/cli-battery-pack/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3](https://github.com/battery-pack-rs/battery-pack/compare/cli-battery-pack-v0.4.2...cli-battery-pack-v0.4.3) - 2026-03-13
+
+### Other
+
+- refactor bphelper-cli and narrow battery-pack dependency ([#48](https://github.com/battery-pack-rs/battery-pack/pull/48))
+
 ## [0.4.2](https://github.com/battery-pack-rs/battery-pack/compare/cli-battery-pack-v0.4.1...cli-battery-pack-v0.4.2) - 2026-03-05
 
 ### Other

--- a/battery-packs/cli-battery-pack/Cargo.toml
+++ b/battery-packs/cli-battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli-battery-pack"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 description = "Battery pack for building CLI applications in Rust"
 license = "MIT OR Apache-2.0"

--- a/battery-packs/error-battery-pack/CHANGELOG.md
+++ b/battery-packs/error-battery-pack/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.3](https://github.com/battery-pack-rs/battery-pack/compare/error-battery-pack-v0.5.2...error-battery-pack-v0.5.3) - 2026-03-13
+
+### Other
+
+- refactor bphelper-cli and narrow battery-pack dependency ([#48](https://github.com/battery-pack-rs/battery-pack/pull/48))
+
 ## [0.5.2](https://github.com/battery-pack-rs/battery-pack/compare/error-battery-pack-v0.5.1...error-battery-pack-v0.5.2) - 2026-03-05
 
 ### Other

--- a/battery-packs/error-battery-pack/Cargo.toml
+++ b/battery-packs/error-battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "error-battery-pack"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2024"
 description = "Error handling done well — anyhow for apps, thiserror for libraries"
 license = "MIT OR Apache-2.0"

--- a/battery-packs/logging-battery-pack/CHANGELOG.md
+++ b/battery-packs/logging-battery-pack/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3](https://github.com/battery-pack-rs/battery-pack/compare/logging-battery-pack-v0.4.2...logging-battery-pack-v0.4.3) - 2026-03-13
+
+### Other
+
+- refactor bphelper-cli and narrow battery-pack dependency ([#48](https://github.com/battery-pack-rs/battery-pack/pull/48))
+
 ## [0.4.2](https://github.com/battery-pack-rs/battery-pack/compare/logging-battery-pack-v0.4.1...logging-battery-pack-v0.4.2) - 2026-03-05
 
 ### Other

--- a/battery-packs/logging-battery-pack/Cargo.toml
+++ b/battery-packs/logging-battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logging-battery-pack"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 description = "Battery pack for logging and tracing in Rust"
 license = "MIT OR Apache-2.0"

--- a/src/battery-pack/CHANGELOG.md
+++ b/src/battery-pack/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.8](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.4.7...battery-pack-v0.4.8) - 2026-03-13
+
+### Other
+
+- refactor bphelper-cli and narrow battery-pack dependency ([#48](https://github.com/battery-pack-rs/battery-pack/pull/48))
+
 ## [0.4.7](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.4.6...battery-pack-v0.4.7) - 2026-03-12
 
 ### Added

--- a/src/battery-pack/Cargo.toml
+++ b/src/battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "battery-pack"
-version = "0.4.7"
+version = "0.4.8"
 edition = "2024"
 description = "Curated crate bundles with docs, templates, and agentic skills"
 license = "MIT OR Apache-2.0"
@@ -37,7 +37,7 @@ required-features = ["cli"]
 
 [dependencies]
 bphelper-build = { path = "bphelper-build", version = "0.4.3", optional = true }
-bphelper-cli = { path = "bphelper-cli", version = "0.6.1", optional = true }
+bphelper-cli = { path = "bphelper-cli", version = "0.7.0", optional = true }
 bphelper-manifest = { path = "bphelper-manifest", version = "0.5.2" }
 anyhow.workspace = true
 

--- a/src/battery-pack/bphelper-cli/CHANGELOG.md
+++ b/src/battery-pack/bphelper-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.6.1...bphelper-cli-v0.7.0) - 2026-03-13
+
+### Other
+
+- refactor bphelper-cli and narrow battery-pack dependency ([#48](https://github.com/battery-pack-rs/battery-pack/pull/48))
+
 ## [0.6.1](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.6.0...bphelper-cli-v0.6.1) - 2026-03-12
 
 ### Added

--- a/src/battery-pack/bphelper-cli/Cargo.toml
+++ b/src/battery-pack/bphelper-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bphelper-cli"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2024"
 description = "CLI for creating and managing battery packs"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `bphelper-cli`: 0.6.1 -> 0.7.0 (⚠ API breaking changes)
* `battery-pack`: 0.4.7 -> 0.4.8 (✓ API compatible changes)
* `cli-battery-pack`: 0.4.2 -> 0.4.3 (✓ API compatible changes)
* `error-battery-pack`: 0.5.2 -> 0.5.3 (✓ API compatible changes)
* `logging-battery-pack`: 0.4.2 -> 0.4.3 (✓ API compatible changes)

### ⚠ `bphelper-cli` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_missing.ron

Failed in:
  enum bphelper_cli::CrateSource, previously in file /tmp/.tmpAZViND/bphelper-cli/src/lib.rs:31
  enum bphelper_cli::ResolvedAdd, previously in file /tmp/.tmpAZViND/bphelper-cli/src/lib.rs:504
  enum bphelper_cli::BpCommands, previously in file /tmp/.tmpAZViND/bphelper-cli/src/lib.rs:124
  enum bphelper_cli::Commands, previously in file /tmp/.tmpAZViND/bphelper-cli/src/lib.rs:47
  enum bphelper_cli::AddTarget, previously in file /tmp/.tmpAZViND/bphelper-cli/src/lib.rs:198

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function bphelper_cli::fetch_battery_pack_detail, previously in file /tmp/.tmpAZViND/bphelper-cli/src/lib.rs:2396
  function bphelper_cli::sync_dep_in_table, previously in file /tmp/.tmpAZViND/bphelper-cli/src/lib.rs:1325
  function bphelper_cli::resolve_template, previously in file /tmp/.tmpAZViND/bphelper-cli/src/lib.rs:2054
  function bphelper_cli::collect_user_dep_versions, previously in file /tmp/.tmpAZViND/bphelper-cli/src/lib.rs:2827
  function bphelper_cli::add_battery_pack, previously in file /tmp/.tmpAZViND/bphelper-cli/src/lib.rs:604
  function bphelper_cli::read_active_features_ws, previously in file /tmp/.tmpAZViND/bphelper-cli/src/lib.rs:1562
  function bphelper_cli::read_active_features, previously in file /tmp/.tmpAZViND/bphelper-cli/src/lib.rs:1489
  function bphelper_cli::fetch_battery_pack_list, previously in file /tmp/.tmpAZViND/bphelper-cli/src/lib.rs:2167
  function bphelper_cli::find_installed_bp_names, previously in file /tmp/.tmpAZViND/bphelper-cli/src/lib.rs:1158
  function bphelper_cli::resolve_add_crates, previously in file /tmp/.tmpAZViND/bphelper-cli/src/lib.rs:528
  function bphelper_cli::load_installed_packs, previously in file /tmp/.tmpAZViND/bphelper-cli/src/lib.rs:2141
  function bphelper_cli::validate_battery_pack_cmd, previously in file /tmp/.tmpAZViND/bphelper-cli/src/lib.rs:2921
  function bphelper_cli::add_dep_to_table, previously in file /tmp/.tmpAZViND/bphelper-cli/src/lib.rs:1278

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct bphelper_cli::BatteryPackDetail, previously in file /tmp/.tmpAZViND/bphelper-cli/src/lib.rs:363
  struct bphelper_cli::NewArgs, previously in file /tmp/.tmpAZViND/bphelper-cli/src/lib.rs:61
  struct bphelper_cli::TemplateInfo, previously in file /tmp/.tmpAZViND/bphelper-cli/src/lib.rs:392
  struct bphelper_cli::AddArgs, previously in file /tmp/.tmpAZViND/bphelper-cli/src/lib.rs:88
  struct bphelper_cli::InstalledPack, previously in file /tmp/.tmpAZViND/bphelper-cli/src/lib.rs:2128
  struct bphelper_cli::BatteryPackSummary, previously in file /tmp/.tmpAZViND/bphelper-cli/src/lib.rs:354
  struct bphelper_cli::Cli, previously in file /tmp/.tmpAZViND/bphelper-cli/src/lib.rs:41
  struct bphelper_cli::ExampleInfo, previously in file /tmp/.tmpAZViND/bphelper-cli/src/lib.rs:402
  struct bphelper_cli::OwnerInfo, previously in file /tmp/.tmpAZViND/bphelper-cli/src/lib.rs:377
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `bphelper-cli`

<blockquote>

## [0.7.0](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.6.1...bphelper-cli-v0.7.0) - 2026-03-13

### Other

- refactor bphelper-cli and narrow battery-pack dependency ([#48](https://github.com/battery-pack-rs/battery-pack/pull/48))
</blockquote>

## `battery-pack`

<blockquote>

## [0.4.8](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.4.7...battery-pack-v0.4.8) - 2026-03-13

### Other

- refactor bphelper-cli and narrow battery-pack dependency ([#48](https://github.com/battery-pack-rs/battery-pack/pull/48))
</blockquote>

## `cli-battery-pack`

<blockquote>

## [0.4.3](https://github.com/battery-pack-rs/battery-pack/compare/cli-battery-pack-v0.4.2...cli-battery-pack-v0.4.3) - 2026-03-13

### Other

- refactor bphelper-cli and narrow battery-pack dependency ([#48](https://github.com/battery-pack-rs/battery-pack/pull/48))
</blockquote>

## `error-battery-pack`

<blockquote>

## [0.5.3](https://github.com/battery-pack-rs/battery-pack/compare/error-battery-pack-v0.5.2...error-battery-pack-v0.5.3) - 2026-03-13

### Other

- refactor bphelper-cli and narrow battery-pack dependency ([#48](https://github.com/battery-pack-rs/battery-pack/pull/48))
</blockquote>

## `logging-battery-pack`

<blockquote>

## [0.4.3](https://github.com/battery-pack-rs/battery-pack/compare/logging-battery-pack-v0.4.2...logging-battery-pack-v0.4.3) - 2026-03-13

### Other

- refactor bphelper-cli and narrow battery-pack dependency ([#48](https://github.com/battery-pack-rs/battery-pack/pull/48))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).