### PR TITLE
ci: add fmt check and tighten clippy to deny all warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,9 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
+      - name: Formatting
+        run: cargo fmt --all -- --check
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
       - name: Build
         run: cargo build
-      - name: Clippy
-        run: cargo clippy -- -D clippy::all
       - name: Run tests
         run: cargo test --verbose


### PR DESCRIPTION
Adding enforcement of rustfmt, and also tightening clippy to hit all targets (including test code) and also deny rustc warnings.