### PR TITLE
fix: Propagate bp-managed errors and show full validation output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,7 @@ dependencies = [
  "crossterm 0.28.1",
  "dialoguer",
  "flate2",
+ "indoc",
  "minijinja",
  "open",
  "ratatui",

--- a/battery-packs/cli-battery-pack/templates/simple/build.rs
+++ b/battery-packs/cli-battery-pack/templates/simple/build.rs
@@ -1,4 +1,1 @@
-fn main() {
-    cli_battery_pack::validate();
-    logging_battery_pack::validate();
-}
+fn main() {}

--- a/battery-packs/cli-battery-pack/templates/subcmds/build.rs
+++ b/battery-packs/cli-battery-pack/templates/subcmds/build.rs
@@ -1,4 +1,1 @@
-fn main() {
-    cli_battery_pack::validate();
-    logging_battery_pack::validate();
-}
+fn main() {}

--- a/src/battery-pack/bphelper-build/tests/snapshots/bphelper_build__tests__test_template_lib_rs_includes_generated_docs.txt
+++ b/src/battery-pack/bphelper-build/tests/snapshots/bphelper_build__tests__test_template_lib_rs_includes_generated_docs.txt
@@ -1,17 +1,5 @@
 #![doc = include_str!(concat!(env!("OUT_DIR"), "/docs.md"))]
 
-/// Validate that the consumer's dependencies match this battery pack's specs.
-///
-/// Call from the consumer's `build.rs`:
-/// ```rust,ignore
-/// fn main() {
-///     {{ crate_name }}::validate();
-/// }
-/// ```
-pub fn validate() {
-    battery_pack::validate(include_str!("../Cargo.toml"));
-}
-
 #[cfg(test)]
 mod tests {
     #[test]

--- a/src/battery-pack/bphelper-cli/Cargo.toml
+++ b/src/battery-pack/bphelper-cli/Cargo.toml
@@ -33,5 +33,6 @@ syntect = { version = "5", default-features = false, features = ["default-themes
 two-face = "0.5"
 
 [dev-dependencies]
+indoc = "2"
 snapbox.workspace = true
 tempfile = "3"

--- a/src/battery-pack/bphelper-cli/src/commands/tests.rs
+++ b/src/battery-pack/bphelper-cli/src/commands/tests.rs
@@ -1062,15 +1062,7 @@ fn add_registers_build_dep() {
     let content = read_cargo_toml(&tmp);
     let build_deps = extract_section(&content, "[build-dependencies]");
 
-    assert_data_eq!(
-        build_deps,
-        str![[r#"
-[build-dependencies]
-basic-battery-pack = { path = "[..]" }
-
-
-"#]]
-    );
+    assert_data_eq!(build_deps, str![""]);
 }
 
 // ============================================================================
@@ -1126,7 +1118,6 @@ insta = "1.34"
         build_deps,
         str![[r#"
 [build-dependencies]
-managed-battery-pack = { path = "[..]" }
 cc = "1.0"
 
 
@@ -1293,17 +1284,9 @@ fn add_all_features_fancy() {
     // [verify cli.add.dep-kind]
     assert_data_eq!(dev_deps, file![_]);
 
-    // Build-deps: only the battery pack itself (cc is hidden)
+    // Build-deps: battery pack no longer added (validate() was removed)
     // [verify format.hidden.effect]
-    assert_data_eq!(
-        build_deps,
-        str![[r#"
-[build-dependencies]
-fancy-battery-pack = { path = "[..]" }
-
-
-"#]]
-    );
+    assert_data_eq!(build_deps, str![""]);
 }
 
 // ============================================================================
@@ -1379,7 +1362,7 @@ fn add_target_package_writes_metadata() {
 }
 
 // ============================================================================
-// build.rs creation
+// build.rs is no longer created (validate() was removed)
 // ============================================================================
 
 // [verify cli.add.register]
@@ -1396,9 +1379,10 @@ fn add_creates_build_rs() {
         tmp.path(),
     );
 
-    let build_rs = std::fs::read_to_string(tmp.path().join("build.rs")).unwrap();
-
-    assert_data_eq!(build_rs, file![_]);
+    assert!(
+        !tmp.path().join("build.rs").exists(),
+        "build.rs should not be created (validate() was removed)"
+    );
 }
 
 // ============================================================================
@@ -1436,10 +1420,6 @@ fn add_twice_is_idempotent() {
         first_content, second_content,
         "adding twice should be idempotent"
     );
-
-    // build.rs should have exactly one validate call
-    let build_rs = std::fs::read_to_string(tmp.path().join("build.rs")).unwrap();
-    assert_data_eq!(build_rs, file![_]);
 }
 
 // ============================================================================

--- a/src/battery-pack/bphelper-cli/src/template_engine.rs
+++ b/src/battery-pack/bphelper-cli/src/template_engine.rs
@@ -78,6 +78,7 @@ pub(crate) struct RenderOpts {
 }
 
 /// A rendered file from a template preview.
+#[derive(Debug)]
 pub(crate) struct RenderedFile {
     /// Relative path within the generated project.
     pub(crate) path: String,
@@ -194,12 +195,15 @@ fn render(
     files.sort_by(|a, b| a.path.cmp(&b.path));
 
     // Resolve bp-managed dependencies in all rendered Cargo.toml files.
-    // Resolution is best-effort: nested template Cargo.toml files (e.g. in a
-    // battery-pack-of-battery-packs) may reference battery packs that don't
-    // exist yet, so we silently skip files that fail to resolve.
+    // Resolution can fail for nested templates (e.g. battery-pack-of-battery-packs)
+    // that reference battery packs not yet published, so we warn instead of failing.
     for file in files.iter_mut().filter(|f| f.path.ends_with("Cargo.toml")) {
-        if let Ok(resolved) = crate::resolve_bp_managed_content(&file.content, crate_root) {
-            file.content = resolved;
+        match crate::resolve_bp_managed_content(&file.content, crate_root) {
+            Ok(resolved) => file.content = resolved,
+            Err(e) => eprintln!(
+                "warning: failed to resolve bp-managed deps in {}: {e:#}",
+                file.path
+            ),
         }
     }
 

--- a/src/battery-pack/bphelper-cli/src/template_engine/tests.rs
+++ b/src/battery-pack/bphelper-cli/src/template_engine/tests.rs
@@ -1,3 +1,4 @@
+use indoc::indoc;
 use snapbox::{ToDebug, assert_data_eq, str};
 
 use super::*;
@@ -320,5 +321,76 @@ fn preview_resolves_bp_managed_deps() {
     assert!(
         cargo.content.contains("managed-battery-pack"),
         "Expected managed dependency"
+    );
+}
+
+#[test]
+fn preview_warns_on_unresolvable_bp_managed_dep() {
+    let tmp = tempfile::tempdir().unwrap();
+    let crate_root = tmp.path();
+
+    std::fs::write(
+        crate_root.join("Cargo.toml"),
+        indoc! {r#"
+            [package]
+            name = "fake-battery-pack"
+            version = "0.1.0"
+            edition = "2021"
+            description = "test"
+            keywords = ["battery-pack"]
+
+            [package.metadata.battery.templates]
+            default = { path = "templates/default", description = "test" }
+        "#},
+    )
+    .unwrap();
+
+    std::fs::create_dir_all(crate_root.join("src")).unwrap();
+    std::fs::write(crate_root.join("src/lib.rs"), "").unwrap();
+
+    let tpl_dir = crate_root.join("templates/default");
+    std::fs::create_dir_all(&tpl_dir).unwrap();
+    std::fs::write(
+        tpl_dir.join("Cargo.toml"),
+        indoc! {r#"
+            [package]
+            name = "{{ project_name }}"
+            version = "0.1.0"
+            edition = "2021"
+
+            [dependencies]
+            nonexistent-crate.bp-managed = true
+
+            [package.metadata.battery-pack]
+            fake-battery-pack = { features = ["default"] }
+        "#},
+    )
+    .unwrap();
+
+    let opts = RenderOpts {
+        crate_root: crate_root.to_path_buf(),
+        template_path: "templates/default".to_string(),
+        project_name: "test-project".to_string(),
+        defines: BTreeMap::new(),
+        interactive_override: Some(false),
+    };
+
+    // Should succeed (warn, not error) since the battery pack may not exist yet
+    let files = preview(opts).unwrap();
+    let cargo = files.iter().find(|f| f.path == "Cargo.toml").unwrap();
+    assert_data_eq!(
+        &cargo.content,
+        str![[r#"
+[package]
+name = "test-project"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+nonexistent-crate.bp-managed = true
+
+[package.metadata.battery-pack]
+fake-battery-pack = { features = ["default"] }
+"#]]
     );
 }

--- a/src/battery-pack/bphelper-cli/src/validate/mod.rs
+++ b/src/battery-pack/bphelper-cli/src/validate/mod.rs
@@ -158,11 +158,13 @@ pub fn validate_templates(manifest_dir: &str) -> Result<()> {
             .context("failed to run cargo check")?;
         anyhow::ensure!(
             output.status.success(),
-            "cargo check failed for template '{name}':\n{}",
+            "cargo check failed for template '{name}':\n{}\n{}",
+            String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );
 
         // cargo test
+        // Failure details (assertions, panics) go to stdout, not stderr.
         let output = std::process::Command::new("cargo")
             .args(["test"])
             .env("CARGO_TARGET_DIR", &*shared_target_dir)
@@ -171,7 +173,8 @@ pub fn validate_templates(manifest_dir: &str) -> Result<()> {
             .context("failed to run cargo test")?;
         anyhow::ensure!(
             output.status.success(),
-            "cargo test failed for template '{name}':\n{}",
+            "cargo test failed for template '{name}':\n{}\n{}",
+            String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );
 

--- a/src/battery-pack/bphelper-cli/src/validate/tests.rs
+++ b/src/battery-pack/bphelper-cli/src/validate/tests.rs
@@ -1,5 +1,6 @@
 //! Tests for battery pack validation.
 
+use indoc::indoc;
 use snapbox::{assert_data_eq, str};
 use std::path::PathBuf;
 
@@ -121,5 +122,91 @@ fn validate_fixture_with_repository_no_warning() {
         result.is_ok(),
         "fancy-battery-pack should validate cleanly: {:?}",
         result.unwrap_err()
+    );
+}
+
+#[test]
+fn validate_template_test_failure_includes_stdout() {
+    // Regression test for https://github.com/battery-pack-rs/battery-pack/issues/73
+    let tmp = tempfile::tempdir().unwrap();
+    let bp = tmp.path().join("test-bp");
+
+    std::fs::create_dir_all(bp.join("src")).unwrap();
+    std::fs::create_dir_all(bp.join("templates/default/src")).unwrap();
+    std::fs::create_dir_all(bp.join("templates/default/tests")).unwrap();
+
+    std::fs::write(
+        bp.join("Cargo.toml"),
+        indoc! {r#"
+            [package]
+            name = "test-battery-pack"
+            version = "0.1.0"
+            edition = "2021"
+            description = "test"
+            keywords = ["battery-pack"]
+
+            [package.metadata.battery.templates]
+            default = { path = "templates/default", description = "test" }
+        "#},
+    )
+    .unwrap();
+    std::fs::write(bp.join("src/lib.rs"), "").unwrap();
+
+    std::fs::write(
+        bp.join("templates/default/Cargo.toml"),
+        indoc! {r#"
+            [package]
+            name = "{{ project_name }}"
+            version = "0.1.0"
+            edition = "2021"
+        "#},
+    )
+    .unwrap();
+    std::fs::write(bp.join("templates/default/src/main.rs"), "fn main() {}\n").unwrap();
+    std::fs::write(
+        bp.join("templates/default/tests/broken.rs"),
+        indoc! {r#"
+            #[test]
+            fn this_test_fails() {
+                assert_eq!("expected", "actual", "THIS DETAIL SHOULD BE VISIBLE");
+            }
+        "#},
+    )
+    .unwrap();
+
+    let err = super::validate_templates(bp.to_str().unwrap()).unwrap_err();
+    let msg = format!("{err:#}");
+
+    snapbox::assert_data_eq!(
+        msg,
+        snapbox::str![[r#"
+cargo test failed for template 'default':
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in [..]s
+
+
+running 1 test
+test this_test_fails ... FAILED
+
+failures:
+
+---- this_test_fails stdout ----
+
+thread 'this_test_fails' ([..]) panicked at tests/broken.rs:3:5:
+assertion `left == right` failed: THIS DETAIL SHOULD BE VISIBLE
+  left: "expected"
+ right: "actual"
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+
+failures:
+    this_test_fails
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in [..]s
+
+...
+"#]]
     );
 }

--- a/src/battery-pack/bphelper-cli/tests/snapshots/bphelper_cli__commands__tests__add_creates_build_rs.txt
+++ b/src/battery-pack/bphelper-cli/tests/snapshots/bphelper_cli__commands__tests__add_creates_build_rs.txt
@@ -1,3 +1,0 @@
-fn main() {
-    basic_battery_pack::validate();
-}

--- a/src/battery-pack/bphelper-cli/tests/snapshots/bphelper_cli__commands__tests__add_twice_is_idempotent.txt
+++ b/src/battery-pack/bphelper-cli/tests/snapshots/bphelper_cli__commands__tests__add_twice_is_idempotent.txt
@@ -1,3 +1,0 @@
-fn main() {
-    basic_battery_pack::validate();
-}

--- a/src/battery-pack/templates/default/src/lib.rs
+++ b/src/battery-pack/templates/default/src/lib.rs
@@ -1,17 +1,5 @@
 #![doc = include_str!(concat!(env!("OUT_DIR"), "/docs.md"))]
 
-/// Validate that the consumer's dependencies match this battery pack's specs.
-///
-/// Call from the consumer's `build.rs`:
-/// ```rust,ignore
-/// fn main() {
-///     {{ crate_name }}::validate();
-/// }
-/// ```
-pub fn validate() {
-    battery_pack::validate(include_str!("../Cargo.toml"));
-}
-
 #[cfg(test)]
 mod tests {
     #[test]

--- a/src/battery-pack/templates/with_template/templates/default/build.rs
+++ b/src/battery-pack/templates/with_template/templates/default/build.rs
@@ -1,3 +1,1 @@
-fn main() {
-    {{ crate_name }}::validate();
-}
+fn main() {}

--- a/src/cargo-bp/tests/snapshots/with_template__with_template_two_level_generation@2.txt
+++ b/src/cargo-bp/tests/snapshots/with_template__with_template_two_level_generation@2.txt
@@ -1,17 +1,5 @@
 #![doc = include_str!(concat!(env!("OUT_DIR"), "/docs.md"))]
 
-/// Validate that the consumer's dependencies match this battery pack's specs.
-///
-/// Call from the consumer's `build.rs`:
-/// ```rust,ignore
-/// fn main() {
-///     http_battery_pack::validate();
-/// }
-/// ```
-pub fn validate() {
-    battery_pack::validate(include_str!("../Cargo.toml"));
-}
-
 #[cfg(test)]
 mod tests {
     #[test]

--- a/src/cargo-bp/tests/snapshots/with_template__with_template_two_level_generation@4.txt
+++ b/src/cargo-bp/tests/snapshots/with_template__with_template_two_level_generation@4.txt
@@ -1,3 +1,1 @@
-fn main() {
-    http_battery_pack::validate();
-}
+fn main() {}


### PR DESCRIPTION
Fixes: #69, #73 

69 - we were just not logging the error, we now do.

73 - we were missing stdout, only showing stderr, but stdout had the interesting info

There are regression tests for each.