### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,7 +184,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "battery-pack"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "bphelper-cli"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "bphelper-manifest",
@@ -433,7 +433,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "cli-battery-pack"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anstream 1.0.0",
  "anstyle",

--- a/battery-packs/cli-battery-pack/CHANGELOG.md
+++ b/battery-packs/cli-battery-pack/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4](https://github.com/battery-pack-rs/battery-pack/compare/cli-battery-pack-v0.4.3...cli-battery-pack-v0.4.4) - 2026-04-02
+
+### Added
+
+- *(cli)* Expand capabilities ([#67](https://github.com/battery-pack-rs/battery-pack/pull/67))
+
 ## [0.4.3](https://github.com/battery-pack-rs/battery-pack/compare/cli-battery-pack-v0.4.2...cli-battery-pack-v0.4.3) - 2026-03-13
 
 ### Other

--- a/battery-packs/cli-battery-pack/Cargo.toml
+++ b/battery-packs/cli-battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli-battery-pack"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 description = "Battery pack for building CLI applications in Rust"
 license = "MIT OR Apache-2.0"

--- a/src/battery-pack/CHANGELOG.md
+++ b/src/battery-pack/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.9](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.4.8...battery-pack-v0.4.9) - 2026-04-02
+
+### Added
+
+- add page and jump scrolling to preview ([#66](https://github.com/battery-pack-rs/battery-pack/pull/66))
+- *(cli)* Expand capabilities ([#67](https://github.com/battery-pack-rs/battery-pack/pull/67))
+
+### Fixed
+
+- force validate_templates to use non_interactive mode ([#70](https://github.com/battery-pack-rs/battery-pack/pull/70))
+- remove double panic hook from `tui.rs`
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.4.8](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.4.7...battery-pack-v0.4.8) - 2026-03-13
 
 ### Other

--- a/src/battery-pack/Cargo.toml
+++ b/src/battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "battery-pack"
-version = "0.4.8"
+version = "0.4.9"
 edition = "2024"
 description = "Curated crate bundles with docs, templates, and agentic skills"
 license = "MIT OR Apache-2.0"
@@ -37,7 +37,7 @@ required-features = ["cli"]
 
 [dependencies]
 bphelper-build = { path = "bphelper-build", version = "0.4.3", optional = true }
-bphelper-cli = { path = "bphelper-cli", version = "0.7.0", optional = true }
+bphelper-cli = { path = "bphelper-cli", version = "0.7.1", optional = true }
 bphelper-manifest = { path = "bphelper-manifest", version = "0.5.2" }
 anyhow.workspace = true
 

--- a/src/battery-pack/bphelper-cli/CHANGELOG.md
+++ b/src/battery-pack/bphelper-cli/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.7.0...bphelper-cli-v0.7.1) - 2026-04-02
+
+### Added
+
+- add page and jump scrolling to preview ([#66](https://github.com/battery-pack-rs/battery-pack/pull/66))
+
+### Fixed
+
+- force validate_templates to use non_interactive mode ([#70](https://github.com/battery-pack-rs/battery-pack/pull/70))
+- remove double panic hook from `tui.rs`
+
 ## [0.7.0](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.6.1...bphelper-cli-v0.7.0) - 2026-03-13
 
 ### Other

--- a/src/battery-pack/bphelper-cli/Cargo.toml
+++ b/src/battery-pack/bphelper-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bphelper-cli"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 description = "CLI for creating and managing battery packs"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `bphelper-cli`: 0.7.0 -> 0.7.1 (✓ API compatible changes)
* `battery-pack`: 0.4.8 -> 0.4.9 (✓ API compatible changes)
* `cli-battery-pack`: 0.4.3 -> 0.4.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `bphelper-cli`

<blockquote>

## [0.7.1](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.7.0...bphelper-cli-v0.7.1) - 2026-04-02

### Added

- add page and jump scrolling to preview ([#66](https://github.com/battery-pack-rs/battery-pack/pull/66))

### Fixed

- force validate_templates to use non_interactive mode ([#70](https://github.com/battery-pack-rs/battery-pack/pull/70))
- remove double panic hook from `tui.rs`
</blockquote>

## `battery-pack`

<blockquote>

## [0.4.9](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.4.8...battery-pack-v0.4.9) - 2026-04-02

### Added

- add page and jump scrolling to preview ([#66](https://github.com/battery-pack-rs/battery-pack/pull/66))
- *(cli)* Expand capabilities ([#67](https://github.com/battery-pack-rs/battery-pack/pull/67))

### Fixed

- force validate_templates to use non_interactive mode ([#70](https://github.com/battery-pack-rs/battery-pack/pull/70))
- remove double panic hook from `tui.rs`

### Other

- update Cargo.lock dependencies
</blockquote>

## `cli-battery-pack`

<blockquote>

## [0.4.4](https://github.com/battery-pack-rs/battery-pack/compare/cli-battery-pack-v0.4.3...cli-battery-pack-v0.4.4) - 2026-04-02

### Added

- *(cli)* Expand capabilities ([#67](https://github.com/battery-pack-rs/battery-pack/pull/67))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).