### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "battery-pack"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "bphelper-build"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "bphelper-manifest",
  "cargo_metadata",
@@ -308,7 +308,7 @@ dependencies = [
 
 [[package]]
 name = "bphelper-cli"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "bphelper-manifest",
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "bphelper-manifest"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "serde",
  "tempfile",
@@ -489,7 +489,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "cli-battery-pack"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anstream 1.0.0",
  "anstyle",

--- a/battery-packs/cli-battery-pack/CHANGELOG.md
+++ b/battery-packs/cli-battery-pack/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/battery-pack-rs/battery-pack/compare/cli-battery-pack-v0.5.0...cli-battery-pack-v0.5.1) - 2026-04-13
+
+### Other
+
+- *(deps)* upgrade ratatui to 0.30 and enable snapbox term-svg ([#81](https://github.com/battery-pack-rs/battery-pack/pull/81))
+
 ## [0.5.0](https://github.com/battery-pack-rs/battery-pack/compare/cli-battery-pack-v0.4.4...cli-battery-pack-v0.5.0) - 2026-04-03
 
 ### Fixed

--- a/battery-packs/cli-battery-pack/Cargo.toml
+++ b/battery-packs/cli-battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli-battery-pack"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 description = "Battery pack for building CLI applications in Rust"
 license = "MIT OR Apache-2.0"

--- a/src/battery-pack/CHANGELOG.md
+++ b/src/battery-pack/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.11](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.4.10...battery-pack-v0.4.11) - 2026-04-13
+
+### Other
+
+- refactor test: change tests to use snapbox instead of expect-test ([#80](https://github.com/battery-pack-rs/battery-pack/pull/80))
+- *(deps)* upgrade ratatui to 0.30 and enable snapbox term-svg ([#81](https://github.com/battery-pack-rs/battery-pack/pull/81))
+
 ## [0.4.10](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.4.9...battery-pack-v0.4.10) - 2026-04-03
 
 ### Fixed

--- a/src/battery-pack/Cargo.toml
+++ b/src/battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "battery-pack"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2024"
 description = "Curated crate bundles with docs, templates, and agentic skills"
 license = "MIT OR Apache-2.0"
@@ -36,9 +36,9 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-bphelper-build = { path = "bphelper-build", version = "0.4.4", optional = true }
-bphelper-cli = { path = "bphelper-cli", version = "0.7.2", optional = true }
-bphelper-manifest = { path = "bphelper-manifest", version = "0.5.3" }
+bphelper-build = { path = "bphelper-build", version = "0.4.5", optional = true }
+bphelper-cli = { path = "bphelper-cli", version = "0.7.3", optional = true }
+bphelper-manifest = { path = "bphelper-manifest", version = "0.5.4" }
 anyhow.workspace = true
 
 [dev-dependencies]

--- a/src/battery-pack/bphelper-build/CHANGELOG.md
+++ b/src/battery-pack/bphelper-build/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.5](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-build-v0.4.4...bphelper-build-v0.4.5) - 2026-04-13
+
+### Other
+
+- refactor test: change tests to use snapbox instead of expect-test ([#80](https://github.com/battery-pack-rs/battery-pack/pull/80))
+
 ## [0.4.4](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-build-v0.4.3...bphelper-build-v0.4.4) - 2026-04-03
 
 ### Other

--- a/src/battery-pack/bphelper-build/Cargo.toml
+++ b/src/battery-pack/bphelper-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bphelper-build"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2024"
 description = "Build-time documentation generation for battery packs"
 license = "MIT OR Apache-2.0"
@@ -8,7 +8,7 @@ repository = "https://github.com/battery-pack-rs/battery-pack"
 keywords = ["battery-pack"]
 
 [dependencies]
-bphelper-manifest = { path = "../bphelper-manifest", version = "0.5.3" }
+bphelper-manifest = { path = "../bphelper-manifest", version = "0.5.4" }
 handlebars.workspace = true
 cargo_metadata.workspace = true
 serde.workspace = true

--- a/src/battery-pack/bphelper-cli/CHANGELOG.md
+++ b/src/battery-pack/bphelper-cli/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.3](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.7.2...bphelper-cli-v0.7.3) - 2026-04-13
+
+### Other
+
+- refactor test: change tests to use snapbox instead of expect-test ([#80](https://github.com/battery-pack-rs/battery-pack/pull/80))
+- *(deps)* upgrade ratatui to 0.30 and enable snapbox term-svg ([#81](https://github.com/battery-pack-rs/battery-pack/pull/81))
+
 ## [0.7.2](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.7.1...bphelper-cli-v0.7.2) - 2026-04-03
 
 ### Fixed

--- a/src/battery-pack/bphelper-cli/Cargo.toml
+++ b/src/battery-pack/bphelper-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bphelper-cli"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2024"
 description = "CLI for creating and managing battery packs"
 license = "MIT OR Apache-2.0"
@@ -8,7 +8,7 @@ repository = "https://github.com/battery-pack-rs/battery-pack"
 keywords = ["battery-pack", "cli", "cargo"]
 
 [dependencies]
-bphelper-manifest = { path = "../bphelper-manifest", version = "0.5.3" }
+bphelper-manifest = { path = "../bphelper-manifest", version = "0.5.4" }
 clap.workspace = true
 minijinja.workspace = true
 walkdir = "2"

--- a/src/battery-pack/bphelper-manifest/CHANGELOG.md
+++ b/src/battery-pack/bphelper-manifest/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.4](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-manifest-v0.5.3...bphelper-manifest-v0.5.4) - 2026-04-13
+
+### Other
+
+- refactor test: change tests to use snapbox instead of expect-test ([#80](https://github.com/battery-pack-rs/battery-pack/pull/80))
+
 ## [0.5.3](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-manifest-v0.5.2...bphelper-manifest-v0.5.3) - 2026-04-03
 
 ### Fixed

--- a/src/battery-pack/bphelper-manifest/Cargo.toml
+++ b/src/battery-pack/bphelper-manifest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bphelper-manifest"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2024"
 description = "Shared battery pack manifest parsing"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `bphelper-manifest`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `bphelper-build`: 0.4.4 -> 0.4.5 (✓ API compatible changes)
* `bphelper-cli`: 0.7.2 -> 0.7.3 (✓ API compatible changes)
* `battery-pack`: 0.4.10 -> 0.4.11 (✓ API compatible changes)
* `cli-battery-pack`: 0.5.0 -> 0.5.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `bphelper-manifest`

<blockquote>

## [0.5.4](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-manifest-v0.5.3...bphelper-manifest-v0.5.4) - 2026-04-13

### Other

- refactor test: change tests to use snapbox instead of expect-test ([#80](https://github.com/battery-pack-rs/battery-pack/pull/80))
</blockquote>

## `bphelper-build`

<blockquote>

## [0.4.5](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-build-v0.4.4...bphelper-build-v0.4.5) - 2026-04-13

### Other

- refactor test: change tests to use snapbox instead of expect-test ([#80](https://github.com/battery-pack-rs/battery-pack/pull/80))
</blockquote>

## `bphelper-cli`

<blockquote>

## [0.7.3](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.7.2...bphelper-cli-v0.7.3) - 2026-04-13

### Other

- refactor test: change tests to use snapbox instead of expect-test ([#80](https://github.com/battery-pack-rs/battery-pack/pull/80))
- *(deps)* upgrade ratatui to 0.30 and enable snapbox term-svg ([#81](https://github.com/battery-pack-rs/battery-pack/pull/81))
</blockquote>

## `battery-pack`

<blockquote>

## [0.4.11](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.4.10...battery-pack-v0.4.11) - 2026-04-13

### Other

- refactor test: change tests to use snapbox instead of expect-test ([#80](https://github.com/battery-pack-rs/battery-pack/pull/80))
- *(deps)* upgrade ratatui to 0.30 and enable snapbox term-svg ([#81](https://github.com/battery-pack-rs/battery-pack/pull/81))
</blockquote>

## `cli-battery-pack`

<blockquote>

## [0.5.1](https://github.com/battery-pack-rs/battery-pack/compare/cli-battery-pack-v0.5.0...cli-battery-pack-v0.5.1) - 2026-04-13

### Other

- *(deps)* upgrade ratatui to 0.30 and enable snapbox term-svg ([#81](https://github.com/battery-pack-rs/battery-pack/pull/81))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).