### PR TITLE
docs: give cargo-bp its own README, refine battery-pack README

### DIFF
--- a/src/battery-pack/README.md
+++ b/src/battery-pack/README.md
@@ -1,9 +1,6 @@
 # battery-pack
 
-The `battery-pack` crate provides two things:
-
-1. **The `cargo bp` CLI** for working with battery packs
-2. **Common infrastructure** for authoring battery packs
+Curated crate bundles with docs, templates, and agentic skills.
 
 📖 **[Read the book](https://battery-pack-rs.github.io/battery-pack)**
 
@@ -14,6 +11,8 @@ A battery pack bundles everything you need to get started in an area: curated cr
 Think of it like an addition to the standard library targeting a particular use case, like building a CLI tool or web server.
 
 ## Installing the CLI
+
+Install [`cargo-bp`](https://crates.io/crates/cargo-bp):
 
 ```bash
 cargo install cargo-bp
@@ -27,7 +26,7 @@ cargo binstall cargo-bp
 # Create a new project from a battery pack template
 cargo bp new cli
 
-# Add a battery pack to your project
+# Add a battery pack to an existing project
 cargo bp add cli
 
 # Show info about a battery pack

--- a/src/cargo-bp/Cargo.toml
+++ b/src/cargo-bp/Cargo.toml
@@ -6,7 +6,7 @@ description = "CLI for creating and managing battery packs (cargo bp)"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/battery-pack-rs/battery-pack"
 keywords = ["battery-pack", "cli", "cargo"]
-readme = "../../README.md"
+readme = "README.md"
 
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/cargo-bp-v{ version }/cargo-bp-{ target }-v{ version }{ archive-suffix }"

--- a/src/cargo-bp/README.md
+++ b/src/cargo-bp/README.md
@@ -1,0 +1,34 @@
+# cargo-bp
+
+The CLI for working with [battery packs](https://crates.io/crates/battery-pack): curated crate bundles with docs, templates, and agentic skills.
+
+📖 **[Read the book](https://battery-pack-rs.github.io/battery-pack)** for the full guide.
+
+## Install
+
+```bash
+cargo install cargo-bp
+# or
+cargo binstall cargo-bp
+```
+
+## Usage
+
+```bash
+# Create a new project from a battery pack template
+cargo bp new cli
+
+# Add a battery pack to an existing project
+cargo bp add cli
+
+# Show info about a battery pack
+cargo bp show cli
+```
+
+## Related crates
+
+- [`battery-pack`](https://crates.io/crates/battery-pack): the library for authoring battery packs
+
+## License
+
+Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE) or [MIT license](LICENSE-MIT) at your option.


### PR DESCRIPTION
`cargo-bp` was using `battery-pack`'s README, which was confusing. Splitting the two apart.