### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "battery-pack"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "anyhow",
  "battery-pack",
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "bphelper-cli"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "bphelper-manifest",
@@ -383,7 +383,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-bp"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,7 +383,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-bp"
-version = "0.4.13"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/src/battery-pack/CHANGELOG.md
+++ b/src/battery-pack/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.13](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.4.12...battery-pack-v0.4.13) - 2026-04-18
+
+### Added
+
+- TUI context-awareness and one-shot exit behavior
+- cargo bp show annotates installed crates and features
+- cargo bp show displays features section
+- add cargo bp rm command to remove battery packs
+- reworked add picker with edit semantics and pre-selection
+- cargo bp add with no args shows helpful message instead of TUI
+- track managed-deps in battery pack metadata
+
+### Fixed
+
+- resolve cargo clippy warnings
+
+### Other
+
+- pacify the merciless cargo fmt
+- pacify the merciless cargo fmt
+- remove dead TUI add screen code
+- cargo bp enable command
+- write_bp_features_to_doc uses regular TOML table instead of inline table
+- Merge pull request #87 from nikomatsakis/do-not-default-to-gui
+- Fix detail view not scrolling when selection moves off screen
+
 ## [0.4.12](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.4.11...battery-pack-v0.4.12) - 2026-04-17
 
 ### Added

--- a/src/battery-pack/Cargo.toml
+++ b/src/battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "battery-pack"
-version = "0.4.12"
+version = "0.4.13"
 edition = "2024"
 description = "Curated crate bundles with docs, templates, and agentic skills"
 license = "MIT OR Apache-2.0"
@@ -22,7 +22,7 @@ cli = ["bphelper-cli"]
 
 [dependencies]
 bphelper-build = { path = "bphelper-build", version = "0.4.5", optional = true }
-bphelper-cli = { path = "bphelper-cli", version = "0.7.3", optional = true }
+bphelper-cli = { path = "bphelper-cli", version = "0.7.4", optional = true }
 bphelper-manifest = { path = "bphelper-manifest", version = "0.5.4" }
 anyhow.workspace = true
 

--- a/src/battery-pack/bphelper-cli/CHANGELOG.md
+++ b/src/battery-pack/bphelper-cli/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.4](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.7.3...bphelper-cli-v0.7.4) - 2026-04-18
+
+### Added
+
+- TUI context-awareness and one-shot exit behavior
+- cargo bp show annotates installed crates and features
+- cargo bp show displays features section
+- add cargo bp rm command to remove battery packs
+- reworked add picker with edit semantics and pre-selection
+- cargo bp add with no args shows helpful message instead of TUI
+- track managed-deps in battery pack metadata
+
+### Fixed
+
+- resolve cargo clippy warnings
+
+### Other
+
+- pacify the merciless cargo fmt
+- pacify the merciless cargo fmt
+- remove dead TUI add screen code
+- cargo bp enable command
+- write_bp_features_to_doc uses regular TOML table instead of inline table
+- Merge pull request #87 from nikomatsakis/do-not-default-to-gui
+- Fix detail view not scrolling when selection moves off screen
+
 ## [0.7.3](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.7.2...bphelper-cli-v0.7.3) - 2026-04-13
 
 ### Other

--- a/src/battery-pack/bphelper-cli/Cargo.toml
+++ b/src/battery-pack/bphelper-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bphelper-cli"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2024"
 description = "CLI for creating and managing battery packs"
 license = "MIT OR Apache-2.0"

--- a/src/cargo-bp/CHANGELOG.md
+++ b/src/cargo-bp/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.13](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-v0.4.12...cargo-bp-v0.4.13) - 2026-04-18
+
+### Added
+
+- TUI context-awareness and one-shot exit behavior
+- cargo bp show annotates installed crates and features
+- cargo bp show displays features section
+- add cargo bp rm command to remove battery packs
+- reworked add picker with edit semantics and pre-selection
+- cargo bp add with no args shows helpful message instead of TUI
+- track managed-deps in battery pack metadata
+
+### Fixed
+
+- resolve cargo clippy warnings
+
+### Other
+
+- pacify the merciless cargo fmt
+- pacify the merciless cargo fmt
+- remove dead TUI add screen code
+- cargo bp enable command
+- write_bp_features_to_doc uses regular TOML table instead of inline table
+- Merge pull request #87 from nikomatsakis/do-not-default-to-gui
+- Fix detail view not scrolling when selection moves off screen
+
 ## [0.4.12](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-v0.4.11...cargo-bp-v0.4.12) - 2026-04-17
 
 ### Other

--- a/src/cargo-bp/Cargo.toml
+++ b/src/cargo-bp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-bp"
-version = "0.4.12"
+version = "0.4.13"
 edition = "2024"
 description = "CLI for creating and managing battery packs (cargo bp)"
 license = "MIT OR Apache-2.0"

--- a/src/cargo-bp/Cargo.toml
+++ b/src/cargo-bp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-bp"
-version = "0.4.13"
+version = "0.5.0"
 edition = "2024"
 description = "CLI for creating and managing battery packs (cargo bp)"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `bphelper-cli`: 0.7.3 -> 0.7.4 (✓ API compatible changes)
* `battery-pack`: 0.4.12 -> 0.4.13 (✓ API compatible changes)
* `cargo-bp`: 0.4.12 -> 0.4.13

<details><summary><i><b>Changelog</b></i></summary><p>

## `bphelper-cli`

<blockquote>

## [0.7.4](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.7.3...bphelper-cli-v0.7.4) - 2026-04-18

### Added

- TUI context-awareness and one-shot exit behavior
- cargo bp show annotates installed crates and features
- cargo bp show displays features section
- add cargo bp rm command to remove battery packs
- reworked add picker with edit semantics and pre-selection
- cargo bp add with no args shows helpful message instead of TUI
- track managed-deps in battery pack metadata

### Fixed

- resolve cargo clippy warnings

### Other

- pacify the merciless cargo fmt
- pacify the merciless cargo fmt
- remove dead TUI add screen code
- cargo bp enable command
- write_bp_features_to_doc uses regular TOML table instead of inline table
- Merge pull request #87 from nikomatsakis/do-not-default-to-gui
- Fix detail view not scrolling when selection moves off screen
</blockquote>

## `battery-pack`

<blockquote>

## [0.4.13](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.4.12...battery-pack-v0.4.13) - 2026-04-18

### Added

- TUI context-awareness and one-shot exit behavior
- cargo bp show annotates installed crates and features
- cargo bp show displays features section
- add cargo bp rm command to remove battery packs
- reworked add picker with edit semantics and pre-selection
- cargo bp add with no args shows helpful message instead of TUI
- track managed-deps in battery pack metadata

### Fixed

- resolve cargo clippy warnings

### Other

- pacify the merciless cargo fmt
- pacify the merciless cargo fmt
- remove dead TUI add screen code
- cargo bp enable command
- write_bp_features_to_doc uses regular TOML table instead of inline table
- Merge pull request #87 from nikomatsakis/do-not-default-to-gui
- Fix detail view not scrolling when selection moves off screen
</blockquote>

## `cargo-bp`

<blockquote>

## [0.4.13](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-v0.4.12...cargo-bp-v0.4.13) - 2026-04-18

### Added

- TUI context-awareness and one-shot exit behavior
- cargo bp show annotates installed crates and features
- cargo bp show displays features section
- add cargo bp rm command to remove battery packs
- reworked add picker with edit semantics and pre-selection
- cargo bp add with no args shows helpful message instead of TUI
- track managed-deps in battery pack metadata

### Fixed

- resolve cargo clippy warnings

### Other

- pacify the merciless cargo fmt
- pacify the merciless cargo fmt
- remove dead TUI add screen code
- cargo bp enable command
- write_bp_features_to_doc uses regular TOML table instead of inline table
- Merge pull request #87 from nikomatsakis/do-not-default-to-gui
- Fix detail view not scrolling when selection moves off screen
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).