### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,7 +245,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "battery-pack"
-version = "0.4.13"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "battery-pack",
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "bphelper-build"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "bphelper-manifest",
  "cargo_metadata",
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "bphelper-cli"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "bphelper-manifest",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-bp"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -492,7 +492,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "ci-battery-pack"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "arbitrary",
  "battery-pack",
@@ -584,7 +584,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "cli-battery-pack"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anstream 1.0.0",
  "anstyle",
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "error-battery-pack"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "battery-pack",
@@ -1956,7 +1956,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "logging-battery-pack"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "battery-pack",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-battery-pack = { path = "src/battery-pack", version = "0.4" }
+battery-pack = { path = "src/battery-pack", version = "0.5" }
 anyhow = "1"
 minijinja = { version = "2", features = ["loader"] }
 cargo_metadata = "0.23"

--- a/battery-packs/ci-battery-pack/CHANGELOG.md
+++ b/battery-packs/ci-battery-pack/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/battery-pack-rs/battery-pack/compare/ci-battery-pack-v0.1.0...ci-battery-pack-v0.1.1) - 2026-04-21
+
+### Other
+
+- updated the following local packages: battery-pack, battery-pack, battery-pack

--- a/battery-packs/ci-battery-pack/Cargo.toml
+++ b/battery-packs/ci-battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ci-battery-pack"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Battery pack for CI/CD workflows in Rust projects"
 license = "MIT OR Apache-2.0"

--- a/battery-packs/cli-battery-pack/CHANGELOG.md
+++ b/battery-packs/cli-battery-pack/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/battery-pack-rs/battery-pack/compare/cli-battery-pack-v0.5.1...cli-battery-pack-v0.6.0) - 2026-04-21
+
+### Added
+
+- implement dynamic shell completions using clap_complete for CLI commands and arguments. ([#99](https://github.com/battery-pack-rs/battery-pack/pull/99))
+
+### Fixed
+
+- Propagate bp-managed errors and show full validation output
+
+### Other
+
+- Remove build.rs hooks, add cargo bp check for drift detection
+
 ## [0.5.1](https://github.com/battery-pack-rs/battery-pack/compare/cli-battery-pack-v0.5.0...cli-battery-pack-v0.5.1) - 2026-04-13
 
 ### Other

--- a/battery-packs/cli-battery-pack/Cargo.toml
+++ b/battery-packs/cli-battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli-battery-pack"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 description = "Battery pack for building CLI applications in Rust"
 license = "MIT OR Apache-2.0"

--- a/battery-packs/error-battery-pack/CHANGELOG.md
+++ b/battery-packs/error-battery-pack/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/battery-pack-rs/battery-pack/compare/error-battery-pack-v0.5.3...error-battery-pack-v0.6.0) - 2026-04-21
+
+### Added
+
+- implement dynamic shell completions using clap_complete for CLI commands and arguments. ([#99](https://github.com/battery-pack-rs/battery-pack/pull/99))
+
+### Other
+
+- Remove build.rs hooks, add cargo bp check for drift detection
+
 ## [0.5.3](https://github.com/battery-pack-rs/battery-pack/compare/error-battery-pack-v0.5.2...error-battery-pack-v0.5.3) - 2026-03-13
 
 ### Other

--- a/battery-packs/error-battery-pack/Cargo.toml
+++ b/battery-packs/error-battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "error-battery-pack"
-version = "0.5.3"
+version = "0.6.0"
 edition = "2024"
 description = "Error handling done well — anyhow for apps, thiserror for libraries"
 license = "MIT OR Apache-2.0"

--- a/battery-packs/logging-battery-pack/CHANGELOG.md
+++ b/battery-packs/logging-battery-pack/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/battery-pack-rs/battery-pack/compare/logging-battery-pack-v0.4.3...logging-battery-pack-v0.5.0) - 2026-04-21
+
+### Added
+
+- implement dynamic shell completions using clap_complete for CLI commands and arguments. ([#99](https://github.com/battery-pack-rs/battery-pack/pull/99))
+
+### Other
+
+- Remove build.rs hooks, add cargo bp check for drift detection
+
 ## [0.4.3](https://github.com/battery-pack-rs/battery-pack/compare/logging-battery-pack-v0.4.2...logging-battery-pack-v0.4.3) - 2026-03-13
 
 ### Other

--- a/battery-packs/logging-battery-pack/Cargo.toml
+++ b/battery-packs/logging-battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logging-battery-pack"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2024"
 description = "Battery pack for logging and tracing in Rust"
 license = "MIT OR Apache-2.0"

--- a/src/battery-pack/CHANGELOG.md
+++ b/src/battery-pack/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.4.13...battery-pack-v0.5.0) - 2026-04-21
+
+### Added
+
+- CI battery pack ([#101](https://github.com/battery-pack-rs/battery-pack/pull/101))
+- implement dynamic shell completions using clap_complete for CLI commands and arguments. ([#99](https://github.com/battery-pack-rs/battery-pack/pull/99))
+- *(cli)* add template preview to `cargo bp show -t` ([#91](https://github.com/battery-pack-rs/battery-pack/pull/91))
+- *(cli)* add global --non-interactive / -N flag with env var support
+
+### Fixed
+
+- Propagate bp-managed errors and show full validation output
+
+### Other
+
+- more tweaks to snap tests ([#108](https://github.com/battery-pack-rs/battery-pack/pull/108))
+- Remove build.rs hooks, add cargo bp check for drift detection
+- *(test)* convert .contains() assertions to snapbox snapshots
+- fmt
+- *(cli)* Use interactive bool instead of passing non_interactive
+- *(cli)* Use interactive bool instead of passing non_interactive
+
 ## [0.4.13](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.4.12...battery-pack-v0.4.13) - 2026-04-18
 
 ### Added

--- a/src/battery-pack/Cargo.toml
+++ b/src/battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "battery-pack"
-version = "0.4.13"
+version = "0.5.0"
 edition = "2024"
 description = "Curated crate bundles with docs, templates, and agentic skills"
 license = "MIT OR Apache-2.0"
@@ -21,8 +21,8 @@ build = ["bphelper-build"]
 cli = ["bphelper-cli"]
 
 [dependencies]
-bphelper-build = { path = "bphelper-build", version = "0.4.5", optional = true }
-bphelper-cli = { path = "bphelper-cli", version = "0.7.4", optional = true }
+bphelper-build = { path = "bphelper-build", version = "0.4.6", optional = true }
+bphelper-cli = { path = "bphelper-cli", version = "0.7.5", optional = true }
 bphelper-manifest = { path = "bphelper-manifest", version = "0.5.4" }
 anyhow.workspace = true
 

--- a/src/battery-pack/bphelper-build/CHANGELOG.md
+++ b/src/battery-pack/bphelper-build/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.6](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-build-v0.4.5...bphelper-build-v0.4.6) - 2026-04-21
+
+### Added
+
+- implement dynamic shell completions using clap_complete for CLI commands and arguments. ([#99](https://github.com/battery-pack-rs/battery-pack/pull/99))
+
+### Fixed
+
+- Propagate bp-managed errors and show full validation output
+
+### Other
+
+- *(test)* convert .contains() assertions to snapbox snapshots
+
 ## [0.4.5](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-build-v0.4.4...bphelper-build-v0.4.5) - 2026-04-13
 
 ### Other

--- a/src/battery-pack/bphelper-build/Cargo.toml
+++ b/src/battery-pack/bphelper-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bphelper-build"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2024"
 description = "Build-time documentation generation for battery packs"
 license = "MIT OR Apache-2.0"

--- a/src/battery-pack/bphelper-cli/CHANGELOG.md
+++ b/src/battery-pack/bphelper-cli/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.5](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.7.4...bphelper-cli-v0.7.5) - 2026-04-21
+
+### Added
+
+- CI battery pack ([#101](https://github.com/battery-pack-rs/battery-pack/pull/101))
+- implement dynamic shell completions using clap_complete for CLI commands and arguments. ([#99](https://github.com/battery-pack-rs/battery-pack/pull/99))
+- *(cli)* add template preview to `cargo bp show -t` ([#91](https://github.com/battery-pack-rs/battery-pack/pull/91))
+- *(cli)* add global --non-interactive / -N flag with env var support
+
+### Fixed
+
+- Propagate bp-managed errors and show full validation output
+
+### Other
+
+- more tweaks to snap tests ([#108](https://github.com/battery-pack-rs/battery-pack/pull/108))
+- Remove build.rs hooks, add cargo bp check for drift detection
+- *(test)* convert .contains() assertions to snapbox snapshots
+- fmt
+- *(cli)* Use interactive bool instead of passing non_interactive
+- *(cli)* Use interactive bool instead of passing non_interactive
+
 ## [0.7.4](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.7.3...bphelper-cli-v0.7.4) - 2026-04-18
 
 ### Added

--- a/src/battery-pack/bphelper-cli/Cargo.toml
+++ b/src/battery-pack/bphelper-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bphelper-cli"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2024"
 description = "CLI for creating and managing battery packs"
 license = "MIT OR Apache-2.0"

--- a/src/cargo-bp/CHANGELOG.md
+++ b/src/cargo-bp/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-v0.5.0...cargo-bp-v0.5.1) - 2026-04-21
+
+### Added
+
+- implement dynamic shell completions using clap_complete for CLI commands and arguments. ([#99](https://github.com/battery-pack-rs/battery-pack/pull/99))
+- *(cli)* add template preview to `cargo bp show -t` ([#91](https://github.com/battery-pack-rs/battery-pack/pull/91))
+- CI battery pack ([#101](https://github.com/battery-pack-rs/battery-pack/pull/101))
+- *(cli)* add global --non-interactive / -N flag with env var support
+
+### Fixed
+
+- Propagate bp-managed errors and show full validation output
+
+### Other
+
+- *(test)* convert .contains() assertions to snapbox snapshots
+- more tweaks to snap tests ([#108](https://github.com/battery-pack-rs/battery-pack/pull/108))
+- Remove build.rs hooks, add cargo bp check for drift detection
+- fmt
+- *(cli)* Use interactive bool instead of passing non_interactive
+- *(cli)* Use interactive bool instead of passing non_interactive
+
 ## [0.4.13](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-v0.4.12...cargo-bp-v0.4.13) - 2026-04-18
 
 ### Added

--- a/src/cargo-bp/Cargo.toml
+++ b/src/cargo-bp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-bp"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 description = "CLI for creating and managing battery packs (cargo bp)"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `bphelper-build`: 0.4.5 -> 0.4.6 (✓ API compatible changes)
* `bphelper-cli`: 0.7.4 -> 0.7.5 (✓ API compatible changes)
* `battery-pack`: 0.4.13 -> 0.5.0 (⚠ API breaking changes)
* `cargo-bp`: 0.5.0 -> 0.5.1
* `cli-battery-pack`: 0.5.1 -> 0.6.0 (⚠ API breaking changes)
* `error-battery-pack`: 0.5.3 -> 0.6.0 (⚠ API breaking changes)
* `logging-battery-pack`: 0.4.3 -> 0.5.0 (⚠ API breaking changes)
* `ci-battery-pack`: 0.1.0 -> 0.1.1

### ⚠ `battery-pack` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function battery_pack::validate, previously in file /tmp/.tmpNt5Ldu/battery-pack/src/lib.rs:54
```

### ⚠ `cli-battery-pack` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function cli_battery_pack::validate, previously in file /tmp/.tmpNt5Ldu/cli-battery-pack/src/lib.rs:11
```

### ⚠ `error-battery-pack` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function error_battery_pack::validate, previously in file /tmp/.tmpNt5Ldu/error-battery-pack/src/lib.rs:11
```

### ⚠ `logging-battery-pack` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function logging_battery_pack::validate, previously in file /tmp/.tmpNt5Ldu/logging-battery-pack/src/lib.rs:11
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `bphelper-build`

<blockquote>

## [0.4.6](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-build-v0.4.5...bphelper-build-v0.4.6) - 2026-04-21

### Added

- implement dynamic shell completions using clap_complete for CLI commands and arguments. ([#99](https://github.com/battery-pack-rs/battery-pack/pull/99))

### Fixed

- Propagate bp-managed errors and show full validation output

### Other

- *(test)* convert .contains() assertions to snapbox snapshots
</blockquote>

## `bphelper-cli`

<blockquote>

## [0.7.5](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.7.4...bphelper-cli-v0.7.5) - 2026-04-21

### Added

- CI battery pack ([#101](https://github.com/battery-pack-rs/battery-pack/pull/101))
- implement dynamic shell completions using clap_complete for CLI commands and arguments. ([#99](https://github.com/battery-pack-rs/battery-pack/pull/99))
- *(cli)* add template preview to `cargo bp show -t` ([#91](https://github.com/battery-pack-rs/battery-pack/pull/91))
- *(cli)* add global --non-interactive / -N flag with env var support

### Fixed

- Propagate bp-managed errors and show full validation output

### Other

- more tweaks to snap tests ([#108](https://github.com/battery-pack-rs/battery-pack/pull/108))
- Remove build.rs hooks, add cargo bp check for drift detection
- *(test)* convert .contains() assertions to snapbox snapshots
- fmt
- *(cli)* Use interactive bool instead of passing non_interactive
- *(cli)* Use interactive bool instead of passing non_interactive
</blockquote>

## `battery-pack`

<blockquote>

## [0.5.0](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.4.13...battery-pack-v0.5.0) - 2026-04-21

### Added

- CI battery pack ([#101](https://github.com/battery-pack-rs/battery-pack/pull/101))
- implement dynamic shell completions using clap_complete for CLI commands and arguments. ([#99](https://github.com/battery-pack-rs/battery-pack/pull/99))
- *(cli)* add template preview to `cargo bp show -t` ([#91](https://github.com/battery-pack-rs/battery-pack/pull/91))
- *(cli)* add global --non-interactive / -N flag with env var support

### Fixed

- Propagate bp-managed errors and show full validation output

### Other

- more tweaks to snap tests ([#108](https://github.com/battery-pack-rs/battery-pack/pull/108))
- Remove build.rs hooks, add cargo bp check for drift detection
- *(test)* convert .contains() assertions to snapbox snapshots
- fmt
- *(cli)* Use interactive bool instead of passing non_interactive
- *(cli)* Use interactive bool instead of passing non_interactive
</blockquote>

## `cargo-bp`

<blockquote>

## [0.5.1](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-v0.5.0...cargo-bp-v0.5.1) - 2026-04-21

### Added

- implement dynamic shell completions using clap_complete for CLI commands and arguments. ([#99](https://github.com/battery-pack-rs/battery-pack/pull/99))
- *(cli)* add template preview to `cargo bp show -t` ([#91](https://github.com/battery-pack-rs/battery-pack/pull/91))
- CI battery pack ([#101](https://github.com/battery-pack-rs/battery-pack/pull/101))
- *(cli)* add global --non-interactive / -N flag with env var support

### Fixed

- Propagate bp-managed errors and show full validation output

### Other

- *(test)* convert .contains() assertions to snapbox snapshots
- more tweaks to snap tests ([#108](https://github.com/battery-pack-rs/battery-pack/pull/108))
- Remove build.rs hooks, add cargo bp check for drift detection
- fmt
- *(cli)* Use interactive bool instead of passing non_interactive
- *(cli)* Use interactive bool instead of passing non_interactive
</blockquote>

## `cli-battery-pack`

<blockquote>

## [0.6.0](https://github.com/battery-pack-rs/battery-pack/compare/cli-battery-pack-v0.5.1...cli-battery-pack-v0.6.0) - 2026-04-21

### Added

- implement dynamic shell completions using clap_complete for CLI commands and arguments. ([#99](https://github.com/battery-pack-rs/battery-pack/pull/99))

### Fixed

- Propagate bp-managed errors and show full validation output

### Other

- Remove build.rs hooks, add cargo bp check for drift detection
</blockquote>

## `error-battery-pack`

<blockquote>

## [0.6.0](https://github.com/battery-pack-rs/battery-pack/compare/error-battery-pack-v0.5.3...error-battery-pack-v0.6.0) - 2026-04-21

### Added

- implement dynamic shell completions using clap_complete for CLI commands and arguments. ([#99](https://github.com/battery-pack-rs/battery-pack/pull/99))

### Other

- Remove build.rs hooks, add cargo bp check for drift detection
</blockquote>

## `logging-battery-pack`

<blockquote>

## [0.5.0](https://github.com/battery-pack-rs/battery-pack/compare/logging-battery-pack-v0.4.3...logging-battery-pack-v0.5.0) - 2026-04-21

### Added

- implement dynamic shell completions using clap_complete for CLI commands and arguments. ([#99](https://github.com/battery-pack-rs/battery-pack/pull/99))

### Other

- Remove build.rs hooks, add cargo bp check for drift detection
</blockquote>

## `ci-battery-pack`

<blockquote>

## [0.1.1](https://github.com/battery-pack-rs/battery-pack/compare/ci-battery-pack-v0.1.0...ci-battery-pack-v0.1.1) - 2026-04-21

### Other

- updated the following local packages: battery-pack, battery-pack, battery-pack
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).