### PR TITLE
chore: release v0.4.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "battery-pack"
-version = "0.4.11"
+version = "0.4.12"
 dependencies = [
  "anyhow",
  "battery-pack",
@@ -383,7 +383,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-bp"
-version = "0.4.11"
+version = "0.4.12"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/src/battery-pack/CHANGELOG.md
+++ b/src/battery-pack/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.12](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.4.11...battery-pack-v0.4.12) - 2026-04-17
+
+### Added
+
+- add battery-pack-cli binary crate for cargo install
+
+### Other
+
+- give cargo-bp its own README, refine battery-pack README ([#86](https://github.com/battery-pack-rs/battery-pack/pull/86))
+- rename battery-pack-cli crate to cargo-bp
+
 ## [0.4.11](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.4.10...battery-pack-v0.4.11) - 2026-04-13
 
 ### Other

--- a/src/battery-pack/Cargo.toml
+++ b/src/battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "battery-pack"
-version = "0.4.11"
+version = "0.4.12"
 edition = "2024"
 description = "Curated crate bundles with docs, templates, and agentic skills"
 license = "MIT OR Apache-2.0"

--- a/src/cargo-bp/CHANGELOG.md
+++ b/src/cargo-bp/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.4.12](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-v0.4.11...cargo-bp-v0.4.12) - 2026-04-17
+
+### Other
+
+- give cargo-bp its own README, refine battery-pack README ([#86](https://github.com/battery-pack-rs/battery-pack/pull/86))

--- a/src/cargo-bp/Cargo.toml
+++ b/src/cargo-bp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-bp"
-version = "0.4.11"
+version = "0.4.12"
 edition = "2024"
 description = "CLI for creating and managing battery packs (cargo bp)"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `battery-pack`: 0.4.11 -> 0.4.12 (✓ API compatible changes)
* `cargo-bp`: 0.4.11 -> 0.4.12

<details><summary><i><b>Changelog</b></i></summary><p>

## `battery-pack`

<blockquote>

## [0.4.12](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.4.11...battery-pack-v0.4.12) - 2026-04-17

### Added

- add battery-pack-cli binary crate for cargo install

### Other

- give cargo-bp its own README, refine battery-pack README ([#86](https://github.com/battery-pack-rs/battery-pack/pull/86))
- rename battery-pack-cli crate to cargo-bp
</blockquote>

## `cargo-bp`

<blockquote>

## [0.4.12](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-v0.4.11...cargo-bp-v0.4.12) - 2026-04-17

### Other

- give cargo-bp its own README, refine battery-pack README ([#86](https://github.com/battery-pack-rs/battery-pack/pull/86))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).