### PR TITLE
feat(cli): add global --non-interactive / -N flag with env var support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ toml = "0.8"
 
 [workspace.dependencies.clap]
 version = "4"
-features = ["derive"]
+features = ["derive", "env"]
 
 [workspace.dependencies.reqwest]
 version = "0.13"

--- a/md/getting-started.md
+++ b/md/getting-started.md
@@ -21,7 +21,7 @@ You'll be prompted for a project name and directory.
 The result is a ready-to-go Rust project with the battery pack's
 recommended crates already in your `Cargo.toml`.
 
-See [Using Battery Packs](./using.md#creating-a-new-project-from-a-template) for the full set of template options, including choosing specific templates, non-interactive mode, and previewing output.
+See [Using Battery Packs](./using.md#creating-a-new-project-from-a-template) for the full set of template options, including choosing specific templates, [non-interactive mode](./using.md#non-interactive-mode), and previewing output.
 
 ## Add a battery pack to an existing project
 

--- a/md/spec/cli.md
+++ b/md/spec/cli.md
@@ -49,6 +49,22 @@ r[cli.path.no-resolve]
 When `--path` is provided, name resolution is not needed.
 The battery pack is read directly from the given directory.
 
+## Non-interactive mode
+
+r[cli.non-interactive.flag]
+`cargo bp --non-interactive` (or `-N`) MUST suppress interactive
+prompts and TUI mode. This is a global flag accepted by all
+subcommands.
+
+r[cli.non-interactive.env]
+Setting `CARGO_BP_NON_INTERACTIVE=true` MUST have the same effect
+as passing `--non-interactive`. The flag and env var are combined
+with OR logic.
+
+r[cli.non-interactive.tty]
+When stdout is not a TTY, `cargo bp` MUST behave as if
+`--non-interactive` were passed.
+
 ## Name resolution
 
 r[cli.name.resolve]
@@ -163,6 +179,11 @@ Placeholders without a default MUST fall back to `<name>` so the
 preview always succeeds. If `--name` is not provided, the preview
 MUST use `my-project` as the project name.
 
+r[cli.new.non-interactive]
+In non-interactive mode, `cargo bp new` MUST fail with an error
+if `--name` is not provided. Template placeholders without a
+default or `--define` override MUST also cause an error.
+
 ## `cargo bp status`
 
 r[cli.status.list]
@@ -210,7 +231,8 @@ If running in a TTY, `cargo bp list` SHOULD display results
 in the interactive TUI.
 
 r[cli.list.non-interactive]
-`cargo bp list --non-interactive` MUST print results as plain text.
+In non-interactive mode, `cargo bp list` MUST print results as
+plain text.
 
 ## `cargo bp validate`
 
@@ -293,4 +315,5 @@ If running in a TTY, `cargo bp show` SHOULD display results
 in the interactive TUI.
 
 r[cli.show.non-interactive]
-`cargo bp show --non-interactive` MUST print results as plain text.
+In non-interactive mode, `cargo bp show` MUST print results as
+plain text.

--- a/md/using.md
+++ b/md/using.md
@@ -19,6 +19,31 @@ The TUI is context-dependent. If you're inside a Rust project, you'll see:
 If you're not in a Rust project, the installed-packs section is
 greyed out, but you can still browse and create new projects.
 
+## Non-interactive mode
+
+Pass `--non-interactive` (or `-N`) to suppress TUI and prompts:
+
+```bash
+cargo bp -N list                        # plain text output
+cargo bp -N show cli                    # plain text output
+cargo bp -N new cli --name my-app       # no prompts
+cargo bp -N rm cli                      # skip "remove deps?" prompt
+```
+
+Set `CARGO_BP_NON_INTERACTIVE=true` to activate for an entire session:
+
+```bash
+export CARGO_BP_NON_INTERACTIVE=true
+cargo bp list              # plain text, no TUI
+cargo bp new cli -n my-app # no prompts
+```
+
+For `new`, use `--name` and `-d` to provide values that would otherwise be prompted:
+
+```bash
+cargo bp new cli --name my-app -d description="My CLI tool"
+```
+
 ## Browsing available packs
 
 ### From the TUI
@@ -62,9 +87,7 @@ To see what a template will generate without writing any files:
 cargo bp new cli --preview
 ```
 
-### Non-interactive mode
-
-To set placeholder values non-interactively (e.g. in CI), use `--name` and `-d`:
+For `new`, use `--name` and `-d` to provide values that would otherwise be prompted:
 
 ```bash
 cargo bp new cli --name my-app -d description="My CLI tool"

--- a/src/battery-pack/bphelper-cli/src/commands/mod.rs
+++ b/src/battery-pack/bphelper-cli/src/commands/mod.rs
@@ -201,8 +201,7 @@ pub fn main() -> Result<()> {
                 Some(path) => CrateSource::Local(path),
                 None => CrateSource::Registry,
             };
-            let non_interactive = non_interactive || !interactive;
-            let interactive = !non_interactive;
+            let interactive = interactive && !non_interactive;
             match command {
                 BpCommands::New {
                     battery_pack,
@@ -210,15 +209,15 @@ pub fn main() -> Result<()> {
                     template,
                     path,
                     define,
-                } => new_from_battery_pack(
-                    &battery_pack,
+                } => new_from_battery_pack(NewFromBpOpts {
+                    battery_pack: &battery_pack,
                     name,
                     template,
-                    path,
-                    &source,
-                    &define,
-                    non_interactive,
-                ),
+                    path_override: path,
+                    source: &source,
+                    define: &define,
+                    interactive,
+                }),
                 BpCommands::Add {
                     battery_pack,
                     crates,
@@ -258,7 +257,7 @@ pub fn main() -> Result<()> {
                 BpCommands::List { filter } => {
                     // [impl cli.list.interactive]
                     // [impl cli.list.non-interactive]
-                    if !non_interactive {
+                    if interactive {
                         crate::tui::run_list(source, filter)
                     } else {
                         // [impl cli.list.query]
@@ -269,7 +268,7 @@ pub fn main() -> Result<()> {
                 BpCommands::Show { battery_pack, path } => {
                     // [impl cli.show.interactive]
                     // [impl cli.show.non-interactive]
-                    if !non_interactive {
+                    if interactive {
                         crate::tui::run_show(&battery_pack, path.as_deref(), source)
                     } else {
                         print_battery_pack_detail(
@@ -295,42 +294,45 @@ pub fn main() -> Result<()> {
 // Implementation
 // ============================================================================
 
+/// Input options for [`new_from_battery_pack`].
+pub(crate) struct NewFromBpOpts<'a> {
+    pub battery_pack: &'a str,
+    pub name: Option<String>,
+    pub template: Option<String>,
+    pub path_override: Option<String>,
+    pub source: &'a CrateSource,
+    pub define: &'a [(String, String)],
+    pub interactive: bool,
+}
+
 // [impl cli.new.template]
 // [impl cli.new.name-flag]
 // [impl cli.new.name-prompt]
 // [impl cli.path.flag]
 // [impl cli.source.replace]
-fn new_from_battery_pack(
-    battery_pack: &str,
-    name: Option<String>,
-    template: Option<String>,
-    path_override: Option<String>,
-    source: &CrateSource,
-    define: &[(String, String)],
-    non_interactive: bool,
-) -> Result<()> {
-    if non_interactive && name.is_none() {
+fn new_from_battery_pack(opts: NewFromBpOpts<'_>) -> Result<()> {
+    if !opts.interactive && opts.name.is_none() {
         bail!("--name is required in non-interactive mode");
     }
 
     let new_opts = NewOpts {
-        battery_pack: battery_pack.to_string(),
-        name,
-        defines: define.iter().cloned().collect(),
-        non_interactive,
+        battery_pack: opts.battery_pack.to_string(),
+        name: opts.name,
+        defines: opts.define.iter().cloned().collect(),
+        interactive: opts.interactive,
     };
 
     // --path takes precedence over --crate-source
-    if let Some(path) = path_override {
-        return generate_from_local(new_opts, &path, template);
+    if let Some(path) = opts.path_override {
+        return generate_from_local(new_opts, &path, opts.template);
     }
 
-    let crate_name = resolve_crate_name(battery_pack);
+    let crate_name = resolve_crate_name(opts.battery_pack);
 
     // Locate the crate directory based on source
     let crate_dir: PathBuf;
     let _temp_dir: Option<tempfile::TempDir>; // keep alive for Registry
-    match source {
+    match opts.source {
         CrateSource::Registry => {
             let crate_info = lookup_crate(&crate_name)?;
             let temp = download_and_extract_crate(&crate_name, &crate_info.version)?;
@@ -352,7 +354,7 @@ fn new_from_battery_pack(
     let templates = parse_template_metadata(&manifest_content, &crate_name)?;
 
     // Resolve which template to use
-    let template_path = resolve_template(&templates, template.as_deref(), non_interactive)?;
+    let template_path = resolve_template(&templates, opts.template.as_deref(), opts.interactive)?;
 
     // Generate the project from the crate directory
     generate_from_path(new_opts, &crate_dir, &template_path)
@@ -1399,7 +1401,7 @@ struct NewOpts {
     battery_pack: String,
     name: Option<String>,
     defines: BTreeMap<String, String>,
-    non_interactive: bool,
+    interactive: bool,
 }
 
 fn generate_from_local(opts: NewOpts, local_path: &str, template: Option<String>) -> Result<()> {
@@ -1415,7 +1417,7 @@ fn generate_from_local(opts: NewOpts, local_path: &str, template: Option<String>
         .and_then(|s| s.to_str())
         .unwrap_or("unknown");
     let templates = parse_template_metadata(&manifest_content, crate_name)?;
-    let template_path = resolve_template(&templates, template.as_deref(), opts.non_interactive)?;
+    let template_path = resolve_template(&templates, template.as_deref(), opts.interactive)?;
 
     generate_from_path(opts, local_path, &template_path)
 }
@@ -1450,10 +1452,10 @@ fn generate_from_path(opts: NewOpts, crate_path: &Path, template_path: &str) -> 
         raw
     };
 
-    let interactive_override = if opts.non_interactive {
-        Some(false)
-    } else {
+    let interactive_override = if opts.interactive {
         None
+    } else {
+        Some(false)
     };
 
     let gen_opts = crate::template_engine::GenerateOpts {
@@ -1503,7 +1505,7 @@ fn parse_template_metadata(
 pub(crate) fn resolve_template(
     templates: &BTreeMap<String, TemplateConfig>,
     requested: Option<&str>,
-    non_interactive: bool,
+    interactive: bool,
 ) -> Result<String> {
     match requested {
         Some(name) => {
@@ -1524,7 +1526,7 @@ pub(crate) fn resolve_template(
             } else if let Some(config) = templates.get("default") {
                 Ok(config.path.clone())
             } else {
-                prompt_for_template(templates, non_interactive)
+                prompt_for_template(templates, interactive)
             }
         }
     }
@@ -1532,7 +1534,7 @@ pub(crate) fn resolve_template(
 
 fn prompt_for_template(
     templates: &BTreeMap<String, TemplateConfig>,
-    non_interactive: bool,
+    interactive: bool,
 ) -> Result<String> {
     use dialoguer::{Select, theme::ColorfulTheme};
 
@@ -1549,7 +1551,7 @@ fn prompt_for_template(
         .collect();
 
     // Check if we're in a TTY for interactive mode
-    if non_interactive || !std::io::stdout().is_terminal() {
+    if !interactive || !std::io::stdout().is_terminal() {
         // Non-interactive: list templates and bail
         println!("Available templates:");
         for item in &items {

--- a/src/battery-pack/bphelper-cli/src/commands/mod.rs
+++ b/src/battery-pack/bphelper-cli/src/commands/mod.rs
@@ -41,6 +41,10 @@ pub(crate) enum Commands {
         #[arg(long)]
         crate_source: Option<PathBuf>,
 
+        /// Disable interactive prompts and TUI mode
+        #[arg(long, short = 'N', global = true, env = "CARGO_BP_NON_INTERACTIVE")]
+        non_interactive: bool,
+
         #[command(subcommand)]
         command: BpCommands,
     },
@@ -141,10 +145,6 @@ pub(crate) enum BpCommands {
     List {
         /// Filter by name (omit to list all battery packs)
         filter: Option<String>,
-
-        /// Disable interactive TUI mode
-        #[arg(long)]
-        non_interactive: bool,
     },
 
     /// Show detailed information about a battery pack
@@ -156,10 +156,6 @@ pub(crate) enum BpCommands {
         /// Use a local path instead of downloading from crates.io
         #[arg(long)]
         path: Option<String>,
-
-        /// Disable interactive TUI mode
-        #[arg(long)]
-        non_interactive: bool,
     },
 
     /// Show status of installed battery packs and version warnings
@@ -198,12 +194,15 @@ pub fn main() -> Result<()> {
     match cli.command {
         Commands::Bp {
             crate_source,
+            non_interactive,
             command,
         } => {
             let source = match crate_source {
                 Some(path) => CrateSource::Local(path),
                 None => CrateSource::Registry,
             };
+            let non_interactive = non_interactive || !interactive;
+            let interactive = !non_interactive;
             match command {
                 BpCommands::New {
                     battery_pack,
@@ -211,7 +210,15 @@ pub fn main() -> Result<()> {
                     template,
                     path,
                     define,
-                } => new_from_battery_pack(&battery_pack, name, template, path, &source, &define),
+                } => new_from_battery_pack(
+                    &battery_pack,
+                    name,
+                    template,
+                    path,
+                    &source,
+                    &define,
+                    non_interactive,
+                ),
                 BpCommands::Add {
                     battery_pack,
                     crates,
@@ -248,13 +255,10 @@ pub fn main() -> Result<()> {
                     interactive,
                     &project_dir,
                 ),
-                BpCommands::List {
-                    filter,
-                    non_interactive,
-                } => {
+                BpCommands::List { filter } => {
                     // [impl cli.list.interactive]
                     // [impl cli.list.non-interactive]
-                    if !non_interactive && interactive {
+                    if !non_interactive {
                         crate::tui::run_list(source, filter)
                     } else {
                         // [impl cli.list.query]
@@ -262,14 +266,10 @@ pub fn main() -> Result<()> {
                         print_battery_pack_list(&source, filter.as_deref())
                     }
                 }
-                BpCommands::Show {
-                    battery_pack,
-                    path,
-                    non_interactive,
-                } => {
+                BpCommands::Show { battery_pack, path } => {
                     // [impl cli.show.interactive]
                     // [impl cli.show.non-interactive]
-                    if !non_interactive && interactive {
+                    if !non_interactive {
                         crate::tui::run_show(&battery_pack, path.as_deref(), source)
                     } else {
                         print_battery_pack_detail(
@@ -307,12 +307,22 @@ fn new_from_battery_pack(
     path_override: Option<String>,
     source: &CrateSource,
     define: &[(String, String)],
+    non_interactive: bool,
 ) -> Result<()> {
-    let defines: std::collections::BTreeMap<String, String> = define.iter().cloned().collect();
+    if non_interactive && name.is_none() {
+        bail!("--name is required in non-interactive mode");
+    }
+
+    let new_opts = NewOpts {
+        battery_pack: battery_pack.to_string(),
+        name,
+        defines: define.iter().cloned().collect(),
+        non_interactive,
+    };
 
     // --path takes precedence over --crate-source
     if let Some(path) = path_override {
-        return generate_from_local(battery_pack, &path, name, template, defines);
+        return generate_from_local(new_opts, &path, template);
     }
 
     let crate_name = resolve_crate_name(battery_pack);
@@ -342,10 +352,10 @@ fn new_from_battery_pack(
     let templates = parse_template_metadata(&manifest_content, &crate_name)?;
 
     // Resolve which template to use
-    let template_path = resolve_template(&templates, template.as_deref())?;
+    let template_path = resolve_template(&templates, template.as_deref(), non_interactive)?;
 
     // Generate the project from the crate directory
-    generate_from_path(battery_pack, &crate_dir, &template_path, name, defines)
+    generate_from_path(new_opts, &crate_dir, &template_path)
 }
 
 /// Result of resolving which crates to add from a battery pack.
@@ -1384,13 +1394,15 @@ fn update_build_rs(build_rs_path: &Path, crate_name: &str) -> Result<()> {
     Ok(())
 }
 
-fn generate_from_local(
-    battery_pack: &str,
-    local_path: &str,
+/// Shared options for `cargo bp new` generation.
+struct NewOpts {
+    battery_pack: String,
     name: Option<String>,
-    template: Option<String>,
-    defines: std::collections::BTreeMap<String, String>,
-) -> Result<()> {
+    defines: BTreeMap<String, String>,
+    non_interactive: bool,
+}
+
+fn generate_from_local(opts: NewOpts, local_path: &str, template: Option<String>) -> Result<()> {
     let local_path = Path::new(local_path);
 
     // Read local Cargo.toml
@@ -1403,9 +1415,9 @@ fn generate_from_local(
         .and_then(|s| s.to_str())
         .unwrap_or("unknown");
     let templates = parse_template_metadata(&manifest_content, crate_name)?;
-    let template_path = resolve_template(&templates, template.as_deref())?;
+    let template_path = resolve_template(&templates, template.as_deref(), opts.non_interactive)?;
 
-    generate_from_path(battery_pack, local_path, &template_path, name, defines)
+    generate_from_path(opts, local_path, &template_path)
 }
 
 /// Prompt for a project name if not provided.
@@ -1430,33 +1442,33 @@ fn ensure_battery_pack_suffix(name: String) -> String {
     }
 }
 
-fn generate_from_path(
-    battery_pack: &str,
-    crate_path: &Path,
-    template_path: &str,
-    name: Option<String>,
-    defines: std::collections::BTreeMap<String, String>,
-) -> Result<()> {
-    let raw = prompt_project_name(name)?;
-    let project_name = if battery_pack == "battery-pack" {
+fn generate_from_path(opts: NewOpts, crate_path: &Path, template_path: &str) -> Result<()> {
+    let raw = prompt_project_name(opts.name)?;
+    let project_name = if opts.battery_pack == "battery-pack" {
         ensure_battery_pack_suffix(raw)
     } else {
         raw
     };
 
-    let opts = crate::template_engine::GenerateOpts {
+    let interactive_override = if opts.non_interactive {
+        Some(false)
+    } else {
+        None
+    };
+
+    let gen_opts = crate::template_engine::GenerateOpts {
         render: crate::template_engine::RenderOpts {
             crate_root: crate_path.to_path_buf(),
             template_path: template_path.to_string(),
             project_name,
-            defines,
-            interactive_override: None,
+            defines: opts.defines,
+            interactive_override,
         },
         destination: None,
         git_init: true,
     };
 
-    crate::template_engine::generate(opts)?;
+    crate::template_engine::generate(gen_opts)?;
 
     Ok(())
 }
@@ -1491,6 +1503,7 @@ fn parse_template_metadata(
 pub(crate) fn resolve_template(
     templates: &BTreeMap<String, TemplateConfig>,
     requested: Option<&str>,
+    non_interactive: bool,
 ) -> Result<String> {
     match requested {
         Some(name) => {
@@ -1506,21 +1519,21 @@ pub(crate) fn resolve_template(
         }
         None => {
             if templates.len() == 1 {
-                // Only one template, use it
                 let (_, config) = templates.iter().next().unwrap();
                 Ok(config.path.clone())
             } else if let Some(config) = templates.get("default") {
-                // Multiple templates, but there's a 'default'
                 Ok(config.path.clone())
             } else {
-                // Multiple templates, no default - prompt user to pick
-                prompt_for_template(templates)
+                prompt_for_template(templates, non_interactive)
             }
         }
     }
 }
 
-fn prompt_for_template(templates: &BTreeMap<String, TemplateConfig>) -> Result<String> {
+fn prompt_for_template(
+    templates: &BTreeMap<String, TemplateConfig>,
+    non_interactive: bool,
+) -> Result<String> {
     use dialoguer::{Select, theme::ColorfulTheme};
 
     // Build display items with descriptions
@@ -1536,7 +1549,7 @@ fn prompt_for_template(templates: &BTreeMap<String, TemplateConfig>) -> Result<S
         .collect();
 
     // Check if we're in a TTY for interactive mode
-    if !std::io::stdout().is_terminal() {
+    if non_interactive || !std::io::stdout().is_terminal() {
         // Non-interactive: list templates and bail
         println!("Available templates:");
         for item in &items {

--- a/src/battery-pack/bphelper-cli/src/commands/mod.rs
+++ b/src/battery-pack/bphelper-cli/src/commands/mod.rs
@@ -295,14 +295,14 @@ pub fn main() -> Result<()> {
 // ============================================================================
 
 /// Input options for [`new_from_battery_pack`].
-pub(crate) struct NewFromBpOpts<'a> {
-    pub battery_pack: &'a str,
-    pub name: Option<String>,
-    pub template: Option<String>,
-    pub path_override: Option<String>,
-    pub source: &'a CrateSource,
-    pub define: &'a [(String, String)],
-    pub interactive: bool,
+struct NewFromBpOpts<'a> {
+    battery_pack: &'a str,
+    name: Option<String>,
+    template: Option<String>,
+    path_override: Option<String>,
+    source: &'a CrateSource,
+    define: &'a [(String, String)],
+    interactive: bool,
 }
 
 // [impl cli.new.template]

--- a/src/battery-pack/bphelper-cli/src/commands/mod.rs
+++ b/src/battery-pack/bphelper-cli/src/commands/mod.rs
@@ -1452,11 +1452,7 @@ fn generate_from_path(opts: NewOpts, crate_path: &Path, template_path: &str) -> 
         raw
     };
 
-    let interactive_override = if opts.interactive {
-        None
-    } else {
-        Some(false)
-    };
+    let interactive_override = if opts.interactive { None } else { Some(false) };
 
     let gen_opts = crate::template_engine::GenerateOpts {
         render: crate::template_engine::RenderOpts {

--- a/src/battery-pack/bphelper-cli/src/commands/tests.rs
+++ b/src/battery-pack/bphelper-cli/src/commands/tests.rs
@@ -26,6 +26,14 @@ fn unwrap_bp_command(cli: super::Cli) -> super::BpCommands {
     }
 }
 
+fn unwrap_bp_non_interactive(cli: &super::Cli) -> bool {
+    match &cli.command {
+        super::Commands::Bp {
+            non_interactive, ..
+        } => *non_interactive,
+    }
+}
+
 // ============================================================================
 // cli.bare.tui — bare `cargo bp` requires a subcommand (prints usage)
 // ============================================================================
@@ -114,7 +122,7 @@ fn resolve_template_single_template_uses_it() {
         },
     );
 
-    let result = super::resolve_template(&templates, None).unwrap();
+    let result = super::resolve_template(&templates, None, false).unwrap();
     assert_eq!(result, "templates/simple");
 }
 
@@ -138,7 +146,7 @@ fn resolve_template_picks_default_when_present() {
         },
     );
 
-    let result = super::resolve_template(&templates, None).unwrap();
+    let result = super::resolve_template(&templates, None, false).unwrap();
     assert_eq!(result, "templates/default");
 }
 
@@ -163,7 +171,7 @@ fn resolve_template_unknown_name_errors() {
         },
     );
 
-    let result = super::resolve_template(&templates, Some("nonexistent"));
+    let result = super::resolve_template(&templates, Some("nonexistent"), false);
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
     assert!(
@@ -196,7 +204,7 @@ fn resolve_template_explicit_flag_overrides() {
         },
     );
 
-    let result = super::resolve_template(&templates, Some("advanced")).unwrap();
+    let result = super::resolve_template(&templates, Some("advanced"), false).unwrap();
     assert_eq!(result, "templates/advanced");
 }
 
@@ -324,14 +332,10 @@ fn show_non_interactive_flag_is_parsed() {
     let cli = super::Cli::try_parse_from(["cargo", "bp", "show", "cli", "--non-interactive"])
         .expect("--non-interactive should be accepted");
 
-    match unwrap_bp_command(cli) {
-        super::BpCommands::Show {
-            non_interactive, ..
-        } => {
-            assert!(non_interactive, "non_interactive should be true");
-        }
-        other => panic!("expected Show, got {:?}", std::mem::discriminant(&other)),
-    }
+    assert!(
+        unwrap_bp_non_interactive(&cli),
+        "non_interactive should be true"
+    );
 }
 
 // [verify cli.show.non-interactive]
@@ -340,14 +344,10 @@ fn show_defaults_to_interactive() {
     let cli = super::Cli::try_parse_from(["cargo", "bp", "show", "cli"])
         .expect("show without --non-interactive should parse");
 
-    match unwrap_bp_command(cli) {
-        super::BpCommands::Show {
-            non_interactive, ..
-        } => {
-            assert!(!non_interactive, "non_interactive should default to false");
-        }
-        other => panic!("expected Show, got {:?}", std::mem::discriminant(&other)),
-    }
+    assert!(
+        !unwrap_bp_non_interactive(&cli),
+        "non_interactive should default to false"
+    );
 }
 
 // [verify cli.list.non-interactive]
@@ -356,14 +356,10 @@ fn list_non_interactive_flag_is_parsed() {
     let cli = super::Cli::try_parse_from(["cargo", "bp", "list", "--non-interactive"])
         .expect("--non-interactive should be accepted");
 
-    match unwrap_bp_command(cli) {
-        super::BpCommands::List {
-            non_interactive, ..
-        } => {
-            assert!(non_interactive, "non_interactive should be true");
-        }
-        other => panic!("expected List, got {:?}", std::mem::discriminant(&other)),
-    }
+    assert!(
+        unwrap_bp_non_interactive(&cli),
+        "non_interactive should be true"
+    );
 }
 
 // [verify cli.list.non-interactive]
@@ -372,14 +368,65 @@ fn list_defaults_to_interactive() {
     let cli = super::Cli::try_parse_from(["cargo", "bp", "list"])
         .expect("list without --non-interactive should parse");
 
-    match unwrap_bp_command(cli) {
-        super::BpCommands::List {
-            non_interactive, ..
-        } => {
-            assert!(!non_interactive, "non_interactive should default to false");
-        }
-        other => panic!("expected List, got {:?}", std::mem::discriminant(&other)),
-    }
+    assert!(
+        !unwrap_bp_non_interactive(&cli),
+        "non_interactive should default to false"
+    );
+}
+
+// --non-interactive is global: accepted before the subcommand
+#[test]
+fn non_interactive_before_subcommand() {
+    let cli = super::Cli::try_parse_from(["cargo", "bp", "--non-interactive", "list"])
+        .expect("--non-interactive before subcommand should parse");
+
+    assert!(unwrap_bp_non_interactive(&cli));
+}
+
+// -N short flag
+#[test]
+fn short_flag_n_is_parsed() {
+    let cli = super::Cli::try_parse_from(["cargo", "bp", "-N", "show", "cli"])
+        .expect("-N should be accepted");
+
+    assert!(unwrap_bp_non_interactive(&cli));
+}
+
+// --non-interactive on new subcommand
+#[test]
+fn new_non_interactive_flag_is_parsed() {
+    let cli = super::Cli::try_parse_from([
+        "cargo",
+        "bp",
+        "new",
+        "cli",
+        "--non-interactive",
+        "-n",
+        "foo",
+    ])
+    .expect("--non-interactive on new should parse");
+
+    assert!(unwrap_bp_non_interactive(&cli));
+}
+
+// cargo bp new without --name in non-interactive mode
+#[test]
+fn new_non_interactive_requires_name() {
+    let result = super::new_from_battery_pack(
+        "cli",
+        None,
+        None,
+        None,
+        &crate::registry::CrateSource::Registry,
+        &[],
+        true,
+    );
+    let err = result.unwrap_err();
+    assert!(
+        err.to_string().contains("--name is required"),
+        "expected --name error, got: {}",
+        err
+    );
 }
 
 // --- from group2_add.rs ---

--- a/src/battery-pack/bphelper-cli/src/commands/tests.rs
+++ b/src/battery-pack/bphelper-cli/src/commands/tests.rs
@@ -122,7 +122,7 @@ fn resolve_template_single_template_uses_it() {
         },
     );
 
-    let result = super::resolve_template(&templates, None, false).unwrap();
+    let result = super::resolve_template(&templates, None, true).unwrap();
     assert_eq!(result, "templates/simple");
 }
 
@@ -146,7 +146,7 @@ fn resolve_template_picks_default_when_present() {
         },
     );
 
-    let result = super::resolve_template(&templates, None, false).unwrap();
+    let result = super::resolve_template(&templates, None, true).unwrap();
     assert_eq!(result, "templates/default");
 }
 
@@ -171,7 +171,7 @@ fn resolve_template_unknown_name_errors() {
         },
     );
 
-    let result = super::resolve_template(&templates, Some("nonexistent"), false);
+    let result = super::resolve_template(&templates, Some("nonexistent"), true);
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
     assert!(
@@ -204,7 +204,7 @@ fn resolve_template_explicit_flag_overrides() {
         },
     );
 
-    let result = super::resolve_template(&templates, Some("advanced"), false).unwrap();
+    let result = super::resolve_template(&templates, Some("advanced"), true).unwrap();
     assert_eq!(result, "templates/advanced");
 }
 
@@ -412,15 +412,16 @@ fn new_non_interactive_flag_is_parsed() {
 // cargo bp new without --name in non-interactive mode
 #[test]
 fn new_non_interactive_requires_name() {
-    let result = super::new_from_battery_pack(
-        "cli",
-        None,
-        None,
-        None,
-        &crate::registry::CrateSource::Registry,
-        &[],
-        true,
-    );
+    let source = crate::registry::CrateSource::Registry;
+    let result = super::new_from_battery_pack(super::NewFromBpOpts {
+        battery_pack: "cli",
+        name: None,
+        template: None,
+        path_override: None,
+        source: &source,
+        define: &[],
+        interactive: false,
+    });
     let err = result.unwrap_err();
     assert!(
         err.to_string().contains("--name is required"),


### PR DESCRIPTION
### Summary

Two changes:

**1. `CARGO_BP_NON_INTERACTIVE` env var.** Activates non-interactive mode for the entire session, suppressing TUI and prompts. Useful for CI or scripting.

```bash
export CARGO_BP_NON_INTERACTIVE=true
cargo bp list              # plain text, no TUI
cargo bp show cli          # plain text, no TUI
cargo bp new cli -n my-app # no prompts
```

**2. `--non-interactive` / `-N` promoted to a global flag.** Previously per-subcommand on `list` and `show` only. Now accepted by all subcommands:

- `list`, `show`: suppress TUI, print plain text
- `new`: require `--name`, fail if placeholders can't be resolved from `--define`
- `rm`: skip the "remove deps?" prompt, keep deps (matches existing non-TTY behavior)
- `add`: no change (already has explicit flags for non-interactive use)

```bash
cargo bp -N rm cli   # no prompt, keeps deps (same as tui behavior)
```

### Testing

New tests for `-N` short flag, flag positioning (before/after subcommand), `new` subcommand parsing, and `new` failing without `--name` in non-interactive mode. Existing `list`/`show` tests updated for the global flag location.
