### PR TITLE
feat(cli): add template preview to `cargo bp show -t`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ tempfile = "3"
 serde_json = "1"
 thiserror = "2"
 toml = "0.8"
-
 snapbox = { version = "1.2.1", features = ["debug"] }
 
 [workspace.dependencies.clap]

--- a/md/spec/cli.md
+++ b/md/spec/cli.md
@@ -172,13 +172,6 @@ r[cli.new.define-flag]
 named placeholder to the given value, skipping the prompt for that
 placeholder. Multiple `-d` flags MAY be provided.
 
-r[cli.new.preview]
-`cargo bp new <pack> --preview` MUST render the template and print
-the resulting files to stdout without writing anything to disk.
-Placeholders without a default MUST fall back to `<name>` so the
-preview always succeeds. If `--name` is not provided, the preview
-MUST use `my-project` as the project name.
-
 r[cli.new.non-interactive]
 In non-interactive mode, `cargo bp new` MUST fail with an error
 if `--name` is not provided. Template placeholders without a
@@ -336,3 +329,12 @@ in the interactive TUI.
 r[cli.show.non-interactive]
 In non-interactive mode, `cargo bp show` MUST print results as
 plain text.
+
+r[cli.show.template-preview]
+`cargo bp show <pack> --template <name>` MUST render the named
+template and display the resulting files. In a TTY, the output
+SHOULD be shown in the interactive TUI preview screen. With
+`--non-interactive`, the rendered files MUST be printed to stdout.
+Placeholders without a default MUST fall back to `<name>` so the
+preview always succeeds. The project name MUST default to
+`my-project`.

--- a/md/using.md
+++ b/md/using.md
@@ -84,7 +84,13 @@ cargo bp new cli --template subcmds
 To see what a template will generate without writing any files:
 
 ```bash
-cargo bp new cli --preview
+cargo bp show cli -t default
+```
+
+In a terminal, this opens an interactive scrollable preview. For plain text output (e.g. in CI or piped to another command):
+
+```bash
+cargo bp show cli -t default --non-interactive
 ```
 
 For `new`, use `--name` and `-d` to provide values that would otherwise be prompted:

--- a/src/battery-pack/bphelper-cli/src/commands/mod.rs
+++ b/src/battery-pack/bphelper-cli/src/commands/mod.rs
@@ -16,10 +16,9 @@ use crate::manifest::{
     write_bp_features_to_doc, write_deps_by_kind, write_workspace_refs_by_kind,
 };
 use crate::registry::{
-    CrateSource, InstalledPack, TemplateConfig, download_and_extract_crate,
-    fetch_battery_pack_detail, fetch_battery_pack_detail_from_source, fetch_battery_pack_list,
-    fetch_bp_spec, find_local_battery_pack_dir, load_installed_bp_spec, lookup_crate,
-    resolve_crate_name, short_name,
+    CrateSource, InstalledPack, TemplateConfig, fetch_battery_pack_detail,
+    fetch_battery_pack_detail_from_source, fetch_battery_pack_list, fetch_bp_spec,
+    load_installed_bp_spec, resolve_crate_name, short_name,
 };
 
 // [impl cli.bare.help]
@@ -153,6 +152,11 @@ pub(crate) enum BpCommands {
         /// Name of the battery pack (e.g., "cli" resolves to "cli-battery-pack")
         battery_pack: String,
 
+        /// Preview a specific template's rendered output
+        // [impl cli.show.template-preview]
+        #[arg(long, short = 't')]
+        template: Option<String>,
+
         /// Use a local path instead of downloading from crates.io
         #[arg(long)]
         path: Option<String>,
@@ -272,16 +276,35 @@ pub fn main() -> Result<()> {
                         print_battery_pack_list(&source, filter.as_deref())
                     }
                 }
-                BpCommands::Show { battery_pack, path } => {
-                    // [impl cli.show.interactive]
-                    // [impl cli.show.non-interactive]
+                BpCommands::Show {
+                    battery_pack,
+                    template,
+                    path,
+                } => {
+                    let show_opts = crate::tui::ShowOpts {
+                        battery_pack: &battery_pack,
+                        template: template.as_deref(),
+                        path: path.as_deref(),
+                        source,
+                    };
                     if interactive {
-                        crate::tui::run_show(&battery_pack, path.as_deref(), source)
+                        // [impl cli.show.interactive]
+                        // [impl cli.show.template-preview]
+                        crate::tui::run_show(show_opts)
+                    } else if let Some(tmpl) = show_opts.template {
+                        // [impl cli.show.template-preview]
+                        print_template_preview(&crate::template_engine::PreviewOpts {
+                            battery_pack: show_opts.battery_pack,
+                            template: tmpl,
+                            path: show_opts.path,
+                            source: &show_opts.source,
+                        })
                     } else {
+                        // [impl cli.show.non-interactive]
                         print_battery_pack_detail(
-                            &battery_pack,
-                            path.as_deref(),
-                            &source,
+                            show_opts.battery_pack,
+                            show_opts.path,
+                            &show_opts.source,
                             &project_dir,
                         )
                     }
@@ -338,27 +361,10 @@ fn new_from_battery_pack(opts: NewFromBpOpts<'_>) -> Result<()> {
     }
 
     let crate_name = resolve_crate_name(opts.battery_pack);
-
-    // Locate the crate directory based on source
-    let crate_dir: PathBuf;
-    let _temp_dir: Option<tempfile::TempDir>; // keep alive for Registry
-    match opts.source {
-        CrateSource::Registry => {
-            let crate_info = lookup_crate(&crate_name)?;
-            let temp = download_and_extract_crate(&crate_name, &crate_info.version)?;
-            crate_dir = temp
-                .path()
-                .join(format!("{}-{}", crate_name, crate_info.version));
-            _temp_dir = Some(temp);
-        }
-        CrateSource::Local(workspace_dir) => {
-            crate_dir = find_local_battery_pack_dir(workspace_dir, &crate_name)?;
-            _temp_dir = None;
-        }
-    }
+    let resolved = crate::registry::resolve_crate_dir(opts.battery_pack, None, opts.source)?;
 
     // Read template metadata from the Cargo.toml
-    let manifest_path = crate_dir.join("Cargo.toml");
+    let manifest_path = resolved.dir.join("Cargo.toml");
     let manifest_content = std::fs::read_to_string(&manifest_path)
         .with_context(|| format!("Failed to read {}", manifest_path.display()))?;
     let templates = parse_template_metadata(&manifest_content, &crate_name)?;
@@ -367,7 +373,7 @@ fn new_from_battery_pack(opts: NewFromBpOpts<'_>) -> Result<()> {
     let template_path = resolve_template(&templates, opts.template.as_deref(), opts.interactive)?;
 
     // Generate the project from the crate directory
-    generate_from_path(new_opts, &crate_dir, &template_path)
+    generate_from_path(new_opts, &resolved.dir, &template_path)
 }
 
 /// Result of resolving which crates to add from a battery pack.
@@ -1680,6 +1686,19 @@ fn print_battery_pack_detail(
     println!("  cargo bp add {}", detail.short_name);
     println!("  cargo bp new {}", detail.short_name);
     println!();
+
+    Ok(())
+}
+
+// [impl cli.show.template-preview]
+fn print_template_preview(opts: &crate::template_engine::PreviewOpts<'_>) -> Result<()> {
+    let (_crate_name, files) = crate::template_engine::preview_template(opts)?;
+
+    for file in &files {
+        println!("── {} ──", file.path);
+        println!("{}", file.content);
+        println!();
+    }
 
     Ok(())
 }

--- a/src/battery-pack/bphelper-cli/src/commands/tests.rs
+++ b/src/battery-pack/bphelper-cli/src/commands/tests.rs
@@ -346,6 +346,48 @@ fn show_defaults_to_interactive() {
     );
 }
 
+// [verify cli.show.template-preview]
+#[test]
+fn show_template_flag_is_parsed() {
+    let cli = super::Cli::try_parse_from(["cargo", "bp", "show", "cli", "-t", "default"])
+        .expect("-t should be accepted");
+
+    match unwrap_bp_command(cli) {
+        super::BpCommands::Show { template, .. } => {
+            assert_eq!(template.as_deref(), Some("default"));
+        }
+        other => panic!("expected Show, got {:?}", std::mem::discriminant(&other)),
+    }
+}
+
+// [verify cli.show.template-preview]
+#[test]
+fn show_template_long_flag_is_parsed() {
+    let cli = super::Cli::try_parse_from(["cargo", "bp", "show", "cli", "--template", "subcmds"])
+        .expect("--template should be accepted");
+
+    match unwrap_bp_command(cli) {
+        super::BpCommands::Show { template, .. } => {
+            assert_eq!(template.as_deref(), Some("subcmds"));
+        }
+        other => panic!("expected Show, got {:?}", std::mem::discriminant(&other)),
+    }
+}
+
+// [verify cli.show.template-preview]
+#[test]
+fn show_without_template_has_none() {
+    let cli = super::Cli::try_parse_from(["cargo", "bp", "show", "cli"])
+        .expect("show without -t should parse");
+
+    match unwrap_bp_command(cli) {
+        super::BpCommands::Show { template, .. } => {
+            assert!(template.is_none());
+        }
+        other => panic!("expected Show, got {:?}", std::mem::discriminant(&other)),
+    }
+}
+
 // [verify cli.list.non-interactive]
 #[test]
 fn list_non_interactive_flag_is_parsed() {

--- a/src/battery-pack/bphelper-cli/src/registry/mod.rs
+++ b/src/battery-pack/bphelper-cli/src/registry/mod.rs
@@ -847,5 +847,45 @@ pub(crate) fn find_template_path(tree: &[String], template_path: &str) -> Option
         .cloned()
 }
 
+/// A resolved battery pack crate directory. Owns the temp dir (if any) to keep it alive.
+pub(crate) struct ResolvedCrate {
+    pub dir: PathBuf,
+    _temp: Option<tempfile::TempDir>,
+}
+
+/// Resolve a battery pack name to a local crate directory.
+///
+/// If `path_override` is set, uses that directly. Otherwise resolves via
+/// `source` (registry download or local workspace lookup).
+pub(crate) fn resolve_crate_dir(
+    battery_pack: &str,
+    path_override: Option<&str>,
+    source: &CrateSource,
+) -> Result<ResolvedCrate> {
+    if let Some(path) = path_override {
+        return Ok(ResolvedCrate {
+            dir: PathBuf::from(path),
+            _temp: None,
+        });
+    }
+
+    let crate_name = resolve_crate_name(battery_pack);
+    match source {
+        CrateSource::Registry => {
+            let info = lookup_crate(&crate_name)?;
+            let temp = download_and_extract_crate(&crate_name, &info.version)?;
+            let dir = temp.path().join(format!("{}-{}", crate_name, info.version));
+            Ok(ResolvedCrate {
+                dir,
+                _temp: Some(temp),
+            })
+        }
+        CrateSource::Local(workspace_dir) => {
+            let dir = find_local_battery_pack_dir(workspace_dir, &crate_name)?;
+            Ok(ResolvedCrate { dir, _temp: None })
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests;

--- a/src/battery-pack/bphelper-cli/src/template_engine.rs
+++ b/src/battery-pack/bphelper-cli/src/template_engine.rs
@@ -368,5 +368,46 @@ fn git_init(project_dir: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Options for previewing a battery pack template.
+pub(crate) struct PreviewOpts<'a> {
+    pub battery_pack: &'a str,
+    pub template: &'a str,
+    pub path: Option<&'a str>,
+    pub source: &'a crate::registry::CrateSource,
+}
+
+/// Resolve a battery pack template and render a preview.
+///
+/// Handles crate-dir resolution, manifest parsing, template lookup, and
+/// rendering. Returns the rendered files and the resolved crate name.
+pub(crate) fn preview_template(opts: &PreviewOpts<'_>) -> Result<(String, Vec<RenderedFile>)> {
+    let crate_name = crate::registry::resolve_crate_name(opts.battery_pack);
+    let resolved = crate::registry::resolve_crate_dir(opts.battery_pack, opts.path, opts.source)?;
+
+    let manifest_path = resolved.dir.join("Cargo.toml");
+    let manifest_content = std::fs::read_to_string(&manifest_path)
+        .with_context(|| format!("Failed to read {}", manifest_path.display()))?;
+    let spec = bphelper_manifest::parse_battery_pack(&manifest_content)
+        .map_err(|e| anyhow::anyhow!("Failed to parse battery pack: {e}"))?;
+    let tmpl = spec.templates.get(opts.template).ok_or_else(|| {
+        let available: Vec<_> = spec.templates.keys().map(|s| s.as_str()).collect();
+        anyhow::anyhow!(
+            "Template '{}' not found. Available: {}",
+            opts.template,
+            available.join(", ")
+        )
+    })?;
+
+    let opts = RenderOpts {
+        crate_root: resolved.dir,
+        template_path: tmpl.path.clone(),
+        project_name: "my-project".to_string(),
+        defines: BTreeMap::new(),
+        interactive_override: Some(false),
+    };
+    let files = preview(opts)?;
+    Ok((crate_name, files))
+}
+
 #[cfg(test)]
 mod tests;

--- a/src/battery-pack/bphelper-cli/src/template_engine/tests.rs
+++ b/src/battery-pack/bphelper-cli/src/template_engine/tests.rs
@@ -394,3 +394,29 @@ fake-battery-pack = { features = ["default"] }
 "#]]
     );
 }
+
+#[test]
+fn preview_template_resolves_and_renders() {
+    let fixtures = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("tests/fixtures/fancy-battery-pack");
+
+    let source = crate::registry::CrateSource::Local(fixtures.parent().unwrap().to_path_buf());
+    let opts = PreviewOpts {
+        battery_pack: "fancy",
+        template: "default",
+        path: None,
+        source: &source,
+    };
+
+    let (crate_name, files) = preview_template(&opts).unwrap();
+    assert_eq!(crate_name, "fancy-battery-pack");
+    assert!(!files.is_empty());
+    assert!(files.iter().any(|f| f.path == "Cargo.toml"));
+    assert!(files.iter().any(|f| f.path == "src/main.rs"));
+}

--- a/src/battery-pack/bphelper-cli/src/tui.rs
+++ b/src/battery-pack/bphelper-cli/src/tui.rs
@@ -24,15 +24,61 @@ use std::time::Duration;
 // Public entry points
 // ============================================================================
 
+/// Options for launching the TUI detail or preview screen.
+pub(crate) struct ShowOpts<'a> {
+    pub battery_pack: &'a str,
+    pub template: Option<&'a str>,
+    pub path: Option<&'a str>,
+    pub source: CrateSource,
+}
+
 /// Run the TUI starting from the list view
-pub fn run_list(source: CrateSource, filter: Option<String>) -> Result<()> {
+pub(crate) fn run_list(source: CrateSource, filter: Option<String>) -> Result<()> {
     let app = App::new_list(source, filter);
     app.run()
 }
 
-/// Run the TUI starting from the detail view
-pub fn run_show(name: &str, path: Option<&str>, source: CrateSource) -> Result<()> {
-    let app = App::new_show(name, path, source);
+/// Run the TUI for a battery pack. Without `template`, shows the detail
+/// screen. With `template`, jumps directly to the template preview.
+pub(crate) fn run_show(opts: ShowOpts<'_>) -> Result<()> {
+    if opts.template.is_some() {
+        run_preview(opts)
+    } else {
+        let app = App::new_show(opts.battery_pack, opts.path, opts.source);
+        app.run()
+    }
+}
+
+/// Run the TUI starting directly in the template preview screen.
+fn run_preview(opts: ShowOpts<'_>) -> Result<()> {
+    let template = opts.template.expect("run_preview requires template");
+    let (crate_name, files) =
+        crate::template_engine::preview_template(&crate::template_engine::PreviewOpts {
+            battery_pack: opts.battery_pack,
+            template,
+            path: opts.path,
+            source: &opts.source,
+        })?;
+    let content = highlight_preview(&files);
+
+    let line_count = content.lines.len() as u16;
+    let app = App {
+        source: opts.source,
+        screen: Screen::Preview(PreviewScreen {
+            content,
+            battery_pack_name: crate_name,
+            template_name: template.to_string(),
+            scroll: 0,
+            line_count,
+            detail: None,
+            selected_index: 0,
+            came_from_list: false,
+        }),
+        should_quit: false,
+        pending_action: None,
+        in_project: false,
+        installed_bp_names: Vec::new(),
+    };
     app.run()
 }
 
@@ -246,14 +292,16 @@ impl FormScreen {
 struct PreviewScreen {
     /// Syntax-highlighted content to display.
     content: Text<'static>,
+    /// Battery pack name for the header.
+    battery_pack_name: String,
     /// Template name for the header.
     template_name: String,
     /// Vertical scroll offset.
     scroll: u16,
     /// Total number of lines in content (for scroll bounds).
     line_count: u16,
-    /// The detail screen to return to on Esc.
-    detail: Rc<BatteryPackDetail>,
+    /// The detail screen to return to on Esc. None = standalone (Esc quits).
+    detail: Option<Rc<BatteryPackDetail>>,
     /// Selected index to restore when returning to detail.
     selected_index: usize,
     came_from_list: bool,
@@ -551,7 +599,7 @@ impl App {
             FormEnd,
             PreviewTemplate(Rc<BatteryPackDetail>, String, usize, bool),
             PreviewScroll(i16),
-            PreviewBack(Rc<BatteryPackDetail>, usize, bool),
+            PreviewBack(Option<Rc<BatteryPackDetail>>, usize, bool),
         }
 
         let action = match &self.screen {
@@ -700,7 +748,7 @@ impl App {
             },
             Screen::Preview(state) => match key {
                 KeyCode::Esc | KeyCode::Char('q') => Action::PreviewBack(
-                    Rc::clone(&state.detail),
+                    state.detail.clone(),
                     state.selected_index,
                     state.came_from_list,
                 ),
@@ -945,10 +993,11 @@ impl App {
                 let line_count = content.lines.len() as u16;
                 self.screen = Screen::Preview(PreviewScreen {
                     content,
+                    battery_pack_name: detail.name.clone(),
                     template_name,
                     scroll: 0,
                     line_count,
-                    detail,
+                    detail: Some(detail),
                     selected_index,
                     came_from_list,
                 });
@@ -961,13 +1010,17 @@ impl App {
                 }
             }
             Action::PreviewBack(detail, selected_index, came_from_list) => {
-                self.screen = Screen::Detail(DetailScreen {
-                    detail: detail.clone(),
-                    selected_index,
-                    came_from_list,
-                    in_project: self.in_project,
-                    is_installed: self.installed_bp_names.contains(&detail.name),
-                });
+                if let Some(detail) = detail {
+                    self.screen = Screen::Detail(DetailScreen {
+                        detail: detail.clone(),
+                        selected_index,
+                        came_from_list,
+                        in_project: self.in_project,
+                        is_installed: self.installed_bp_names.contains(&detail.name),
+                    });
+                } else {
+                    self.should_quit = true;
+                }
             }
         }
     }
@@ -1485,7 +1538,10 @@ fn render_preview(frame: &mut Frame, state: &PreviewScreen) {
 
     frame.render_widget(
         Paragraph::new(Line::from(vec![
-            Span::styled(&state.detail.name, Style::default().fg(Color::Green).bold()),
+            Span::styled(
+                &state.battery_pack_name,
+                Style::default().fg(Color::Green).bold(),
+            ),
             Span::raw(" / "),
             Span::styled(
                 &state.template_name,

--- a/src/battery-pack/bphelper-cli/src/tui/tests.rs
+++ b/src/battery-pack/bphelper-cli/src/tui/tests.rs
@@ -433,10 +433,11 @@ fn preview_esc_returns_to_detail() {
     let detail = make_detail(&["serde"], &["default"], &[]);
     let mut app = make_app(Screen::Preview(PreviewScreen {
         content: Text::from("test content"),
+        battery_pack_name: "test-battery-pack".to_string(),
         template_name: "default".to_string(),
         scroll: 0,
         line_count: 1,
-        detail: Rc::new(detail),
+        detail: Some(Rc::new(detail)),
         selected_index: 2,
         came_from_list: true,
     }));
@@ -454,10 +455,11 @@ fn preview_scroll_down_and_up() {
     let detail = make_detail(&[], &["default"], &[]);
     let mut app = make_app(Screen::Preview(PreviewScreen {
         content: Text::from("line1\nline2\nline3\nline4\nline5"),
+        battery_pack_name: "test-battery-pack".to_string(),
         template_name: "default".to_string(),
         scroll: 0,
         line_count: 5,
-        detail: Rc::new(detail),
+        detail: Some(Rc::new(detail)),
         selected_index: 0,
         came_from_list: false,
     }));
@@ -488,10 +490,11 @@ fn preview_scroll_clamps_at_bounds() {
     let detail = make_detail(&[], &["default"], &[]);
     let mut app = make_app(Screen::Preview(PreviewScreen {
         content: Text::from("line1\nline2"),
+        battery_pack_name: "test-battery-pack".to_string(),
         template_name: "default".to_string(),
         scroll: 0,
         line_count: 2,
-        detail: Rc::new(detail),
+        detail: Some(Rc::new(detail)),
         selected_index: 0,
         came_from_list: false,
     }));
@@ -501,4 +504,54 @@ fn preview_scroll_clamps_at_bounds() {
     if let Screen::Preview(state) = &app.screen {
         assert_eq!(state.scroll, 0);
     }
+}
+
+// [verify cli.show.template-preview]
+#[test]
+fn preview_standalone_esc_quits() {
+    let mut app = make_app(Screen::Preview(PreviewScreen {
+        content: Text::from("standalone preview"),
+        battery_pack_name: "cli-battery-pack".to_string(),
+        template_name: "default".to_string(),
+        scroll: 0,
+        line_count: 1,
+        detail: None,
+        selected_index: 0,
+        came_from_list: false,
+    }));
+
+    app.handle_key(KeyCode::Esc);
+    assert!(app.should_quit);
+}
+
+// [verify cli.show.template-preview]
+#[test]
+fn preview_standalone_renders_header_and_content() {
+    let mut app = make_app(Screen::Preview(PreviewScreen {
+        content: Text::from("fn main() {}"),
+        battery_pack_name: "cli-battery-pack".to_string(),
+        template_name: "simple".to_string(),
+        scroll: 0,
+        line_count: 1,
+        detail: None,
+        selected_index: 0,
+        came_from_list: false,
+    }));
+
+    let output = render_app_to_string(&mut app, 60, 10);
+    assert!(
+        output.contains("cli-battery-pack"),
+        "Expected pack name in header:\n{}",
+        output
+    );
+    assert!(
+        output.contains("simple"),
+        "Expected template name in header:\n{}",
+        output
+    );
+    assert!(
+        output.contains("fn main()"),
+        "Expected content in output:\n{}",
+        output
+    );
 }

--- a/src/cargo-bp/tests/show_preview.rs
+++ b/src/cargo-bp/tests/show_preview.rs
@@ -1,0 +1,98 @@
+//! Integration tests for `cargo bp show --template --non-interactive`.
+
+use assert_cmd::Command;
+use snapbox::{assert_data_eq, str};
+use std::path::Path;
+
+fn cargo_bp() -> Command {
+    Command::new(assert_cmd::cargo::cargo_bin!("cargo-bp"))
+}
+
+fn fixtures_dir() -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("battery-pack")
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("tests/fixtures")
+}
+
+#[test]
+fn show_template_preview_prints_rendered_files() {
+    let fixture = fixtures_dir().join("fancy-battery-pack");
+
+    let output = cargo_bp()
+        .args([
+            "bp",
+            "show",
+            "fancy",
+            "-t",
+            "default",
+            "--non-interactive",
+            "--path",
+            &fixture.to_string_lossy(),
+        ])
+        .output()
+        .expect("failed to run cargo-bp");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_data_eq!(
+        stdout.as_ref(),
+        str![[r#"
+── Cargo.toml ──
+[package]
+name = "my-project"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+dialoguer = "0.11"
+
+── src/main.rs ──
+fn main() {
+    println!("Hello from default template!");
+}
+
+
+"#]]
+    );
+}
+
+#[test]
+fn show_template_preview_unknown_template_errors() {
+    let fixture = fixtures_dir().join("fancy-battery-pack");
+
+    let output = cargo_bp()
+        .args([
+            "bp",
+            "show",
+            "fancy",
+            "-t",
+            "nonexistent",
+            "--non-interactive",
+            "--path",
+            &fixture.to_string_lossy(),
+        ])
+        .output()
+        .expect("failed to run cargo-bp");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_data_eq!(
+        stderr.as_ref(),
+        str![[r#"
+Error: Template 'nonexistent' not found. Available: default, full
+
+"#]]
+    );
+}


### PR DESCRIPTION
### Summary

The `--preview` flag on `cargo bp new` was specced and documented but lost during the lib.rs module split refactor (eed5c9a). Rather than restoring it on `new`, this moves template preview to `cargo bp show -t <template>`, which is a better fit: `show` already means "show me info about this pack," and a template name just narrows what you're showing.

```bash
# Interactive TUI preview (syntax-highlighted, scrollable)
cargo bp show cli -t default

# Non-interactive (stdout, for CI or piping)
cargo bp show cli -t default --non-interactive

# With a local path
cargo bp show fancy -t default --non-interactive --path tests/fixtures/fancy-battery-pack
```

Without `-t`, `show` behaves exactly as before. The TUI's existing preview (pressing `p` on a template in the detail screen) also continues to work.

Threw in some light consolidation of related helpers.

### Testing

- e2e CLI snapshot testing for non-interactive paths
- unit tests on the CLI handling, TUI rendering, tui escape