### PR TITLE
feat: CI battery pack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -713,25 +722,24 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "num-traits",
- "once_cell",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -739,12 +747,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -1416,12 +1424,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1757,17 +1759,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "is-wsl"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1794,9 +1785,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -2283,6 +2274,16 @@ checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,6 +145,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "assert_cmd"
@@ -320,6 +335,7 @@ dependencies = [
  "minijinja",
  "open",
  "ratatui",
+ "regex",
  "reqwest",
  "semver",
  "serde",
@@ -421,6 +437,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,6 +480,46 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "ci-battery-pack"
+version = "0.1.0"
+dependencies = [
+ "arbitrary",
+ "battery-pack",
+ "criterion",
+ "libfuzzer-sys",
+ "snapbox",
+ "xflags",
+ "xshell",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clap"
@@ -650,6 +712,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -716,6 +814,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -819,6 +923,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1248,6 +1363,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "handlebars"
 version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1288,6 +1414,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1625,6 +1757,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is-wsl"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1648,6 +1791,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1740,6 +1892,16 @@ name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
 
 [[package]]
 name = "libredox"
@@ -2082,6 +2244,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "open"
 version = "5.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2270,6 +2438,34 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -2492,7 +2688,7 @@ dependencies = [
  "compact_str",
  "hashbrown 0.16.1",
  "indoc",
- "itertools",
+ "itertools 0.14.0",
  "kasuari",
  "lru",
  "strum",
@@ -2544,13 +2740,33 @@ dependencies = [
  "hashbrown 0.16.1",
  "indoc",
  "instability",
- "itertools",
+ "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
  "strum",
  "time",
  "unicode-segmentation",
  "unicode-width",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -3367,6 +3583,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3639,7 +3865,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -4481,6 +4707,36 @@ dependencies = [
  "libc",
  "rustix 1.1.4",
 ]
+
+[[package]]
+name = "xflags"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d9e15fbb3de55454b0106e314b28e671279009b363e6f1d8e39fdc3bf048944"
+dependencies = [
+ "xflags-macros",
+]
+
+[[package]]
+name = "xflags-macros"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "672423d4fea7ffa2f6c25ba60031ea13dc6258070556f125cc4d790007d4a155"
+
+[[package]]
+name = "xshell"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e7290c623014758632efe00737145b6867b66292c42167f2ec381eb566a373d"
+dependencies = [
+ "xshell-macros",
+]
+
+[[package]]
+name = "xshell-macros"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32ac00cd3f8ec9c1d33fb3e7958a82df6989c42d747bd326c822b1d625283547"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "src/battery-pack/bphelper-manifest",
 	# --- battery packs
     "battery-packs/cli-battery-pack",
+    "battery-packs/ci-battery-pack",
     "battery-packs/error-battery-pack",
     "battery-packs/logging-battery-pack",
 ]

--- a/battery-packs/ci-battery-pack/Cargo.toml
+++ b/battery-packs/ci-battery-pack/Cargo.toml
@@ -18,6 +18,7 @@ xtask = { path = "templates/xtask", description = "cargo-xtask scaffold with cod
 trusted-publishing = { path = "templates/trusted-publishing", description = "release-plz with OIDC trusted publishing" }
 binary-release = { path = "templates/binary-release", description = "Cross-platform binary builds for GitHub Releases + cargo-binstall" }
 mutation-testing = { path = "templates/mutation-testing", description = "Mutation testing with cargo-mutants" }
+clippy-sarif = { path = "templates/clippy-sarif", description = "Clippy with GitHub PR annotations via SARIF" }
 
 [package.metadata.battery-pack]
 hidden = ["battery-pack", "snapbox"]

--- a/battery-packs/ci-battery-pack/Cargo.toml
+++ b/battery-packs/ci-battery-pack/Cargo.toml
@@ -25,7 +25,7 @@ hidden = ["battery-pack", "snapbox"]
 battery-pack = { workspace = true }
 
 # Benchmarking
-criterion = { version = "0.5", features = ["html_reports"], optional = true }
+criterion = { version = "0.8", features = ["html_reports"], optional = true }
 
 # Fuzzing (for the fuzz/ sub-crate)
 libfuzzer-sys = { version = "0.4", optional = true }

--- a/battery-packs/ci-battery-pack/Cargo.toml
+++ b/battery-packs/ci-battery-pack/Cargo.toml
@@ -1,0 +1,49 @@
+[package]
+name = "ci-battery-pack"
+version = "0.1.0"
+edition = "2024"
+description = "Battery pack for CI/CD workflows in Rust projects"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/battery-pack-rs/battery-pack"
+keywords = ["battery-pack", "ci", "github-actions", "testing"]
+
+[package.metadata.battery.templates]
+full = { path = "templates/full", description = "Full CI setup with optional benchmarks, fuzzing, mdbook, spellcheck, and xtask" }
+benchmarks = { path = "templates/benchmarks", description = "Criterion bench scaffold + Bencher CI" }
+fuzzing = { path = "templates/fuzzing", description = "cargo-fuzz scaffold + CI workflows" }
+stress-test = { path = "templates/stress-test", description = "nextest stress test workflow" }
+mdbook = { path = "templates/mdbook", description = "mdBook scaffold + GitHub Pages deployment" }
+spellcheck = { path = "templates/spellcheck", description = "crate-ci/typos config + CI workflow" }
+xtask = { path = "templates/xtask", description = "cargo-xtask scaffold with codegen --check" }
+trusted-publishing = { path = "templates/trusted-publishing", description = "release-plz with OIDC trusted publishing" }
+binary-release = { path = "templates/binary-release", description = "Cross-platform binary builds for GitHub Releases + cargo-binstall" }
+
+[package.metadata.battery-pack]
+hidden = ["battery-pack", "snapbox"]
+
+[dependencies]
+battery-pack = { workspace = true }
+
+# Benchmarking
+criterion = { version = "0.5", features = ["html_reports"], optional = true }
+
+# Fuzzing (for the fuzz/ sub-crate)
+libfuzzer-sys = { version = "0.4", optional = true }
+arbitrary = { version = "1", features = ["derive"], optional = true }
+
+# xtask
+xshell = { version = "0.2", optional = true }
+xflags = { version = "0.3", optional = true }
+
+[build-dependencies]
+battery-pack = { workspace = true, features = ["build"] }
+
+[dev-dependencies]
+battery-pack = { workspace = true, features = ["cli"] }
+snapbox = "1"
+
+[features]
+default = []
+benchmarks = ["criterion"]
+fuzzing = ["libfuzzer-sys", "arbitrary"]
+xtask = ["xshell", "xflags"]

--- a/battery-packs/ci-battery-pack/Cargo.toml
+++ b/battery-packs/ci-battery-pack/Cargo.toml
@@ -17,6 +17,7 @@ spellcheck = { path = "templates/spellcheck", description = "crate-ci/typos conf
 xtask = { path = "templates/xtask", description = "cargo-xtask scaffold with codegen --check" }
 trusted-publishing = { path = "templates/trusted-publishing", description = "release-plz with OIDC trusted publishing" }
 binary-release = { path = "templates/binary-release", description = "Cross-platform binary builds for GitHub Releases + cargo-binstall" }
+mutation-testing = { path = "templates/mutation-testing", description = "Mutation testing with cargo-mutants" }
 
 [package.metadata.battery-pack]
 hidden = ["battery-pack", "snapbox"]

--- a/battery-packs/ci-battery-pack/README.md
+++ b/battery-packs/ci-battery-pack/README.md
@@ -1,6 +1,6 @@
 # ci-battery-pack
 
-A [battery pack](https://crates.io/crates/battery-pack) for CI/CD workflows in Rust projects — the kind of thing you'd copy from tokio or hyper, but generated fresh with pinned SHAs and your project's MSRV.
+A [battery pack](https://crates.io/crates/battery-pack) for CI/CD workflows in Rust projects. This is the kind of thing you'd copy from tokio or hyper, but generated fresh with pinned SHAs and your project's MSRV.
 
 Currently supports GitHub Actions. Someday there will be more supported platforms.
 

--- a/battery-packs/ci-battery-pack/README.md
+++ b/battery-packs/ci-battery-pack/README.md
@@ -63,6 +63,7 @@ The `full` template generates a stub Rust project (Cargo.toml, src/lib.rs, READM
 | `spellcheck` | false | [typos](https://github.com/crate-ci/typos) config + workflow | |
 | `xtask` | false | [cargo-xtask](https://github.com/matklad/cargo-xtask) scaffold with codegen `--check` | `xshell`, `xflags` |
 | `mutation_testing` | false | [cargo-mutants](https://mutants.rs/) mutation testing | |
+| `clippy_sarif` | false | Clippy with GitHub PR annotations via [SARIF](https://github.com/psastras/sarif-rs) | |
 
 ### SHA pinning
 
@@ -96,6 +97,10 @@ See [release-plz docs](https://release-plz.dev/docs) for more.
 3. Add your project slug as a `BENCHER_PROJECT` repo variable
 
 See [Bencher docs](https://bencher.dev/docs) for more.
+
+### Clippy SARIF (if clippy_sarif enabled)
+
+Works automatically on public repos. For private repos, enable Code Scanning at Settings → Security → Code security.
 
 ## License
 

--- a/battery-packs/ci-battery-pack/README.md
+++ b/battery-packs/ci-battery-pack/README.md
@@ -88,6 +88,8 @@ If you enabled `binary_release`, you also need a PAT so the release event trigge
 
 Without `binary_release`, `GITHUB_TOKEN` works fine and no PAT is needed.
 
+Alternatively, you can avoid the PAT by moving the binary build steps into the release workflow itself.
+
 See [release-plz docs](https://release-plz.dev/docs) for more.
 
 ### Bencher (if benchmarks enabled)

--- a/battery-packs/ci-battery-pack/README.md
+++ b/battery-packs/ci-battery-pack/README.md
@@ -1,0 +1,110 @@
+# ci-battery-pack
+
+A [battery pack](https://crates.io/crates/battery-pack) for CI/CD workflows in Rust projects.
+
+Currently supports GitHub Actions. Someday there will be more supported platforms.
+
+## Quick Start
+
+Minimalist (core CI only):
+
+```sh
+cargo bp new ci --name my-project
+```
+
+Maximalist (everything enabled):
+
+```sh
+cargo bp new ci --name my-project -d all
+```
+
+Pick individual features:
+
+```sh
+cargo bp new ci --name my-project -d ci_platform=github -d benchmarks -d fuzzing -d spellcheck
+```
+
+Config files only (no CI workflows):
+
+```sh
+cargo bp new ci --name my-project -d ci_platform=none
+```
+
+Generates config files only (deny.toml, release-plz.toml) without CI workflows. Useful if you use a different CI system.
+
+Or run `cargo bp new ci` interactively and answer the prompts.
+
+Each optional feature is also available as a standalone template:
+
+```sh
+cargo bp new ci --template fuzzing --name my-project
+```
+
+## What You Get
+
+### Always included
+
+- [cargo-deny](https://github.com/EmbarkStudios/cargo-deny) config (`deny.toml`)
+- README with CI, crates.io, and docs.rs badges
+- Stub Cargo.toml, src/lib.rs with test
+
+### GitHub Actions (`ci_platform=github`, the default)
+
+- CI workflow: fmt, clippy, build matrix (MSRV x stable x nightly), feature powerset, semver-checks, gate job
+- Security audit workflow (cargo-deny, daily + on Cargo.toml changes)
+- Dependabot config for Cargo and GitHub Actions updates
+
+### Optional features (`-d flag`)
+
+| Flag | Default | What it adds | Curated deps |
+|------|---------|-------------|-------------|
+| `trusted_publishing` | true | [release-plz](https://release-plz.dev/) with OIDC trusted publishing | |
+| `binary_release` | false | Cross-platform binary builds for GitHub Releases + [cargo-binstall](https://github.com/cargo-bins/cargo-binstall) | |
+| `benchmarks` | false | [Criterion](https://crates.io/crates/criterion) bench scaffold + [Bencher](https://bencher.dev/) regression detection | `criterion` |
+| `fuzzing` | false | [cargo-fuzz](https://github.com/rust-fuzz/cargo-fuzz) scaffold + PR smoke test + nightly extended run | `libfuzzer-sys`, `arbitrary` |
+| `stress_tests` | false | [nextest](https://nexte.st/) stress test workflow | |
+| `mdbook` | false | [mdBook](https://rust-lang.github.io/mdBook/) scaffold + GitHub Pages deployment | |
+| `spellcheck` | false | [typos](https://github.com/crate-ci/typos) config + workflow | |
+| `xtask` | false | [cargo-xtask](https://github.com/matklad/cargo-xtask) scaffold with codegen `--check` | `xshell`, `xflags` |
+
+### SHA pinning
+
+All GitHub Actions are pinned to commit SHAs at generation time per
+[GitHub's security guidance](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).
+Use [Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot)
+to keep them up to date.
+
+## Setup
+
+After generating your project, set `ci-pass` as the required status check in branch protection.
+
+### release-plz
+
+1. [Configure trusted publishing](https://doc.rust-lang.org/cargo/reference/registry-authentication.html#trusted-publishing) on crates.io
+2. In repo settings → Actions → General, enable "Allow GitHub Actions to create and approve pull requests"
+
+If you enabled `binary_release`, you also need a PAT so the release event triggers the binary build:
+
+3. Create a [fine-grained PAT](https://github.com/settings/personal-access-tokens/new) with `contents: write` and `pull-requests: write` for your repo
+4. Add it as a `RELEASE_PLZ_TOKEN` repo secret
+
+Without `binary_release`, `GITHUB_TOKEN` works fine and no PAT is needed.
+
+See [release-plz docs](https://release-plz.dev/docs) for more.
+
+### Bencher (if benchmarks enabled)
+
+1. [Create a project](https://bencher.dev/docs) on Bencher
+2. Add `BENCHER_API_TOKEN` as a repo secret
+3. Add your project slug as a `BENCHER_PROJECT` repo variable
+
+See [Bencher docs](https://bencher.dev/docs) for more.
+
+## License
+
+Licensed under either of:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+
+at your option.

--- a/battery-packs/ci-battery-pack/README.md
+++ b/battery-packs/ci-battery-pack/README.md
@@ -62,6 +62,7 @@ The `full` template generates a stub Rust project (Cargo.toml, src/lib.rs, READM
 | `mdbook` | false | [mdBook](https://rust-lang.github.io/mdBook/) scaffold + GitHub Pages deployment | |
 | `spellcheck` | false | [typos](https://github.com/crate-ci/typos) config + workflow | |
 | `xtask` | false | [cargo-xtask](https://github.com/matklad/cargo-xtask) scaffold with codegen `--check` | `xshell`, `xflags` |
+| `mutation_testing` | false | [cargo-mutants](https://mutants.rs/) mutation testing | |
 
 ### SHA pinning
 

--- a/battery-packs/ci-battery-pack/README.md
+++ b/battery-packs/ci-battery-pack/README.md
@@ -1,18 +1,18 @@
 # ci-battery-pack
 
-A [battery pack](https://crates.io/crates/battery-pack) for CI/CD workflows in Rust projects.
+A [battery pack](https://crates.io/crates/battery-pack) for CI/CD workflows in Rust projects — the kind of thing you'd copy from tokio or hyper, but generated fresh with pinned SHAs and your project's MSRV.
 
 Currently supports GitHub Actions. Someday there will be more supported platforms.
 
 ## Quick Start
 
-Minimalist (core CI only):
+The `full` template generates a complete project with CI. Use it to bootstrap a new project:
 
 ```sh
 cargo bp new ci --name my-project
 ```
 
-Maximalist (everything enabled):
+Everything enabled:
 
 ```sh
 cargo bp new ci --name my-project -d all
@@ -24,35 +24,31 @@ Pick individual features:
 cargo bp new ci --name my-project -d ci_platform=github -d benchmarks -d fuzzing -d spellcheck
 ```
 
-Config files only (no CI workflows):
+Config files only (no CI workflows, no stub project):
 
 ```sh
 cargo bp new ci --name my-project -d ci_platform=none
 ```
 
-Generates config files only (deny.toml, release-plz.toml) without CI workflows. Useful if you use a different CI system.
-
 Or run `cargo bp new ci` interactively and answer the prompts.
 
-Each optional feature is also available as a standalone template:
+Each optional feature is also available as a standalone template for adding to an existing project:
 
 ```sh
 cargo bp new ci --template fuzzing --name my-project
+cargo bp new ci --template trusted-publishing --name my-project
 ```
 
-## What You Get
+## What the `full` template generates
 
-### Always included
+The `full` template generates a stub Rust project (Cargo.toml, src/lib.rs, README with badges) along with CI configuration. If you're adding CI to an existing project, use the standalone templates instead.
 
-- [cargo-deny](https://github.com/EmbarkStudios/cargo-deny) config (`deny.toml`)
-- README with CI, crates.io, and docs.rs badges
-- Stub Cargo.toml, src/lib.rs with test
+### Core CI (GitHub Actions)
 
-### GitHub Actions (`ci_platform=github`, the default)
-
-- CI workflow: fmt, clippy, build matrix (MSRV x stable x nightly), feature powerset, semver-checks, gate job
+- CI workflow: fmt, clippy, warnings check, docsrs check, build matrix (stable × nightly), feature powerset, MSRV, semver-checks, gate job
 - Security audit workflow (cargo-deny, daily + on Cargo.toml changes)
 - Dependabot config for Cargo and GitHub Actions updates
+- cargo-deny config (`deny.toml`)
 
 ### Optional features (`-d flag`)
 

--- a/battery-packs/ci-battery-pack/build.rs
+++ b/battery-packs/ci-battery-pack/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    battery_pack::build::generate_docs().unwrap();
+}

--- a/battery-packs/ci-battery-pack/docs.handlebars.md
+++ b/battery-packs/ci-battery-pack/docs.handlebars.md
@@ -1,0 +1,3 @@
+{{readme}}
+
+{{crate-table}}

--- a/battery-packs/ci-battery-pack/snippets/github/ci-pass.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/ci-pass.yml
@@ -1,5 +1,5 @@
   ci-pass:
-    needs: [fmt, clippy, warnings, docsrs, build, features, msrv, semver{% if all or benchmarks %}, bench, bench-pr{% endif %}{% if all or fuzzing %}, fuzz-smoke{% endif %}{% if all or stress_tests %}, stress-test{% endif %}{% if all or spellcheck %}, spellcheck{% endif %}{% if all or xtask %}, xtask{% endif %}{% if all or mutation_testing %}, mutants{% endif %}]
+    needs: [fmt, clippy, warnings, docsrs, build, features, msrv, lockfile, minimal-versions, semver{% if all or benchmarks %}, bench, bench-pr{% endif %}{% if all or fuzzing %}, fuzz-smoke{% endif %}{% if all or stress_tests %}, stress-test{% endif %}{% if all or spellcheck %}, spellcheck{% endif %}{% if all or xtask %}, xtask{% endif %}{% if all or mutation_testing %}, mutants{% endif %}]
     if: {% raw %}${{ !cancelled() }}{% endraw %}
     runs-on: ubuntu-latest
     steps:

--- a/battery-packs/ci-battery-pack/snippets/github/ci-pass.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/ci-pass.yml
@@ -1,5 +1,5 @@
   ci-pass:
-    needs: [fmt, clippy, warnings, docsrs, build, features, msrv, lockfile, minimal-versions, semver{% if all or benchmarks %}, bench, bench-pr{% endif %}{% if all or fuzzing %}, fuzz-smoke{% endif %}{% if all or stress_tests %}, stress-test{% endif %}{% if all or spellcheck %}, spellcheck{% endif %}{% if all or xtask %}, xtask{% endif %}{% if all or mutation_testing %}, mutants{% endif %}{% if all or clippy_sarif %}, clippy-sarif{% endif %}]
+    needs: [fmt, {% if all or clippy_sarif %}clippy-sarif{% else %}clippy{% endif %}, warnings, docsrs, build, features, msrv, lockfile, minimal-versions, semver{% if all or benchmarks %}, bench, bench-pr{% endif %}{% if all or fuzzing %}, fuzz-smoke{% endif %}{% if all or stress_tests %}, stress-test{% endif %}{% if all or spellcheck %}, spellcheck{% endif %}{% if all or xtask %}, xtask{% endif %}{% if all or mutation_testing %}, mutants{% endif %}]
     if: {% raw %}${{ !cancelled() }}{% endraw %}
     runs-on: ubuntu-latest
     steps:

--- a/battery-packs/ci-battery-pack/snippets/github/ci-pass.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/ci-pass.yml
@@ -1,5 +1,5 @@
   ci-pass:
-    needs: [fmt, clippy, build, features, msrv, semver{% if all or benchmarks %}, bench, bench-pr{% endif %}{% if all or fuzzing %}, fuzz-smoke{% endif %}{% if all or stress_tests %}, stress-test{% endif %}{% if all or spellcheck %}, spellcheck{% endif %}{% if all or xtask %}, xtask{% endif %}]
+    needs: [fmt, clippy, warnings, docsrs, build, features, msrv, semver{% if all or benchmarks %}, bench, bench-pr{% endif %}{% if all or fuzzing %}, fuzz-smoke{% endif %}{% if all or stress_tests %}, stress-test{% endif %}{% if all or spellcheck %}, spellcheck{% endif %}{% if all or xtask %}, xtask{% endif %}]
     if: {% raw %}${{ !cancelled() }}{% endraw %}
     runs-on: ubuntu-latest
     steps:

--- a/battery-packs/ci-battery-pack/snippets/github/ci-pass.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/ci-pass.yml
@@ -1,5 +1,5 @@
   ci-pass:
-    needs: [fmt, clippy, warnings, docsrs, build, features, msrv, lockfile, minimal-versions, semver{% if all or benchmarks %}, bench, bench-pr{% endif %}{% if all or fuzzing %}, fuzz-smoke{% endif %}{% if all or stress_tests %}, stress-test{% endif %}{% if all or spellcheck %}, spellcheck{% endif %}{% if all or xtask %}, xtask{% endif %}{% if all or mutation_testing %}, mutants{% endif %}]
+    needs: [fmt, clippy, warnings, docsrs, build, features, msrv, lockfile, minimal-versions, semver{% if all or benchmarks %}, bench, bench-pr{% endif %}{% if all or fuzzing %}, fuzz-smoke{% endif %}{% if all or stress_tests %}, stress-test{% endif %}{% if all or spellcheck %}, spellcheck{% endif %}{% if all or xtask %}, xtask{% endif %}{% if all or mutation_testing %}, mutants{% endif %}{% if all or clippy_sarif %}, clippy-sarif{% endif %}]
     if: {% raw %}${{ !cancelled() }}{% endraw %}
     runs-on: ubuntu-latest
     steps:

--- a/battery-packs/ci-battery-pack/snippets/github/ci-pass.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/ci-pass.yml
@@ -1,5 +1,5 @@
   ci-pass:
-    needs: [fmt, clippy, warnings, docsrs, build, features, msrv, semver{% if all or benchmarks %}, bench, bench-pr{% endif %}{% if all or fuzzing %}, fuzz-smoke{% endif %}{% if all or stress_tests %}, stress-test{% endif %}{% if all or spellcheck %}, spellcheck{% endif %}{% if all or xtask %}, xtask{% endif %}]
+    needs: [fmt, clippy, warnings, docsrs, build, features, msrv, semver{% if all or benchmarks %}, bench, bench-pr{% endif %}{% if all or fuzzing %}, fuzz-smoke{% endif %}{% if all or stress_tests %}, stress-test{% endif %}{% if all or spellcheck %}, spellcheck{% endif %}{% if all or xtask %}, xtask{% endif %}{% if all or mutation_testing %}, mutants{% endif %}]
     if: {% raw %}${{ !cancelled() }}{% endraw %}
     runs-on: ubuntu-latest
     steps:

--- a/battery-packs/ci-battery-pack/snippets/github/ci-pass.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/ci-pass.yml
@@ -1,0 +1,6 @@
+  ci-pass:
+    needs: [fmt, clippy, build, features, msrv, semver{% if all or benchmarks %}, bench, bench-pr{% endif %}{% if all or fuzzing %}, fuzz-smoke{% endif %}{% if all or stress_tests %}, stress-test{% endif %}{% if all or spellcheck %}, spellcheck{% endif %}{% if all or xtask %}, xtask{% endif %}]
+    if: {% raw %}${{ !cancelled() }}{% endraw %}
+    runs-on: ubuntu-latest
+    steps:
+      - run: jq --exit-status 'all(.result == "success" or .result == "skipped")' <<< '{% raw %}${{ toJson(needs) }}{% endraw %}'

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/bench.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/bench.yml
@@ -1,3 +1,6 @@
+  # Bencher regression detection. Requires:
+  # - BENCHER_API_TOKEN repo secret (https://bencher.dev/docs)
+  # - BENCHER_PROJECT repo variable (your Bencher project slug)
   bench:
     if: {% raw %}${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && vars.BENCHER_PROJECT != '' }}{% endraw %}
     runs-on: ubuntu-latest

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/bench.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/bench.yml
@@ -6,6 +6,8 @@
     runs-on: ubuntu-latest
     steps:
       - uses: {{ pin_github_action("actions/checkout", "v6") }}
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
       - uses: {{ pin_github_action("bencherdev/bencher", "v0") }}
@@ -23,6 +25,8 @@
       pull-requests: write
     steps:
       - uses: {{ pin_github_action("actions/checkout", "v6") }}
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
       - uses: {{ pin_github_action("bencherdev/bencher", "v0") }}

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/bench.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/bench.yml
@@ -1,0 +1,36 @@
+  bench:
+    if: {% raw %}${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && vars.BENCHER_PROJECT != '' }}{% endraw %}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: {{ pin_github_action("actions/checkout", "v6") }}
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
+      - uses: {{ pin_github_action("bencherdev/bencher", "v0") }}
+      - run: |
+          bencher run \
+            --project {% raw %}${{ vars.BENCHER_PROJECT }}{% endraw %} \
+            --token {% raw %}${{ secrets.BENCHER_API_TOKEN }}{% endraw %} \
+            --branch main \
+            --adapter rust_criterion \
+            "cargo bench --all-features"
+  bench-pr:
+    if: {% raw %}${{ github.event_name == 'pull_request' && vars.BENCHER_PROJECT != '' }}{% endraw %}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: {{ pin_github_action("actions/checkout", "v6") }}
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
+      - uses: {{ pin_github_action("bencherdev/bencher", "v0") }}
+      - run: |
+          bencher run \
+            --project {% raw %}${{ vars.BENCHER_PROJECT }}{% endraw %} \
+            --token {% raw %}${{ secrets.BENCHER_API_TOKEN }}{% endraw %} \
+            --branch {% raw %}${{ github.head_ref }}{% endraw %} \
+            --start-point main \
+            --start-point-reset \
+            --adapter rust_criterion \
+            --error-on-alert \
+            --github-actions {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %} \
+            "cargo bench --all-features"

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/bench.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/bench.yml
@@ -10,6 +10,8 @@
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
+        with:
+          save-if: {% raw %}${{ github.ref == 'refs/heads/main' }}{% endraw %}
       - uses: {{ pin_github_action("bencherdev/bencher", "v0") }}
       - run: |
           bencher run \
@@ -29,6 +31,8 @@
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
+        with:
+          save-if: {% raw %}${{ github.ref == 'refs/heads/main' }}{% endraw %}
       - uses: {{ pin_github_action("bencherdev/bencher", "v0") }}
       - run: |
           bencher run \

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/build.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/build.yml
@@ -1,0 +1,13 @@
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: [stable, nightly]
+        flags: ["--all-features", "--no-default-features"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: {{ pin_github_action("actions/checkout", "v6") }}
+      - uses: ./.github/actions/rust-build
+        with:
+          toolchain: {% raw %}${{ matrix.toolchain }}{% endraw %}
+          flags: {% raw %}${{ matrix.flags }}{% endraw %}

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/build.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/build.yml
@@ -7,6 +7,8 @@
     runs-on: ubuntu-latest
     steps:
       - uses: {{ pin_github_action("actions/checkout", "v6") }}
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/rust-build
         with:
           toolchain: {% raw %}${{ matrix.toolchain }}{% endraw %}

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/clippy-sarif.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/clippy-sarif.yml
@@ -1,0 +1,24 @@
+  # Clippy with GitHub PR annotations via SARIF (https://github.com/psastras/sarif-rs)
+  clippy-sarif:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - uses: {{ pin_github_action("actions/checkout", "v6") }}
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
+      - run: cargo install clippy-sarif --locked
+      - run: cargo install sarif-fmt --locked
+      - name: Run clippy with SARIF output
+        run: >
+          cargo clippy --workspace --all-features --all-targets --message-format=json
+          | clippy-sarif | tee clippy-results.sarif | sarif-fmt
+        continue-on-error: true
+      - uses: {{ pin_github_action("github/codeql-action", "v3") }}
+        with:
+          sarif_file: clippy-results.sarif
+          wait-for-processing: true

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/clippy-sarif.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/clippy-sarif.yml
@@ -18,7 +18,8 @@
           cargo clippy --workspace --all-features --all-targets --message-format=json
           | clippy-sarif | tee clippy-results.sarif | sarif-fmt
         continue-on-error: true
-      - uses: {{ pin_github_action("github/codeql-action", "v3") }}
+      - name: Upload SARIF
+        uses: {{ pin_github_action("github/codeql-action", "v3", "upload-sarif") }}
         with:
           sarif_file: clippy-results.sarif
           wait-for-processing: true

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/clippy-sarif.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/clippy-sarif.yml
@@ -11,6 +11,8 @@
         with:
           components: clippy
       - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
+        with:
+          save-if: {% raw %}${{ github.ref == 'refs/heads/main' }}{% endraw %}
       - run: cargo install clippy-sarif --locked
       - run: cargo install sarif-fmt --locked
       - name: Run clippy with SARIF output

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/clippy.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/clippy.yml
@@ -1,3 +1,4 @@
+  # https://doc.rust-lang.org/clippy/
   clippy:
     runs-on: ubuntu-latest
     steps:

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/clippy.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/clippy.yml
@@ -9,4 +9,4 @@
         with:
           components: clippy
       - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
-      - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+      - run: cargo clippy --workspace --all-targets --all-features --keep-going -- -D warnings

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/clippy.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/clippy.yml
@@ -9,4 +9,6 @@
         with:
           components: clippy
       - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
+        with:
+          save-if: {% raw %}${{ github.ref == 'refs/heads/main' }}{% endraw %}
       - run: cargo clippy --workspace --all-targets --all-features --keep-going -- -D warnings

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/clippy.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/clippy.yml
@@ -1,0 +1,9 @@
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: {{ pin_github_action("actions/checkout", "v6") }}
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
+      - run: cargo clippy --workspace --all-targets --all-features -- -D warnings

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/clippy.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/clippy.yml
@@ -3,6 +3,8 @@
     runs-on: ubuntu-latest
     steps:
       - uses: {{ pin_github_action("actions/checkout", "v6") }}
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/docsrs.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/docsrs.yml
@@ -1,0 +1,9 @@
+  docsrs:
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: "-D warnings --cfg docsrs"
+    steps:
+      - uses: {{ pin_github_action("actions/checkout", "v6") }}
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
+      - run: cargo doc --no-deps --all-features

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/docsrs.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/docsrs.yml
@@ -1,3 +1,4 @@
+  # Validate docs build with docsrs cfg on nightly
   docsrs:
     runs-on: ubuntu-latest
     env:

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/docsrs.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/docsrs.yml
@@ -5,6 +5,8 @@
       RUSTDOCFLAGS: "-D warnings --cfg docsrs"
     steps:
       - uses: {{ pin_github_action("actions/checkout", "v6") }}
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@nightly
       - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
       - run: cargo doc --no-deps --all-features

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/docsrs.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/docsrs.yml
@@ -9,4 +9,6 @@
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@nightly
       - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
+        with:
+          save-if: {% raw %}${{ github.ref == 'refs/heads/main' }}{% endraw %}
       - run: cargo doc --no-deps --all-features

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/features.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/features.yml
@@ -1,3 +1,4 @@
+  # https://github.com/taiki-e/cargo-hack
   features:
     runs-on: ubuntu-latest
     steps:

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/features.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/features.yml
@@ -3,6 +3,8 @@
     runs-on: ubuntu-latest
     steps:
       - uses: {{ pin_github_action("actions/checkout", "v6") }}
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
       - uses: {{ pin_github_action("taiki-e/install-action", "v2") }}

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/features.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/features.yml
@@ -1,0 +1,10 @@
+  features:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: {{ pin_github_action("actions/checkout", "v6") }}
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
+      - uses: {{ pin_github_action("taiki-e/install-action", "v2") }}
+        with:
+          tool: cargo-hack
+      - run: cargo hack check --feature-powerset --depth 2 --no-dev-deps

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/features.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/features.yml
@@ -7,6 +7,8 @@
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
+        with:
+          save-if: {% raw %}${{ github.ref == 'refs/heads/main' }}{% endraw %}
       - uses: {{ pin_github_action("taiki-e/install-action", "v2") }}
         with:
           tool: cargo-hack

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/fmt.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/fmt.yml
@@ -1,3 +1,4 @@
+  # https://github.com/rust-lang/rustfmt
   fmt:
     runs-on: ubuntu-latest
     steps:

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/fmt.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/fmt.yml
@@ -3,6 +3,8 @@
     runs-on: ubuntu-latest
     steps:
       - uses: {{ pin_github_action("actions/checkout", "v6") }}
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/fmt.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/fmt.yml
@@ -1,0 +1,8 @@
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: {{ pin_github_action("actions/checkout", "v6") }}
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+      - run: cargo fmt --all -- --check

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/fuzz-smoke.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/fuzz-smoke.yml
@@ -1,3 +1,4 @@
+  # https://github.com/rust-fuzz/cargo-fuzz
   fuzz-smoke:
     runs-on: ubuntu-latest
     steps:

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/fuzz-smoke.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/fuzz-smoke.yml
@@ -1,0 +1,14 @@
+  fuzz-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: {{ pin_github_action("actions/checkout", "v6") }}
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
+        with:
+          workspaces: fuzz -> target
+      - uses: dtolnay/install@cargo-fuzz
+      - name: Smoke test fuzz targets (60s each)
+        run: |
+          for target in $(cargo fuzz list); do
+            cargo fuzz run "$target" -- -max_total_time=60
+          done

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/fuzz-smoke.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/fuzz-smoke.yml
@@ -3,6 +3,8 @@
     runs-on: ubuntu-latest
     steps:
       - uses: {{ pin_github_action("actions/checkout", "v6") }}
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@nightly
       - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
         with:

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/fuzz-smoke.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/fuzz-smoke.yml
@@ -8,6 +8,7 @@
       - uses: dtolnay/rust-toolchain@nightly
       - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
         with:
+          save-if: {% raw %}${{ github.ref == 'refs/heads/main' }}{% endraw %}
           workspaces: fuzz -> target
       - uses: dtolnay/install@cargo-fuzz
       - name: Smoke test fuzz targets (60s each)

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/lockfile.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/lockfile.yml
@@ -1,0 +1,9 @@
+  # Ensure Cargo.lock is in sync with Cargo.toml
+  lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: {{ pin_github_action("actions/checkout", "v6") }}
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo update --workspace --locked

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/minimal-versions.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/minimal-versions.yml
@@ -1,0 +1,11 @@
+  # Ensure minimum dependency versions work (https://doc.rust-lang.org/cargo/reference/resolver.html)
+  minimal-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: {{ pin_github_action("actions/checkout", "v6") }}
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@nightly
+      - run: cargo +nightly generate-lockfile -Z minimal-versions
+      - run: cargo +stable check --workspace --all-features --locked --keep-going

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/msrv.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/msrv.yml
@@ -1,3 +1,4 @@
+  # https://github.com/taiki-e/cargo-hack (--rust-version)
   msrv:
     runs-on: ubuntu-latest
     steps:

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/msrv.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/msrv.yml
@@ -10,4 +10,4 @@
       - uses: {{ pin_github_action("taiki-e/install-action", "v2") }}
         with:
           tool: cargo-hack
-      - run: cargo hack check --rust-version --workspace --all-targets --locked
+      - run: cargo hack check --rust-version --workspace --all-targets --ignore-private --locked

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/msrv.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/msrv.yml
@@ -3,6 +3,8 @@
     runs-on: ubuntu-latest
     steps:
       - uses: {{ pin_github_action("actions/checkout", "v6") }}
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
       - uses: {{ pin_github_action("taiki-e/install-action", "v2") }}

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/msrv.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/msrv.yml
@@ -7,6 +7,8 @@
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
+        with:
+          save-if: {% raw %}${{ github.ref == 'refs/heads/main' }}{% endraw %}
       - uses: {{ pin_github_action("taiki-e/install-action", "v2") }}
         with:
           tool: cargo-hack

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/msrv.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/msrv.yml
@@ -1,0 +1,16 @@
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: {{ pin_github_action("actions/checkout", "v6") }}
+      - name: Read MSRV from Cargo.toml
+        id: msrv
+        run: echo "version=$(yq -r '.package.rust-version // .workspace.package.rust-version' Cargo.toml)" >> "$GITHUB_OUTPUT"
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: {% raw %}${{ steps.msrv.outputs.version }}{% endraw %}
+      - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
+      - name: Resolve MSRV-compatible dependencies
+        env:
+          CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS: fallback
+        run: cargo update
+      - run: cargo check --all-features

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/mutants.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/mutants.yml
@@ -3,6 +3,8 @@
     runs-on: ubuntu-latest
     steps:
       - uses: {{ pin_github_action("actions/checkout", "v6") }}
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
       - uses: {{ pin_github_action("taiki-e/install-action", "v2") }}

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/mutants.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/mutants.yml
@@ -7,6 +7,8 @@
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
+        with:
+          save-if: {% raw %}${{ github.ref == 'refs/heads/main' }}{% endraw %}
       - uses: {{ pin_github_action("taiki-e/install-action", "v2") }}
         with:
           tool: cargo-mutants

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/mutants.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/mutants.yml
@@ -1,0 +1,17 @@
+  # cargo-mutants: find code not covered by tests (https://mutants.rs/)
+  mutants:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: {{ pin_github_action("actions/checkout", "v6") }}
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
+      - uses: {{ pin_github_action("taiki-e/install-action", "v2") }}
+        with:
+          tool: cargo-mutants
+      - run: cargo mutants --no-shuffle -vV
+      - name: Upload mutation report
+        if: always()
+        uses: {{ pin_github_action("actions/upload-artifact", "v4") }}
+        with:
+          name: mutants-report
+          path: mutants.out/

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/semver.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/semver.yml
@@ -1,3 +1,4 @@
+  # https://github.com/obi1kenobi/cargo-semver-checks
   semver:
     runs-on: ubuntu-latest
     steps:

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/semver.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/semver.yml
@@ -1,0 +1,5 @@
+  semver:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: {{ pin_github_action("actions/checkout", "v6") }}
+      - uses: {{ pin_github_action("obi1kenobi/cargo-semver-checks-action", "v2") }}

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/semver.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/semver.yml
@@ -3,4 +3,6 @@
     runs-on: ubuntu-latest
     steps:
       - uses: {{ pin_github_action("actions/checkout", "v6") }}
+        with:
+          persist-credentials: false
       - uses: {{ pin_github_action("obi1kenobi/cargo-semver-checks-action", "v2") }}

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/spellcheck.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/spellcheck.yml
@@ -1,3 +1,4 @@
+  # https://github.com/crate-ci/typos
   spellcheck:
     runs-on: ubuntu-latest
     steps:

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/spellcheck.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/spellcheck.yml
@@ -1,0 +1,5 @@
+  spellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: {{ pin_github_action("actions/checkout", "v6") }}
+      - uses: {{ pin_github_action("crate-ci/typos", "v1") }}

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/spellcheck.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/spellcheck.yml
@@ -3,4 +3,6 @@
     runs-on: ubuntu-latest
     steps:
       - uses: {{ pin_github_action("actions/checkout", "v6") }}
+        with:
+          persist-credentials: false
       - uses: {{ pin_github_action("crate-ci/typos", "v1") }}

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/stress-test.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/stress-test.yml
@@ -1,3 +1,4 @@
+  # https://nexte.st/ (--stress-duration)
   stress-test:
     runs-on: ubuntu-latest
     steps:

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/stress-test.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/stress-test.yml
@@ -7,5 +7,6 @@
       - uses: {{ pin_github_action("taiki-e/install-action", "v2") }}
         with:
           tool: nextest
+      # nextest is used here for --stress-duration (not available in cargo test)
       - run: cargo nextest run --all-features --stress-duration '5m'
         timeout-minutes: 10

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/stress-test.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/stress-test.yml
@@ -3,6 +3,8 @@
     runs-on: ubuntu-latest
     steps:
       - uses: {{ pin_github_action("actions/checkout", "v6") }}
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
       - uses: {{ pin_github_action("taiki-e/install-action", "v2") }}

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/stress-test.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/stress-test.yml
@@ -7,6 +7,8 @@
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
+        with:
+          save-if: {% raw %}${{ github.ref == 'refs/heads/main' }}{% endraw %}
       - uses: {{ pin_github_action("taiki-e/install-action", "v2") }}
         with:
           tool: nextest

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/stress-test.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/stress-test.yml
@@ -1,0 +1,11 @@
+  stress-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: {{ pin_github_action("actions/checkout", "v6") }}
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
+      - uses: {{ pin_github_action("taiki-e/install-action", "v2") }}
+        with:
+          tool: nextest
+      - run: cargo nextest run --all-features --stress-duration '5m'
+        timeout-minutes: 10

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/warnings.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/warnings.yml
@@ -1,10 +1,9 @@
-  msrv:
+  warnings:
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-Dwarnings"
     steps:
       - uses: {{ pin_github_action("actions/checkout", "v6") }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
-      - uses: {{ pin_github_action("taiki-e/install-action", "v2") }}
-        with:
-          tool: cargo-hack
-      - run: cargo hack check --rust-version --workspace --all-targets --locked
+      - run: cargo check --all-targets --all-features

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/warnings.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/warnings.yml
@@ -1,3 +1,4 @@
+  # Dedicated warnings check so test failures are visible even with warnings
   warnings:
     runs-on: ubuntu-latest
     env:

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/warnings.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/warnings.yml
@@ -9,4 +9,4 @@
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
-      - run: cargo check --all-targets --all-features
+      - run: cargo check --all-targets --all-features --keep-going

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/warnings.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/warnings.yml
@@ -5,6 +5,8 @@
       RUSTFLAGS: "-Dwarnings"
     steps:
       - uses: {{ pin_github_action("actions/checkout", "v6") }}
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
       - run: cargo check --all-targets --all-features

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/warnings.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/warnings.yml
@@ -9,4 +9,6 @@
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
+        with:
+          save-if: {% raw %}${{ github.ref == 'refs/heads/main' }}{% endraw %}
       - run: cargo check --all-targets --all-features --keep-going

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/xtask.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/xtask.yml
@@ -1,3 +1,4 @@
+  # https://github.com/matklad/cargo-xtask
   xtask:
     runs-on: ubuntu-latest
     steps:

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/xtask.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/xtask.yml
@@ -1,0 +1,7 @@
+  xtask:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: {{ pin_github_action("actions/checkout", "v6") }}
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
+      - run: cargo xtask codegen --check

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/xtask.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/xtask.yml
@@ -7,4 +7,6 @@
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
+        with:
+          save-if: {% raw %}${{ github.ref == 'refs/heads/main' }}{% endraw %}
       - run: cargo xtask codegen --check

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/xtask.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/xtask.yml
@@ -3,6 +3,8 @@
     runs-on: ubuntu-latest
     steps:
       - uses: {{ pin_github_action("actions/checkout", "v6") }}
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
       - run: cargo xtask codegen --check

--- a/battery-packs/ci-battery-pack/src/lib.rs
+++ b/battery-packs/ci-battery-pack/src/lib.rs
@@ -50,6 +50,7 @@ mod tests {
 .github/workflows/audit.yml
 .github/workflows/ci.yml
 .github/workflows/release.yml
+.github/workflows/rust-next.yml
 Cargo.toml
 README.md
 deny.toml
@@ -73,6 +74,7 @@ src/lib.rs
 .github/workflows/fuzz-nightly.yml
 .github/workflows/mdbook.yml
 .github/workflows/release.yml
+.github/workflows/rust-next.yml
 .github/workflows/stress-test.yml
 Cargo.toml
 README.md
@@ -104,6 +106,7 @@ xtask/src/main.rs
 .github/workflows/ci.yml
 .github/workflows/fuzz-nightly.yml
 .github/workflows/release.yml
+.github/workflows/rust-next.yml
 Cargo.toml
 README.md
 deny.toml
@@ -126,6 +129,7 @@ src/lib.rs
 .github/workflows/ci.yml
 .github/workflows/fuzz-nightly.yml
 .github/workflows/release.yml
+.github/workflows/rust-next.yml
 Cargo.toml
 README.md
 _typos.toml
@@ -148,6 +152,7 @@ src/lib.rs
 .github/workflows/audit.yml
 .github/workflows/ci.yml
 .github/workflows/release.yml
+.github/workflows/rust-next.yml
 Cargo.toml
 README.md
 benches/example_bench.rs
@@ -168,6 +173,7 @@ src/lib.rs
 .github/workflows/audit.yml
 .github/workflows/ci.yml
 .github/workflows/release.yml
+.github/workflows/rust-next.yml
 .github/workflows/stress-test.yml
 Cargo.toml
 README.md
@@ -189,6 +195,7 @@ src/lib.rs
 .github/workflows/ci.yml
 .github/workflows/mdbook.yml
 .github/workflows/release.yml
+.github/workflows/rust-next.yml
 Cargo.toml
 README.md
 book.toml
@@ -211,6 +218,7 @@ src/lib.rs
 .github/workflows/audit.yml
 .github/workflows/ci.yml
 .github/workflows/release.yml
+.github/workflows/rust-next.yml
 Cargo.toml
 README.md
 _typos.toml
@@ -232,6 +240,7 @@ src/lib.rs
 .github/workflows/audit.yml
 .github/workflows/ci.yml
 .github/workflows/release.yml
+.github/workflows/rust-next.yml
 Cargo.toml
 README.md
 deny.toml
@@ -598,12 +607,14 @@ src/main.rs
 .github/workflows/build-binaries.yml
 .github/workflows/ci.yml
 .github/workflows/release.yml
+.github/workflows/rust-next.yml
 Cargo.toml
 README.md
 deny.toml
 release-plz.toml
 src/lib.rs
-src/main.rs"#]]
+src/main.rs
+"#]]
         );
     }
 }

--- a/battery-packs/ci-battery-pack/src/lib.rs
+++ b/battery-packs/ci-battery-pack/src/lib.rs
@@ -266,6 +266,7 @@ xtask/src/main.rs
             ("xtask", "true"),
             ("binary_release", "true"),
             ("mutation_testing", "true"),
+            ("clippy_sarif", "true"),
         ]);
         assert_eq!(all_files, individual_files);
     }

--- a/battery-packs/ci-battery-pack/src/lib.rs
+++ b/battery-packs/ci-battery-pack/src/lib.rs
@@ -256,6 +256,7 @@ xtask/src/main.rs
             ("spellcheck", "true"),
             ("xtask", "true"),
             ("binary_release", "true"),
+            ("mutation_testing", "true"),
         ]);
         assert_eq!(all_files, individual_files);
     }

--- a/battery-packs/ci-battery-pack/src/lib.rs
+++ b/battery-packs/ci-battery-pack/src/lib.rs
@@ -1,0 +1,605 @@
+#![doc = include_str!(concat!(env!("OUT_DIR"), "/docs.md"))]
+
+#[cfg(test)]
+mod tests {
+    use battery_pack::testing::PreviewBuilder;
+
+    // Note: validate_templates is not used because it runs cargo check on ALL
+    // templates, but standalone templates (benchmarks, fuzzing, etc.) are partial
+    // scaffolds without a Cargo.toml. The full template is validated end-to-end
+    // via the test repo: https://github.com/jlizen/ci-battery-pack-test/actions
+    use snapbox::{assert_data_eq, str};
+
+    fn file_list(defines: &[(&str, &str)]) -> String {
+        let mut builder = PreviewBuilder::new(env!("CARGO_MANIFEST_DIR"))
+            .template("templates/full")
+            .define("ci_platform", "github")
+            .define("repo_owner", "test-owner");
+        for (k, v) in defines {
+            builder = builder.define(*k, *v);
+        }
+        let files = builder.preview().unwrap();
+        let mut paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
+        paths.sort();
+        paths.join("\n")
+    }
+
+    fn get_content(defines: &[(&str, &str)], path: &str) -> String {
+        let mut builder = PreviewBuilder::new(env!("CARGO_MANIFEST_DIR"))
+            .template("templates/full")
+            .define("ci_platform", "github")
+            .define("repo_owner", "test-owner");
+        for (k, v) in defines {
+            builder = builder.define(*k, *v);
+        }
+        let files = builder.preview().unwrap();
+        files
+            .into_iter()
+            .find(|f| f.path == path)
+            .unwrap_or_else(|| panic!("file not found: {path}"))
+            .content
+    }
+
+    #[test]
+    fn minimalist_file_list() {
+        assert_data_eq!(
+            file_list(&[]),
+            str![[r#"
+.github/actions/rust-build/action.yml
+.github/dependabot.yml
+.github/workflows/audit.yml
+.github/workflows/ci.yml
+.github/workflows/release.yml
+Cargo.toml
+README.md
+deny.toml
+release-plz.toml
+src/lib.rs
+"#]]
+        );
+    }
+
+    #[test]
+    fn maximalist_file_list() {
+        assert_data_eq!(
+            file_list(&[("all", "true")]),
+            str![[r#"
+.cargo/config.toml
+.github/actions/rust-build/action.yml
+.github/dependabot.yml
+.github/workflows/audit.yml
+.github/workflows/build-binaries.yml
+.github/workflows/ci.yml
+.github/workflows/fuzz-nightly.yml
+.github/workflows/mdbook.yml
+.github/workflows/release.yml
+.github/workflows/stress-test.yml
+Cargo.toml
+README.md
+_typos.toml
+benches/example_bench.rs
+book.toml
+deny.toml
+fuzz/Cargo.toml
+fuzz/fuzz_targets/fuzz_example.rs
+md/SUMMARY.md
+md/intro.md
+release-plz.toml
+src/lib.rs
+src/main.rs
+xtask/Cargo.toml
+xtask/src/main.rs
+"#]]
+        );
+    }
+
+    #[test]
+    fn fuzzing_only_file_list() {
+        assert_data_eq!(
+            file_list(&[("fuzzing", "true")]),
+            str![[r#"
+.github/actions/rust-build/action.yml
+.github/dependabot.yml
+.github/workflows/audit.yml
+.github/workflows/ci.yml
+.github/workflows/fuzz-nightly.yml
+.github/workflows/release.yml
+Cargo.toml
+README.md
+deny.toml
+fuzz/Cargo.toml
+fuzz/fuzz_targets/fuzz_example.rs
+release-plz.toml
+src/lib.rs
+"#]]
+        );
+    }
+
+    #[test]
+    fn mixed_features_file_list() {
+        assert_data_eq!(
+            file_list(&[("fuzzing", "true"), ("spellcheck", "true")]),
+            str![[r#"
+.github/actions/rust-build/action.yml
+.github/dependabot.yml
+.github/workflows/audit.yml
+.github/workflows/ci.yml
+.github/workflows/fuzz-nightly.yml
+.github/workflows/release.yml
+Cargo.toml
+README.md
+_typos.toml
+deny.toml
+fuzz/Cargo.toml
+fuzz/fuzz_targets/fuzz_example.rs
+release-plz.toml
+src/lib.rs
+"#]]
+        );
+    }
+
+    #[test]
+    fn benchmarks_only_file_list() {
+        assert_data_eq!(
+            file_list(&[("benchmarks", "true")]),
+            str![[r#"
+.github/actions/rust-build/action.yml
+.github/dependabot.yml
+.github/workflows/audit.yml
+.github/workflows/ci.yml
+.github/workflows/release.yml
+Cargo.toml
+README.md
+benches/example_bench.rs
+deny.toml
+release-plz.toml
+src/lib.rs
+"#]]
+        );
+    }
+
+    #[test]
+    fn stress_tests_only_file_list() {
+        assert_data_eq!(
+            file_list(&[("stress_tests", "true")]),
+            str![[r#"
+.github/actions/rust-build/action.yml
+.github/dependabot.yml
+.github/workflows/audit.yml
+.github/workflows/ci.yml
+.github/workflows/release.yml
+.github/workflows/stress-test.yml
+Cargo.toml
+README.md
+deny.toml
+release-plz.toml
+src/lib.rs
+"#]]
+        );
+    }
+
+    #[test]
+    fn mdbook_only_file_list() {
+        assert_data_eq!(
+            file_list(&[("mdbook", "true")]),
+            str![[r#"
+.github/actions/rust-build/action.yml
+.github/dependabot.yml
+.github/workflows/audit.yml
+.github/workflows/ci.yml
+.github/workflows/mdbook.yml
+.github/workflows/release.yml
+Cargo.toml
+README.md
+book.toml
+deny.toml
+md/SUMMARY.md
+md/intro.md
+release-plz.toml
+src/lib.rs
+"#]]
+        );
+    }
+
+    #[test]
+    fn spellcheck_only_file_list() {
+        assert_data_eq!(
+            file_list(&[("spellcheck", "true")]),
+            str![[r#"
+.github/actions/rust-build/action.yml
+.github/dependabot.yml
+.github/workflows/audit.yml
+.github/workflows/ci.yml
+.github/workflows/release.yml
+Cargo.toml
+README.md
+_typos.toml
+deny.toml
+release-plz.toml
+src/lib.rs
+"#]]
+        );
+    }
+
+    #[test]
+    fn xtask_only_file_list() {
+        assert_data_eq!(
+            file_list(&[("xtask", "true")]),
+            str![[r#"
+.cargo/config.toml
+.github/actions/rust-build/action.yml
+.github/dependabot.yml
+.github/workflows/audit.yml
+.github/workflows/ci.yml
+.github/workflows/release.yml
+Cargo.toml
+README.md
+deny.toml
+release-plz.toml
+src/lib.rs
+xtask/Cargo.toml
+xtask/src/main.rs
+"#]]
+        );
+    }
+
+    #[test]
+    fn all_flag_matches_maximalist() {
+        // -d all should produce the same files as enabling every flag individually
+        let all_files = file_list(&[("all", "true")]);
+        let individual_files = file_list(&[
+            ("trusted_publishing", "true"),
+            ("benchmarks", "true"),
+            ("fuzzing", "true"),
+            ("stress_tests", "true"),
+            ("mdbook", "true"),
+            ("spellcheck", "true"),
+            ("xtask", "true"),
+            ("binary_release", "true"),
+        ]);
+        assert_eq!(all_files, individual_files);
+    }
+
+    #[test]
+    fn trusted_publishing_disabled_strips_release_files() {
+        let list = file_list(&[("trusted_publishing", "false")]);
+        assert!(
+            !list.contains("release.yml"),
+            "release workflow should be stripped"
+        );
+        assert!(
+            !list.contains("release-plz.toml"),
+            "release-plz.toml should be stripped"
+        );
+        // Core CI should still be present
+        assert!(list.contains("ci.yml"));
+        assert!(list.contains("deny.toml"));
+    }
+
+    #[test]
+    fn none_platform_strips_github_keeps_configs() {
+        let files = PreviewBuilder::new(env!("CARGO_MANIFEST_DIR"))
+            .template("templates/full")
+            .define("ci_platform", "none")
+            .define("repo_owner", "test-owner")
+            .define("all", "true")
+            .preview()
+            .unwrap();
+        let mut paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
+        paths.sort();
+        let list = paths.join("\n");
+        // No .github/ files should be present
+        assert!(
+            !list.contains(".github/"),
+            "ci_platform=none should strip all .github/ files"
+        );
+        assert_data_eq!(
+            list,
+            str![[r#"
+.cargo/config.toml
+Cargo.toml
+README.md
+_typos.toml
+benches/example_bench.rs
+book.toml
+deny.toml
+fuzz/Cargo.toml
+fuzz/fuzz_targets/fuzz_example.rs
+md/SUMMARY.md
+md/intro.md
+release-plz.toml
+src/lib.rs
+src/main.rs
+xtask/Cargo.toml
+xtask/src/main.rs
+"#]]
+        );
+    }
+
+    #[test]
+    fn ci_yml_contains_gate_job() {
+        let content = get_content(&[], ".github/workflows/ci.yml");
+        assert!(
+            content.contains("ci-pass"),
+            "ci.yml should have ci-pass gate job"
+        );
+    }
+
+    #[test]
+    fn release_yml_uses_repo_owner() {
+        let content = get_content(&[], ".github/workflows/release.yml");
+        assert!(
+            content.contains("test-owner"),
+            "release.yml should contain repo_owner"
+        );
+    }
+
+    #[test]
+    fn cargo_toml_has_valid_rust_version() {
+        let content = get_content(&[], "Cargo.toml");
+        let line = content
+            .lines()
+            .find(|l| l.starts_with("rust-version"))
+            .unwrap();
+        // Should be like: rust-version = "1.91.1"
+        let version = line.split('"').nth(1).unwrap();
+        let parts: Vec<&str> = version.split('.').collect();
+        assert!(parts.len() >= 2, "rust-version should be semver: {version}");
+        assert!(
+            parts[0].parse::<u32>().unwrap() >= 1,
+            "major >= 1: {version}"
+        );
+    }
+
+    #[test]
+    fn fuzz_nightly_workflow_has_crash_artifacts() {
+        let files = PreviewBuilder::new(env!("CARGO_MANIFEST_DIR"))
+            .template("templates/full")
+            .define("ci_platform", "github")
+            .define("repo_owner", "test-owner")
+            .define("fuzzing", "true")
+            .define("description", "")
+            .preview()
+            .unwrap();
+        let content = files
+            .iter()
+            .find(|f| f.path == ".github/workflows/fuzz-nightly.yml")
+            .unwrap();
+        assert!(
+            content.content.contains("upload-artifact"),
+            "fuzz-nightly should upload crash artifacts"
+        );
+        assert!(
+            content.content.contains("max_total_time"),
+            "fuzz-nightly should have duration config"
+        );
+    }
+
+    #[test]
+    fn stress_test_workflow_has_timeout() {
+        let files = PreviewBuilder::new(env!("CARGO_MANIFEST_DIR"))
+            .template("templates/full")
+            .define("ci_platform", "github")
+            .define("repo_owner", "test-owner")
+            .define("stress_tests", "true")
+            .define("description", "")
+            .preview()
+            .unwrap();
+        let content = files
+            .iter()
+            .find(|f| f.path == ".github/workflows/stress-test.yml")
+            .unwrap();
+        assert!(
+            content.content.contains("timeout-minutes"),
+            "stress-test should have timeout"
+        );
+        assert!(
+            content.content.contains("stress-duration"),
+            "stress-test should use nextest stress-duration"
+        );
+    }
+
+    #[test]
+    fn description_placeholder_in_cargo_toml() {
+        let files = PreviewBuilder::new(env!("CARGO_MANIFEST_DIR"))
+            .template("templates/full")
+            .define("ci_platform", "github")
+            .define("repo_owner", "test-owner")
+            .define("description", "My cool project")
+            .preview()
+            .unwrap();
+        let cargo = files.iter().find(|f| f.path == "Cargo.toml").unwrap();
+        assert!(
+            cargo.content.contains("My cool project"),
+            "description should appear in Cargo.toml"
+        );
+    }
+
+    #[test]
+    fn bp_managed_deps_resolved() {
+        let files = PreviewBuilder::new(env!("CARGO_MANIFEST_DIR"))
+            .template("templates/full")
+            .define("ci_platform", "github")
+            .define("repo_owner", "test-owner")
+            .define("all", "true")
+            .define("description", "")
+            .preview()
+            .unwrap();
+
+        // Root Cargo.toml: criterion should be resolved, not bp-managed
+        let root = files.iter().find(|f| f.path == "Cargo.toml").unwrap();
+        assert!(
+            root.content.contains("criterion = {"),
+            "criterion should be resolved"
+        );
+        assert!(
+            !root.content.contains("bp-managed"),
+            "bp-managed should not appear in root"
+        );
+
+        // xtask/Cargo.toml: xshell, xflags, anyhow should be resolved
+        let xtask = files.iter().find(|f| f.path == "xtask/Cargo.toml").unwrap();
+        assert!(
+            !xtask.content.contains("bp-managed"),
+            "bp-managed should not appear in xtask"
+        );
+        assert!(xtask.content.contains("xshell"), "xshell should be present");
+
+        // fuzz/Cargo.toml: libfuzzer-sys, arbitrary should be resolved
+        let fuzz = files.iter().find(|f| f.path == "fuzz/Cargo.toml").unwrap();
+        assert!(
+            !fuzz.content.contains("bp-managed"),
+            "bp-managed should not appear in fuzz"
+        );
+        assert!(
+            fuzz.content.contains("libfuzzer-sys"),
+            "libfuzzer-sys should be present"
+        );
+    }
+
+    // -- Pin action SHA verification --
+
+    #[test]
+    fn ci_yml_has_pinned_shas() {
+        let content = get_content(&[], ".github/workflows/ci.yml");
+        assert!(
+            !content.contains("could-not-resolve"),
+            "ci.yml should not contain unresolved pin_github_action markers"
+        );
+        // Check that at least one line has a 40-char hex SHA after @.
+        let has_sha = content.lines().any(|line| {
+            let trimmed = line.trim().strip_prefix("- ").unwrap_or(line.trim());
+            if let Some(rest) = trimmed.strip_prefix("uses:") {
+                rest.contains('@')
+                    && rest
+                        .split('@')
+                        .nth(1)
+                        .and_then(|after| after.split_whitespace().next())
+                        .is_some_and(|sha| {
+                            sha.len() == 40 && sha.chars().all(|c| c.is_ascii_hexdigit())
+                        })
+            } else {
+                false
+            }
+        });
+        assert!(has_sha, "ci.yml should contain SHA-pinned actions");
+    }
+
+    #[test]
+    fn composite_action_has_pinned_shas() {
+        let content = get_content(&[], ".github/actions/rust-build/action.yml");
+        assert!(
+            !content.contains("could-not-resolve"),
+            "action.yml should not contain unresolved pin_github_action markers"
+        );
+    }
+
+    // -- Standalone template tests --
+
+    fn standalone_file_list(template: &str) -> String {
+        let files = PreviewBuilder::new(env!("CARGO_MANIFEST_DIR"))
+            .template(format!("templates/{template}"))
+            .define("ci_platform", "github")
+            .define("repo_owner", "test-owner")
+            .preview()
+            .unwrap();
+        let mut paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
+        paths.sort();
+        paths.join("\n")
+    }
+
+    #[test]
+    fn standalone_benchmarks() {
+        assert_data_eq!(
+            standalone_file_list("benchmarks"),
+            str![[r#"
+.github/workflows/benchmarks.yml
+benches/example_bench.rs"#]]
+        );
+    }
+
+    #[test]
+    fn standalone_fuzzing() {
+        assert_data_eq!(
+            standalone_file_list("fuzzing"),
+            str![[r#"
+.github/workflows/fuzz-nightly.yml
+.github/workflows/fuzz-pr.yml
+fuzz/Cargo.toml
+fuzz/fuzz_targets/fuzz_example.rs"#]]
+        );
+    }
+
+    #[test]
+    fn standalone_stress_test() {
+        assert_data_eq!(
+            standalone_file_list("stress-test"),
+            str![[r#"
+.github/workflows/stress-test.yml"#]]
+        );
+    }
+
+    #[test]
+    fn standalone_mdbook() {
+        assert_data_eq!(
+            standalone_file_list("mdbook"),
+            str![[r#"
+.github/workflows/mdbook.yml
+book.toml
+md/SUMMARY.md
+md/intro.md"#]]
+        );
+    }
+
+    #[test]
+    fn standalone_spellcheck() {
+        assert_data_eq!(
+            standalone_file_list("spellcheck"),
+            str![[r#"
+.github/workflows/typos.yml
+_typos.toml"#]]
+        );
+    }
+
+    #[test]
+    fn standalone_xtask() {
+        assert_data_eq!(
+            standalone_file_list("xtask"),
+            str![[r#"
+.cargo/config.toml
+.github/workflows/xtask.yml
+xtask/Cargo.toml
+xtask/src/main.rs"#]]
+        );
+    }
+
+    #[test]
+    fn standalone_binary_release() {
+        assert_data_eq!(
+            standalone_file_list("binary-release"),
+            str![[r#"
+.github/workflows/build-binaries.yml
+src/main.rs"#]]
+        );
+    }
+
+    #[test]
+    fn binary_release_only_file_list() {
+        assert_data_eq!(
+            file_list(&[("binary_release", "true")]),
+            str![[r#"
+.github/actions/rust-build/action.yml
+.github/dependabot.yml
+.github/workflows/audit.yml
+.github/workflows/build-binaries.yml
+.github/workflows/ci.yml
+.github/workflows/release.yml
+Cargo.toml
+README.md
+deny.toml
+release-plz.toml
+src/lib.rs
+src/main.rs"#]]
+        );
+    }
+}

--- a/battery-packs/ci-battery-pack/src/lib.rs
+++ b/battery-packs/ci-battery-pack/src/lib.rs
@@ -618,4 +618,26 @@ src/main.rs
 "#]]
         );
     }
+
+    // -- pin_github_action output verification --
+
+    #[test]
+    fn pin_github_action_subpath_in_generated_output() {
+        let files = PreviewBuilder::new(env!("CARGO_MANIFEST_DIR"))
+            .template("templates/full")
+            .define("ci_platform", "github")
+            .define("repo_owner", "test-owner")
+            .define("description", "")
+            .define("clippy_sarif", "true")
+            .preview()
+            .unwrap();
+        let ci = files
+            .iter()
+            .find(|f| f.path == ".github/workflows/ci.yml")
+            .unwrap();
+        assert!(
+            ci.content.contains("github/codeql-action/upload-sarif@"),
+            "should contain subpath in action reference"
+        );
+    }
 }

--- a/battery-packs/ci-battery-pack/src/lib.rs
+++ b/battery-packs/ci-battery-pack/src/lib.rs
@@ -2,7 +2,7 @@
 
 #[cfg(test)]
 mod tests {
-    use battery_pack::testing::PreviewBuilder;
+    use ::battery_pack::testing::PreviewBuilder;
 
     // Note: validate_templates is not used because it runs cargo check on ALL
     // templates, but standalone templates (benchmarks, fuzzing, etc.) are partial

--- a/battery-packs/ci-battery-pack/src/lib.rs
+++ b/battery-packs/ci-battery-pack/src/lib.rs
@@ -579,7 +579,10 @@ xtask/src/main.rs"#]]
             standalone_file_list("binary-release"),
             str![[r#"
 .github/workflows/build-binaries.yml
-src/main.rs"#]]
+Cargo.toml
+cargo-bin-section.toml
+src/main.rs
+"#]]
         );
     }
 

--- a/battery-packs/ci-battery-pack/templates/benchmarks/.github/workflows/benchmarks.yml
+++ b/battery-packs/ci-battery-pack/templates/benchmarks/.github/workflows/benchmarks.yml
@@ -1,0 +1,15 @@
+{%- if ci_platform == "github" -%}
+name: Benchmarks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+{% include "snippets/github/jobs/bench.yml" %}
+{%- endif %}

--- a/battery-packs/ci-battery-pack/templates/benchmarks/benches/example_bench.rs
+++ b/battery-packs/ci-battery-pack/templates/benchmarks/benches/example_bench.rs
@@ -1,0 +1,17 @@
+use {{ crate_name }}::add;
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+
+fn bench_add(c: &mut Criterion) {
+    let mut group = c.benchmark_group("add");
+    for (left, right) in [(1, 2), (100, 200), (u64::MAX / 2, u64::MAX / 2)] {
+        group.bench_with_input(
+            BenchmarkId::new("add", format!("{left}+{right}")),
+            &(left, right),
+            |b, &(l, r)| b.iter(|| add(black_box(l), black_box(r))),
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_add);
+criterion_main!(benches);

--- a/battery-packs/ci-battery-pack/templates/benchmarks/benches/example_bench.rs
+++ b/battery-packs/ci-battery-pack/templates/benchmarks/benches/example_bench.rs
@@ -1,5 +1,6 @@
 use {{ crate_name }}::add;
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 
 fn bench_add(c: &mut Criterion) {
     let mut group = c.benchmark_group("add");

--- a/battery-packs/ci-battery-pack/templates/benchmarks/bp-template.toml
+++ b/battery-packs/ci-battery-pack/templates/benchmarks/bp-template.toml
@@ -1,0 +1,10 @@
+[placeholders.ci_platform]
+type = "select"
+prompt = "CI platform"
+options = ["github", "none"]
+default = "github"
+
+[placeholders.repo_owner]
+type = "string"
+prompt = "Repository owner (org or user)"
+default = "OWNER"

--- a/battery-packs/ci-battery-pack/templates/binary-release/.github/workflows/build-binaries.yml
+++ b/battery-packs/ci-battery-pack/templates/binary-release/.github/workflows/build-binaries.yml
@@ -1,5 +1,6 @@
 {%- if ci_platform == "github" -%}
 # Builds cross-platform binaries and uploads to GitHub Releases.
+# Binaries are discoverable by cargo-binstall (https://github.com/cargo-bins/cargo-binstall).
 # Triggered automatically when release-plz publishes a release.
 # workflow_dispatch lets you build binaries manually without a release.
 name: Build Binaries

--- a/battery-packs/ci-battery-pack/templates/binary-release/.github/workflows/build-binaries.yml
+++ b/battery-packs/ci-battery-pack/templates/binary-release/.github/workflows/build-binaries.yml
@@ -2,18 +2,11 @@
 # Builds cross-platform binaries and uploads to GitHub Releases.
 # Binaries are discoverable by cargo-binstall (https://github.com/cargo-bins/cargo-binstall).
 # Triggered automatically when release-plz publishes a release.
-# workflow_dispatch lets you build binaries manually without a release.
 name: Build Binaries
 
 on:
   release:
     types: [published]
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: "Release tag (e.g., v0.1.0)"
-        required: true
-        type: string
 
 permissions:
   contents: write
@@ -56,11 +49,7 @@ jobs:
         id: version
         shell: bash
         run: |
-          if [ "{% raw %}${{ github.event_name }}{% endraw %}" = "workflow_dispatch" ]; then
-            TAG="{% raw %}${{ inputs.tag }}{% endraw %}"
-          else
-            TAG="{% raw %}${{ github.event.release.tag_name }}{% endraw %}"
-          fi
+          TAG="{% raw %}${{ github.event.release.tag_name }}{% endraw %}"
           # Strip package name prefix (e.g. "my-crate-v0.1.0" -> "v0.1.0")
           VERSION="${TAG##*-v}"
           echo "version=v${VERSION}" >> "$GITHUB_OUTPUT"
@@ -80,15 +69,7 @@ jobs:
           Compress-Archive -Path {{ project_name }}.exe -DestinationPath ../../../{{ project_name }}-{% raw %}${{ matrix.target }}{% endraw %}-{% raw %}${{ steps.version.outputs.version }}{% endraw %}.zip
 
       - name: Upload release asset
-        if: {% raw %}${{ github.event_name == 'release' }}{% endraw %}
         uses: {{ pin_github_action("softprops/action-gh-release", "v2") }}
         with:
           files: {{ project_name }}-{% raw %}${{ matrix.target }}{% endraw %}-{% raw %}${{ steps.version.outputs.version }}{% endraw %}.{% raw %}${{ matrix.archive }}{% endraw %}
-
-      - name: Upload artifact
-        if: {% raw %}${{ github.event_name == 'workflow_dispatch' }}{% endraw %}
-        uses: {{ pin_github_action("actions/upload-artifact", "v4") }}
-        with:
-          name: {{ project_name }}-{% raw %}${{ matrix.target }}{% endraw %}
-          path: {{ project_name }}-{% raw %}${{ matrix.target }}{% endraw %}-{% raw %}${{ steps.version.outputs.version }}{% endraw %}.{% raw %}${{ matrix.archive }}{% endraw %}
 {%- endif %}

--- a/battery-packs/ci-battery-pack/templates/binary-release/.github/workflows/build-binaries.yml
+++ b/battery-packs/ci-battery-pack/templates/binary-release/.github/workflows/build-binaries.yml
@@ -54,10 +54,13 @@ jobs:
         shell: bash
         run: |
           if [ "{% raw %}${{ github.event_name }}{% endraw %}" = "workflow_dispatch" ]; then
-            echo "version={% raw %}${{ inputs.tag }}{% endraw %}" >> "$GITHUB_OUTPUT"
+            TAG="{% raw %}${{ inputs.tag }}{% endraw %}"
           else
-            echo "version={% raw %}${{ github.event.release.tag_name }}{% endraw %}" >> "$GITHUB_OUTPUT"
+            TAG="{% raw %}${{ github.event.release.tag_name }}{% endraw %}"
           fi
+          # Strip package name prefix (e.g. "my-crate-v0.1.0" -> "v0.1.0")
+          VERSION="${TAG##*-v}"
+          echo "version=v${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Package (Unix)
         if: {% raw %}${{ matrix.archive == 'tar.gz' }}{% endraw %}

--- a/battery-packs/ci-battery-pack/templates/binary-release/.github/workflows/build-binaries.yml
+++ b/battery-packs/ci-battery-pack/templates/binary-release/.github/workflows/build-binaries.yml
@@ -45,6 +45,8 @@ jobs:
 
     steps:
       - uses: {{ pin_github_action("actions/checkout", "v6") }}
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: {% raw %}${{ matrix.target }}{% endraw %}

--- a/battery-packs/ci-battery-pack/templates/binary-release/.github/workflows/build-binaries.yml
+++ b/battery-packs/ci-battery-pack/templates/binary-release/.github/workflows/build-binaries.yml
@@ -1,0 +1,88 @@
+{%- if ci_platform == "github" -%}
+# Builds cross-platform binaries and uploads to GitHub Releases.
+# Triggered automatically when release-plz publishes a release.
+# workflow_dispatch lets you build binaries manually without a release.
+name: Build Binaries
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g., v0.1.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: {% raw %}Build ${{ matrix.target }}{% endraw %}
+    runs-on: {% raw %}${{ matrix.os }}{% endraw %}
+    if: {% raw %}${{ github.repository_owner == '{% endraw %}{{ repo_owner }}{% raw %}' }}{% endraw %}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            archive: tar.gz
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
+            archive: tar.gz
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            archive: tar.gz
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            archive: tar.gz
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            archive: zip
+
+    steps:
+      - uses: {{ pin_github_action("actions/checkout", "v6") }}
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: {% raw %}${{ matrix.target }}{% endraw %}
+      - run: cargo build --release --target {% raw %}${{ matrix.target }}{% endraw %} -p {{ project_name }}
+
+      - name: Determine version
+        id: version
+        shell: bash
+        run: |
+          if [ "{% raw %}${{ github.event_name }}{% endraw %}" = "workflow_dispatch" ]; then
+            echo "version={% raw %}${{ inputs.tag }}{% endraw %}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version={% raw %}${{ github.event.release.tag_name }}{% endraw %}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Package (Unix)
+        if: {% raw %}${{ matrix.archive == 'tar.gz' }}{% endraw %}
+        shell: bash
+        run: |
+          cd target/{% raw %}${{ matrix.target }}{% endraw %}/release
+          tar -czvf ../../../{{ project_name }}-{% raw %}${{ matrix.target }}{% endraw %}-{% raw %}${{ steps.version.outputs.version }}{% endraw %}.tar.gz {{ project_name }}
+
+      - name: Package (Windows)
+        if: {% raw %}${{ matrix.archive == 'zip' }}{% endraw %}
+        shell: pwsh
+        run: |
+          cd target/{% raw %}${{ matrix.target }}{% endraw %}/release
+          Compress-Archive -Path {{ project_name }}.exe -DestinationPath ../../../{{ project_name }}-{% raw %}${{ matrix.target }}{% endraw %}-{% raw %}${{ steps.version.outputs.version }}{% endraw %}.zip
+
+      - name: Upload release asset
+        if: {% raw %}${{ github.event_name == 'release' }}{% endraw %}
+        uses: {{ pin_github_action("softprops/action-gh-release", "v2") }}
+        with:
+          files: {{ project_name }}-{% raw %}${{ matrix.target }}{% endraw %}-{% raw %}${{ steps.version.outputs.version }}{% endraw %}.{% raw %}${{ matrix.archive }}{% endraw %}
+
+      - name: Upload artifact
+        if: {% raw %}${{ github.event_name == 'workflow_dispatch' }}{% endraw %}
+        uses: {{ pin_github_action("actions/upload-artifact", "v4") }}
+        with:
+          name: {{ project_name }}-{% raw %}${{ matrix.target }}{% endraw %}
+          path: {{ project_name }}-{% raw %}${{ matrix.target }}{% endraw %}-{% raw %}${{ steps.version.outputs.version }}{% endraw %}.{% raw %}${{ matrix.archive }}{% endraw %}
+{%- endif %}

--- a/battery-packs/ci-battery-pack/templates/binary-release/Cargo.toml
+++ b/battery-packs/ci-battery-pack/templates/binary-release/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "{{ project_name }}"
+version = "0.1.0"
+edition = "2024"
+{% include "templates/binary-release/cargo-bin-section.toml" %}

--- a/battery-packs/ci-battery-pack/templates/binary-release/bp-template.toml
+++ b/battery-packs/ci-battery-pack/templates/binary-release/bp-template.toml
@@ -1,0 +1,10 @@
+[placeholders.ci_platform]
+type = "select"
+prompt = "CI platform"
+options = ["github", "none"]
+default = "github"
+
+[placeholders.repo_owner]
+type = "string"
+prompt = "Repository owner (org or user)"
+default = "OWNER"

--- a/battery-packs/ci-battery-pack/templates/binary-release/cargo-bin-section.toml
+++ b/battery-packs/ci-battery-pack/templates/binary-release/cargo-bin-section.toml
@@ -1,0 +1,7 @@
+
+[[bin]]
+name = "{{ project_name }}"
+path = "src/main.rs"
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/{ name }-v{ version }/{ name }-{ target }-v{ version }{ archive-suffix }"

--- a/battery-packs/ci-battery-pack/templates/binary-release/src/main.rs
+++ b/battery-packs/ci-battery-pack/templates/binary-release/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello from {}!", env!("CARGO_PKG_NAME"));
+}

--- a/battery-packs/ci-battery-pack/templates/clippy-sarif/.github/workflows/clippy-sarif.yml
+++ b/battery-packs/ci-battery-pack/templates/clippy-sarif/.github/workflows/clippy-sarif.yml
@@ -1,0 +1,18 @@
+{%- if ci_platform == "github" -%}
+# Clippy with GitHub PR annotations via SARIF
+# https://github.com/psastras/sarif-rs
+name: Clippy SARIF
+
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+{% include "snippets/github/jobs/clippy-sarif.yml" %}
+{%- endif %}

--- a/battery-packs/ci-battery-pack/templates/clippy-sarif/bp-template.toml
+++ b/battery-packs/ci-battery-pack/templates/clippy-sarif/bp-template.toml
@@ -1,0 +1,10 @@
+[placeholders.ci_platform]
+type = "select"
+prompt = "CI platform"
+options = ["github", "none"]
+default = "github"
+
+[placeholders.repo_owner]
+type = "string"
+prompt = "Repository owner (org or user)"
+default = "OWNER"

--- a/battery-packs/ci-battery-pack/templates/full/.cargo/config.toml
+++ b/battery-packs/ci-battery-pack/templates/full/.cargo/config.toml
@@ -1,0 +1,3 @@
+{%- if all or xtask -%}
+{% include "templates/xtask/.cargo/config.toml" %}
+{% endif %}

--- a/battery-packs/ci-battery-pack/templates/full/.github/actions/rust-build/action.yml
+++ b/battery-packs/ci-battery-pack/templates/full/.github/actions/rust-build/action.yml
@@ -26,6 +26,8 @@ runs:
 
     - name: Test
       shell: bash
+      # For faster parallel test execution, consider nextest (https://nexte.st/).
+      # Note: nextest has non-standard behaviors — review before adopting.
       run: cargo test --verbose {% raw %}${{ inputs.flags }}{% endraw %}
 
     # cargo test doesn't run doctests with --no-run, run them separately

--- a/battery-packs/ci-battery-pack/templates/full/.github/actions/rust-build/action.yml
+++ b/battery-packs/ci-battery-pack/templates/full/.github/actions/rust-build/action.yml
@@ -27,7 +27,7 @@ runs:
     - name: Test
       shell: bash
       # For faster parallel test execution, consider nextest (https://nexte.st/).
-      # Note: nextest has non-standard behaviors — review before adopting.
+      # Note: nextest has non-standard behaviors. Review before adopting.
       run: cargo test --verbose {% raw %}${{ inputs.flags }}{% endraw %}
 
     # cargo test doesn't run doctests with --no-run, run them separately

--- a/battery-packs/ci-battery-pack/templates/full/.github/actions/rust-build/action.yml
+++ b/battery-packs/ci-battery-pack/templates/full/.github/actions/rust-build/action.yml
@@ -1,5 +1,5 @@
 {%- if ci_platform == "github" -%}
-name: Rust Build
+name: Rust Test
 description: Install toolchain, cache, build, and test a Rust project.
 
 inputs:
@@ -14,40 +14,22 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: dtolnay/rust-toolchain@master
+    - uses: {{ pin_github_action("dtolnay/rust-toolchain", "master") }}
       with:
         toolchain: {% raw %}${{ inputs.toolchain }}{% endraw %}
 
     - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
 
-    - uses: {{ pin_github_action("taiki-e/install-action", "v2") }}
-      with:
-        tool: nextest
-
-    # Remove Cargo.lock for non-stable toolchains so MSRV and nightly
-    # resolve fresh dependencies instead of using a lockfile pinned to stable.
-    - name: Remove Cargo.lock for non-stable
-      if: {% raw %}${{ inputs.toolchain != 'stable' }}{% endraw %}
-      shell: bash
-      run: rm -fv Cargo.lock
-
     - name: Build
       shell: bash
-      run: cargo build --verbose {% raw %}${{ inputs.flags }}{% endraw %}
+      run: cargo test --no-run --verbose {% raw %}${{ inputs.flags }}{% endraw %}
 
-    - name: Test (nextest)
+    - name: Test
       shell: bash
-      run: cargo nextest run --verbose {% raw %}${{ inputs.flags }}{% endraw %}
+      run: cargo test --verbose {% raw %}${{ inputs.flags }}{% endraw %}
 
-    - name: Test (doctests)
+    # cargo test doesn't run doctests with --no-run, run them separately
+    - name: Doctests
       shell: bash
       run: cargo test --doc --verbose {% raw %}${{ inputs.flags }}{% endraw %}
-
-    # Validate docs build on nightly with --cfg docsrs
-    - name: Check docs (nightly only)
-      if: {% raw %}${{ inputs.toolchain == 'nightly' && inputs.flags == '--all-features' }}{% endraw %}
-      shell: bash
-      env:
-        RUSTDOCFLAGS: "-D warnings --cfg docsrs"
-      run: cargo doc --verbose --no-deps {% raw %}${{ inputs.flags }}{% endraw %}
 {%- endif %}

--- a/battery-packs/ci-battery-pack/templates/full/.github/actions/rust-build/action.yml
+++ b/battery-packs/ci-battery-pack/templates/full/.github/actions/rust-build/action.yml
@@ -1,0 +1,53 @@
+{%- if ci_platform == "github" -%}
+name: Rust Build
+description: Install toolchain, cache, build, and test a Rust project.
+
+inputs:
+  toolchain:
+    description: Rust toolchain to install (e.g. stable, nightly, 1.80.0)
+    required: true
+  flags:
+    description: Cargo flags (e.g. --all-features, --no-default-features)
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: {% raw %}${{ inputs.toolchain }}{% endraw %}
+
+    - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
+
+    - uses: {{ pin_github_action("taiki-e/install-action", "v2") }}
+      with:
+        tool: nextest
+
+    # Remove Cargo.lock for non-stable toolchains so MSRV and nightly
+    # resolve fresh dependencies instead of using a lockfile pinned to stable.
+    - name: Remove Cargo.lock for non-stable
+      if: {% raw %}${{ inputs.toolchain != 'stable' }}{% endraw %}
+      shell: bash
+      run: rm -fv Cargo.lock
+
+    - name: Build
+      shell: bash
+      run: cargo build --verbose {% raw %}${{ inputs.flags }}{% endraw %}
+
+    - name: Test (nextest)
+      shell: bash
+      run: cargo nextest run --verbose {% raw %}${{ inputs.flags }}{% endraw %}
+
+    - name: Test (doctests)
+      shell: bash
+      run: cargo test --doc --verbose {% raw %}${{ inputs.flags }}{% endraw %}
+
+    # Validate docs build on nightly with --cfg docsrs
+    - name: Check docs (nightly only)
+      if: {% raw %}${{ inputs.toolchain == 'nightly' && inputs.flags == '--all-features' }}{% endraw %}
+      shell: bash
+      env:
+        RUSTDOCFLAGS: "-D warnings --cfg docsrs"
+      run: cargo doc --verbose --no-deps {% raw %}${{ inputs.flags }}{% endraw %}
+{%- endif %}

--- a/battery-packs/ci-battery-pack/templates/full/.github/actions/rust-build/action.yml
+++ b/battery-packs/ci-battery-pack/templates/full/.github/actions/rust-build/action.yml
@@ -19,6 +19,8 @@ runs:
         toolchain: {% raw %}${{ inputs.toolchain }}{% endraw %}
 
     - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
+      with:
+        save-if: {% raw %}${{ github.ref == 'refs/heads/main' }}{% endraw %}
 
     - name: Build
       shell: bash

--- a/battery-packs/ci-battery-pack/templates/full/.github/dependabot.yml
+++ b/battery-packs/ci-battery-pack/templates/full/.github/dependabot.yml
@@ -1,0 +1,18 @@
+{%- if ci_platform == "github" -%}
+# https://docs.github.com/en/code-security/dependabot
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      # Cargo resolves compatible versions automatically.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+{%- endif %}

--- a/battery-packs/ci-battery-pack/templates/full/.github/workflows/audit.yml
+++ b/battery-packs/ci-battery-pack/templates/full/.github/workflows/audit.yml
@@ -1,4 +1,5 @@
 {%- if ci_platform == "github" -%}
+# https://embarkstudios.github.io/cargo-deny/
 name: Audit
 
 on:

--- a/battery-packs/ci-battery-pack/templates/full/.github/workflows/audit.yml
+++ b/battery-packs/ci-battery-pack/templates/full/.github/workflows/audit.yml
@@ -13,11 +13,26 @@ permissions:
   contents: read
 
 jobs:
-  audit:
+  # Advisories are non-blocking: new advisories shouldn't break CI for unrelated PRs
+  advisories:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: {{ pin_github_action("actions/checkout", "v6") }}
+        with:
+          persist-credentials: false
+      - uses: {{ pin_github_action("EmbarkStudios/cargo-deny-action", "v2") }}
+        with:
+          command: check advisories
+
+  # Licenses, bans, and sources are blocking: these are the user's responsibility
+  deny:
     runs-on: ubuntu-latest
     steps:
       - uses: {{ pin_github_action("actions/checkout", "v6") }}
         with:
           persist-credentials: false
       - uses: {{ pin_github_action("EmbarkStudios/cargo-deny-action", "v2") }}
+        with:
+          command: check bans licenses sources
 {%- endif %}

--- a/battery-packs/ci-battery-pack/templates/full/.github/workflows/audit.yml
+++ b/battery-packs/ci-battery-pack/templates/full/.github/workflows/audit.yml
@@ -17,5 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: {{ pin_github_action("actions/checkout", "v6") }}
+        with:
+          persist-credentials: false
       - uses: {{ pin_github_action("EmbarkStudios/cargo-deny-action", "v2") }}
 {%- endif %}

--- a/battery-packs/ci-battery-pack/templates/full/.github/workflows/audit.yml
+++ b/battery-packs/ci-battery-pack/templates/full/.github/workflows/audit.yml
@@ -1,0 +1,20 @@
+{%- if ci_platform == "github" -%}
+name: Audit
+
+on:
+  push:
+    paths: ["**/Cargo.toml", "**/Cargo.lock"]
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: {{ pin_github_action("actions/checkout", "v6") }}
+      - uses: {{ pin_github_action("EmbarkStudios/cargo-deny-action", "v2") }}
+{%- endif %}

--- a/battery-packs/ci-battery-pack/templates/full/.github/workflows/build-binaries.yml
+++ b/battery-packs/ci-battery-pack/templates/full/.github/workflows/build-binaries.yml
@@ -1,0 +1,3 @@
+{%- if all or binary_release -%}
+{% include "templates/binary-release/.github/workflows/build-binaries.yml" %}
+{%- endif %}

--- a/battery-packs/ci-battery-pack/templates/full/.github/workflows/ci.yml
+++ b/battery-packs/ci-battery-pack/templates/full/.github/workflows/ci.yml
@@ -19,7 +19,9 @@ env:
 
 jobs:
 {% include "snippets/github/jobs/fmt.yml" %}
+{%- if not (all or clippy_sarif) %}
 {% include "snippets/github/jobs/clippy.yml" %}
+{%- endif %}
 {% include "snippets/github/jobs/warnings.yml" %}
 {% include "snippets/github/jobs/docsrs.yml" %}
 {% include "snippets/github/jobs/build.yml" %}

--- a/battery-packs/ci-battery-pack/templates/full/.github/workflows/ci.yml
+++ b/battery-packs/ci-battery-pack/templates/full/.github/workflows/ci.yml
@@ -15,12 +15,13 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  RUSTFLAGS: "-Dwarnings"
   CARGO_TERM_COLOR: always
 
 jobs:
 {% include "snippets/github/jobs/fmt.yml" %}
 {% include "snippets/github/jobs/clippy.yml" %}
+{% include "snippets/github/jobs/warnings.yml" %}
+{% include "snippets/github/jobs/docsrs.yml" %}
 {% include "snippets/github/jobs/build.yml" %}
 {% include "snippets/github/jobs/features.yml" %}
 {% include "snippets/github/jobs/msrv.yml" %}

--- a/battery-packs/ci-battery-pack/templates/full/.github/workflows/ci.yml
+++ b/battery-packs/ci-battery-pack/templates/full/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
 {%- endif -%}
 {%- if all or mutation_testing %}
 {% include "snippets/github/jobs/mutants.yml" %}
+{%- endif -%}
+{%- if all or clippy_sarif %}
+{% include "snippets/github/jobs/clippy-sarif.yml" %}
 {%- endif %}
 {% include "snippets/github/ci-pass.yml" %}
 {%- endif %}

--- a/battery-packs/ci-battery-pack/templates/full/.github/workflows/ci.yml
+++ b/battery-packs/ci-battery-pack/templates/full/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
 {% include "snippets/github/jobs/build.yml" %}
 {% include "snippets/github/jobs/features.yml" %}
 {% include "snippets/github/jobs/msrv.yml" %}
+{% include "snippets/github/jobs/lockfile.yml" %}
+{% include "snippets/github/jobs/minimal-versions.yml" %}
 {% include "snippets/github/jobs/semver.yml" %}
 {%- if all or benchmarks %}
 {% include "snippets/github/jobs/bench.yml" %}

--- a/battery-packs/ci-battery-pack/templates/full/.github/workflows/ci.yml
+++ b/battery-packs/ci-battery-pack/templates/full/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+{%- if ci_platform == "github" -%}
+name: CI
+
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: {% raw %}${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}{% endraw %}
+  cancel-in-progress: true
+
+env:
+  RUSTFLAGS: "-Dwarnings"
+  CARGO_TERM_COLOR: always
+
+jobs:
+{% include "snippets/github/jobs/fmt.yml" %}
+{% include "snippets/github/jobs/clippy.yml" %}
+{% include "snippets/github/jobs/build.yml" %}
+{% include "snippets/github/jobs/features.yml" %}
+{% include "snippets/github/jobs/msrv.yml" %}
+{% include "snippets/github/jobs/semver.yml" %}
+{%- if all or benchmarks %}
+{% include "snippets/github/jobs/bench.yml" %}
+{%- endif -%}
+{%- if all or fuzzing %}
+{% include "snippets/github/jobs/fuzz-smoke.yml" %}
+{%- endif -%}
+{%- if all or stress_tests %}
+{% include "snippets/github/jobs/stress-test.yml" %}
+{%- endif -%}
+{%- if all or spellcheck %}
+{% include "snippets/github/jobs/spellcheck.yml" %}
+{%- endif -%}
+{%- if all or xtask %}
+{% include "snippets/github/jobs/xtask.yml" %}
+{%- endif %}
+{% include "snippets/github/ci-pass.yml" %}
+{%- endif %}

--- a/battery-packs/ci-battery-pack/templates/full/.github/workflows/ci.yml
+++ b/battery-packs/ci-battery-pack/templates/full/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
 {%- endif -%}
 {%- if all or xtask %}
 {% include "snippets/github/jobs/xtask.yml" %}
+{%- endif -%}
+{%- if all or mutation_testing %}
+{% include "snippets/github/jobs/mutants.yml" %}
 {%- endif %}
 {% include "snippets/github/ci-pass.yml" %}
 {%- endif %}

--- a/battery-packs/ci-battery-pack/templates/full/.github/workflows/fuzz-nightly.yml
+++ b/battery-packs/ci-battery-pack/templates/full/.github/workflows/fuzz-nightly.yml
@@ -1,0 +1,3 @@
+{%- if all or fuzzing %}
+{% include "templates/fuzzing/.github/workflows/fuzz-nightly.yml" %}
+{%- endif %}

--- a/battery-packs/ci-battery-pack/templates/full/.github/workflows/mdbook.yml
+++ b/battery-packs/ci-battery-pack/templates/full/.github/workflows/mdbook.yml
@@ -1,0 +1,3 @@
+{%- if all or mdbook %}
+{% include "templates/mdbook/.github/workflows/mdbook.yml" %}
+{%- endif %}

--- a/battery-packs/ci-battery-pack/templates/full/.github/workflows/release.yml
+++ b/battery-packs/ci-battery-pack/templates/full/.github/workflows/release.yml
@@ -1,0 +1,3 @@
+{%- if all or trusted_publishing -%}
+{% include "templates/trusted-publishing/.github/workflows/release.yml" %}
+{%- endif %}

--- a/battery-packs/ci-battery-pack/templates/full/.github/workflows/rust-next.yml
+++ b/battery-packs/ci-battery-pack/templates/full/.github/workflows/rust-next.yml
@@ -1,0 +1,40 @@
+{%- if ci_platform == "github" -%}
+# Non-blocking canary: checks latest dependency versions and beta/nightly Rust.
+# Failures here are informational, not blocking.
+# https://github.com/epage/_rust/blob/main/.github/workflows/rust-next.yml
+name: rust-next
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  latest-deps:
+    name: Latest dependencies
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: {{ pin_github_action("actions/checkout", "v6") }}
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
+      - run: cargo update
+      - run: cargo test --workspace --all-features
+
+  beta:
+    name: Beta Rust
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: {{ pin_github_action("actions/checkout", "v6") }}
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@beta
+      - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
+      - run: cargo test --workspace --all-features
+{%- endif %}

--- a/battery-packs/ci-battery-pack/templates/full/.github/workflows/rust-next.yml
+++ b/battery-packs/ci-battery-pack/templates/full/.github/workflows/rust-next.yml
@@ -23,6 +23,8 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
+        with:
+          save-if: {% raw %}${{ github.ref == 'refs/heads/main' }}{% endraw %}
       - run: cargo update
       - run: cargo test --workspace --all-features
 
@@ -36,5 +38,7 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@beta
       - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
+        with:
+          save-if: {% raw %}${{ github.ref == 'refs/heads/main' }}{% endraw %}
       - run: cargo test --workspace --all-features
 {%- endif %}

--- a/battery-packs/ci-battery-pack/templates/full/.github/workflows/stress-test.yml
+++ b/battery-packs/ci-battery-pack/templates/full/.github/workflows/stress-test.yml
@@ -1,0 +1,3 @@
+{%- if all or stress_tests %}
+{% include "templates/stress-test/.github/workflows/stress-test.yml" %}
+{%- endif %}

--- a/battery-packs/ci-battery-pack/templates/full/Cargo.toml
+++ b/battery-packs/ci-battery-pack/templates/full/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "{{ project_name }}"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 rust-version = "{{ rust_stable_version() }}"
 description = "{{ description }}"
 license = "MIT OR Apache-2.0"
@@ -21,10 +21,7 @@ name = "example_bench"
 harness = false
 {% endif %}
 {% if all or binary_release %}
-
-[[bin]]
-name = "{{ project_name }}"
-path = "src/main.rs"
+{% include "templates/binary-release/cargo-bin-section.toml" %}
 {% endif %}
 
 [package.metadata.battery-pack]

--- a/battery-packs/ci-battery-pack/templates/full/Cargo.toml
+++ b/battery-packs/ci-battery-pack/templates/full/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "{{ project_name }}"
+version = "0.1.0"
+edition = "2021"
+rust-version = "{{ rust_stable_version() }}"
+description = "{{ description }}"
+license = "MIT OR Apache-2.0"
+repository = "{% if repository %}{{ repository }}{% else %}https://github.com/{{ repo_owner }}/{{ project_name }}{% endif %}"
+{% if all or xtask %}
+
+[workspace]
+members = [".", "xtask"]
+{% endif %}
+{% if all or benchmarks %}
+
+[dev-dependencies]
+criterion.bp-managed = true
+
+[[bench]]
+name = "example_bench"
+harness = false
+{% endif %}
+{% if all or binary_release %}
+
+[[bin]]
+name = "{{ project_name }}"
+path = "src/main.rs"
+{% endif %}
+
+[package.metadata.battery-pack]
+ci-battery-pack = { features = ["benchmarks"] }

--- a/battery-packs/ci-battery-pack/templates/full/README.md
+++ b/battery-packs/ci-battery-pack/templates/full/README.md
@@ -1,0 +1,16 @@
+# {{ project_name }}
+
+[![CI](https://github.com/{{ repo_owner }}/{{ project_name }}/actions/workflows/ci.yml/badge.svg)](https://github.com/{{ repo_owner }}/{{ project_name }}/actions/workflows/ci.yml)
+[![crates.io](https://img.shields.io/crates/v/{{ project_name }}.svg)](https://crates.io/crates/{{ project_name }})
+[![docs.rs](https://docs.rs/{{ project_name }}/badge.svg)](https://docs.rs/{{ project_name }})
+
+{{ description }}
+
+## License
+
+Licensed under either of:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+
+at your option.

--- a/battery-packs/ci-battery-pack/templates/full/_typos.toml
+++ b/battery-packs/ci-battery-pack/templates/full/_typos.toml
@@ -1,0 +1,3 @@
+{%- if all or spellcheck -%}
+{% include "templates/spellcheck/_typos.toml" %}
+{% endif %}

--- a/battery-packs/ci-battery-pack/templates/full/benches/example_bench.rs
+++ b/battery-packs/ci-battery-pack/templates/full/benches/example_bench.rs
@@ -1,0 +1,3 @@
+{%- if all or benchmarks -%}
+{% include "templates/benchmarks/benches/example_bench.rs" %}
+{% endif %}

--- a/battery-packs/ci-battery-pack/templates/full/book.toml
+++ b/battery-packs/ci-battery-pack/templates/full/book.toml
@@ -1,0 +1,3 @@
+{%- if all or mdbook -%}
+{% include "templates/mdbook/book.toml" %}
+{% endif %}

--- a/battery-packs/ci-battery-pack/templates/full/bp-template.toml
+++ b/battery-packs/ci-battery-pack/templates/full/bp-template.toml
@@ -64,6 +64,11 @@ type = "bool"
 prompt = "Include mutation testing (cargo-mutants)?"
 default = "false"
 
+[placeholders.clippy_sarif]
+type = "bool"
+prompt = "Include clippy SARIF integration (PR annotations)?"
+default = "false"
+
 [placeholders.repository]
 type = "string"
 prompt = "Repository URL (leave empty for GitHub default)"

--- a/battery-packs/ci-battery-pack/templates/full/bp-template.toml
+++ b/battery-packs/ci-battery-pack/templates/full/bp-template.toml
@@ -59,6 +59,11 @@ type = "bool"
 prompt = "Include cross-platform binary builds (GitHub Releases + cargo-binstall)?"
 default = "false"
 
+[placeholders.mutation_testing]
+type = "bool"
+prompt = "Include mutation testing (cargo-mutants)?"
+default = "false"
+
 [placeholders.repository]
 type = "string"
 prompt = "Repository URL (leave empty for GitHub default)"

--- a/battery-packs/ci-battery-pack/templates/full/bp-template.toml
+++ b/battery-packs/ci-battery-pack/templates/full/bp-template.toml
@@ -14,11 +14,6 @@ type = "string"
 prompt = "Project description"
 default = "TODO: add description"
 
-[placeholders.repository]
-type = "string"
-prompt = "Repository URL (leave empty for GitHub default)"
-default = ""
-
 [placeholders.all]
 type = "bool"
 prompt = "Enable all optional features?"
@@ -63,3 +58,8 @@ default = "false"
 type = "bool"
 prompt = "Include cross-platform binary builds (GitHub Releases + cargo-binstall)?"
 default = "false"
+
+[placeholders.repository]
+type = "string"
+prompt = "Repository URL (leave empty for GitHub default)"
+default = ""

--- a/battery-packs/ci-battery-pack/templates/full/bp-template.toml
+++ b/battery-packs/ci-battery-pack/templates/full/bp-template.toml
@@ -1,0 +1,65 @@
+[placeholders.ci_platform]
+type = "select"
+prompt = "CI platform"
+options = ["github", "none"]
+default = "github"
+
+[placeholders.repo_owner]
+type = "string"
+prompt = "Repository owner (org or user)"
+default = "OWNER"
+
+[placeholders.description]
+type = "string"
+prompt = "Project description"
+default = "TODO: add description"
+
+[placeholders.repository]
+type = "string"
+prompt = "Repository URL (leave empty for GitHub default)"
+default = ""
+
+[placeholders.all]
+type = "bool"
+prompt = "Enable all optional features?"
+default = "false"
+
+[placeholders.trusted_publishing]
+type = "bool"
+prompt = "Include trusted publishing (release-plz)?"
+default = "true"
+
+[placeholders.benchmarks]
+type = "bool"
+prompt = "Include benchmark CI (Criterion + Bencher)?"
+default = "false"
+
+[placeholders.fuzzing]
+type = "bool"
+prompt = "Include fuzz testing (cargo-fuzz)?"
+default = "false"
+
+[placeholders.stress_tests]
+type = "bool"
+prompt = "Include stress tests (nextest --stress-duration)?"
+default = "false"
+
+[placeholders.mdbook]
+type = "bool"
+prompt = "Include mdBook with GitHub Pages deployment?"
+default = "false"
+
+[placeholders.spellcheck]
+type = "bool"
+prompt = "Include spell checking (crate-ci/typos)?"
+default = "false"
+
+[placeholders.xtask]
+type = "bool"
+prompt = "Include cargo-xtask pattern?"
+default = "false"
+
+[placeholders.binary_release]
+type = "bool"
+prompt = "Include cross-platform binary builds (GitHub Releases + cargo-binstall)?"
+default = "false"

--- a/battery-packs/ci-battery-pack/templates/full/deny.toml
+++ b/battery-packs/ci-battery-pack/templates/full/deny.toml
@@ -1,0 +1,28 @@
+# https://embarkstudios.github.io/cargo-deny/
+
+[advisories]
+unmaintained = "workspace"
+yanked = "warn"
+
+[licenses]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-3.0",
+    "CC0-1.0",
+    "Zlib",
+    "MPL-2.0",
+]
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/battery-packs/ci-battery-pack/templates/full/fuzz/Cargo.toml
+++ b/battery-packs/ci-battery-pack/templates/full/fuzz/Cargo.toml
@@ -1,0 +1,3 @@
+{%- if all or fuzzing -%}
+{% include "templates/fuzzing/fuzz/Cargo.toml" %}
+{% endif %}

--- a/battery-packs/ci-battery-pack/templates/full/fuzz/fuzz_targets/fuzz_example.rs
+++ b/battery-packs/ci-battery-pack/templates/full/fuzz/fuzz_targets/fuzz_example.rs
@@ -1,0 +1,3 @@
+{%- if all or fuzzing -%}
+{% include "templates/fuzzing/fuzz/fuzz_targets/fuzz_example.rs" %}
+{% endif %}

--- a/battery-packs/ci-battery-pack/templates/full/md/SUMMARY.md
+++ b/battery-packs/ci-battery-pack/templates/full/md/SUMMARY.md
@@ -1,0 +1,3 @@
+{%- if all or mdbook -%}
+{% include "templates/mdbook/md/SUMMARY.md" %}
+{% endif %}

--- a/battery-packs/ci-battery-pack/templates/full/md/intro.md
+++ b/battery-packs/ci-battery-pack/templates/full/md/intro.md
@@ -1,0 +1,3 @@
+{%- if all or mdbook -%}
+{% include "templates/mdbook/md/intro.md" %}
+{% endif %}

--- a/battery-packs/ci-battery-pack/templates/full/release-plz.toml
+++ b/battery-packs/ci-battery-pack/templates/full/release-plz.toml
@@ -1,0 +1,3 @@
+{%- if all or trusted_publishing -%}
+{% include "templates/trusted-publishing/release-plz.toml" %}
+{%- endif %}

--- a/battery-packs/ci-battery-pack/templates/full/src/lib.rs
+++ b/battery-packs/ci-battery-pack/templates/full/src/lib.rs
@@ -1,0 +1,15 @@
+/// Stub library. Replace with your crate's code.
+pub fn add(left: u64, right: u64) -> u64 {
+    left.wrapping_add(right)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        assert_eq!(add(2, 2), 4);
+    }
+}
+

--- a/battery-packs/ci-battery-pack/templates/full/src/main.rs
+++ b/battery-packs/ci-battery-pack/templates/full/src/main.rs
@@ -1,0 +1,5 @@
+{%- if all or binary_release -%}
+fn main() {
+    println!("Hello from {}!", env!("CARGO_PKG_NAME"));
+}
+{% endif %}

--- a/battery-packs/ci-battery-pack/templates/full/xtask/Cargo.toml
+++ b/battery-packs/ci-battery-pack/templates/full/xtask/Cargo.toml
@@ -1,0 +1,3 @@
+{%- if all or xtask -%}
+{% include "templates/xtask/xtask/Cargo.toml" %}
+{% endif %}

--- a/battery-packs/ci-battery-pack/templates/full/xtask/src/main.rs
+++ b/battery-packs/ci-battery-pack/templates/full/xtask/src/main.rs
@@ -1,0 +1,3 @@
+{%- if all or xtask -%}
+{% include "templates/xtask/xtask/src/main.rs" %}
+{% endif %}

--- a/battery-packs/ci-battery-pack/templates/fuzzing/.github/workflows/fuzz-nightly.yml
+++ b/battery-packs/ci-battery-pack/templates/fuzzing/.github/workflows/fuzz-nightly.yml
@@ -1,0 +1,38 @@
+{%- if ci_platform == "github" -%}
+name: Fuzz (nightly)
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+    inputs:
+      duration:
+        description: "Fuzz duration per target in seconds"
+        default: "300"
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz-nightly:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: {{ pin_github_action("actions/checkout", "v6") }}
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
+        with:
+          workspaces: fuzz -> target
+      - uses: dtolnay/install@cargo-fuzz
+      - name: Extended fuzz run
+        run: |
+          duration={% raw %}${{ inputs.duration || '300' }}{% endraw %}
+          for target in $(cargo fuzz list); do
+            cargo fuzz run "$target" -- -max_total_time="$duration"
+          done
+      - name: Upload crash artifacts
+        if: failure()
+        uses: {{ pin_github_action("actions/upload-artifact", "v4") }}
+        with:
+          name: fuzz-crashes
+          path: fuzz/artifacts/
+{%- endif %}

--- a/battery-packs/ci-battery-pack/templates/fuzzing/.github/workflows/fuzz-nightly.yml
+++ b/battery-packs/ci-battery-pack/templates/fuzzing/.github/workflows/fuzz-nightly.yml
@@ -1,4 +1,5 @@
 {%- if ci_platform == "github" -%}
+# https://github.com/rust-fuzz/cargo-fuzz
 name: Fuzz (nightly)
 
 on:

--- a/battery-packs/ci-battery-pack/templates/fuzzing/.github/workflows/fuzz-nightly.yml
+++ b/battery-packs/ci-battery-pack/templates/fuzzing/.github/workflows/fuzz-nightly.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: {{ pin_github_action("actions/checkout", "v6") }}
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@nightly
       - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
         with:

--- a/battery-packs/ci-battery-pack/templates/fuzzing/.github/workflows/fuzz-nightly.yml
+++ b/battery-packs/ci-battery-pack/templates/fuzzing/.github/workflows/fuzz-nightly.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
       - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
         with:
+          save-if: {% raw %}${{ github.ref == 'refs/heads/main' }}{% endraw %}
           workspaces: fuzz -> target
       - uses: dtolnay/install@cargo-fuzz
       - name: Extended fuzz run

--- a/battery-packs/ci-battery-pack/templates/fuzzing/.github/workflows/fuzz-pr.yml
+++ b/battery-packs/ci-battery-pack/templates/fuzzing/.github/workflows/fuzz-pr.yml
@@ -1,0 +1,13 @@
+{%- if ci_platform == "github" -%}
+name: Fuzz (PR)
+
+on:
+  pull_request:
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+{% include "snippets/github/jobs/fuzz-smoke.yml" %}
+{%- endif %}

--- a/battery-packs/ci-battery-pack/templates/fuzzing/bp-template.toml
+++ b/battery-packs/ci-battery-pack/templates/fuzzing/bp-template.toml
@@ -1,0 +1,10 @@
+[placeholders.ci_platform]
+type = "select"
+prompt = "CI platform"
+options = ["github", "none"]
+default = "github"
+
+[placeholders.repo_owner]
+type = "string"
+prompt = "Repository owner (org or user)"
+default = "OWNER"

--- a/battery-packs/ci-battery-pack/templates/fuzzing/fuzz/Cargo.toml
+++ b/battery-packs/ci-battery-pack/templates/fuzzing/fuzz/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "{{ crate_name }}-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys.bp-managed = true
+arbitrary.bp-managed = true
+{{ project_name }} = { path = ".." }
+
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "fuzz_example"
+path = "fuzz_targets/fuzz_example.rs"
+doc = false
+
+[package.metadata.battery-pack]
+ci-battery-pack = { features = ["fuzzing"] }

--- a/battery-packs/ci-battery-pack/templates/fuzzing/fuzz/Cargo.toml
+++ b/battery-packs/ci-battery-pack/templates/fuzzing/fuzz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "{{ crate_name }}-fuzz"
 version = "0.0.0"
 publish = false
-edition = "2021"
+edition = "2024"
 
 [package.metadata]
 cargo-fuzz = true

--- a/battery-packs/ci-battery-pack/templates/fuzzing/fuzz/fuzz_targets/fuzz_example.rs
+++ b/battery-packs/ci-battery-pack/templates/fuzzing/fuzz/fuzz_targets/fuzz_example.rs
@@ -1,0 +1,15 @@
+#![no_main]
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use {{ crate_name }}::add;
+
+#[derive(Debug, Arbitrary)]
+struct FuzzInput {
+    left: u64,
+    right: u64,
+}
+
+fuzz_target!(|input: FuzzInput| {
+    // TODO: Replace with your crate's API.
+    let _ = add(input.left, input.right);
+});

--- a/battery-packs/ci-battery-pack/templates/mdbook/.github/workflows/mdbook.yml
+++ b/battery-packs/ci-battery-pack/templates/mdbook/.github/workflows/mdbook.yml
@@ -1,5 +1,6 @@
 {%- if ci_platform == "github" -%}
 {%- if ci_platform == "github" -%}
+# https://rust-lang.github.io/mdBook/
 name: Deploy mdBook
 
 on:

--- a/battery-packs/ci-battery-pack/templates/mdbook/.github/workflows/mdbook.yml
+++ b/battery-packs/ci-battery-pack/templates/mdbook/.github/workflows/mdbook.yml
@@ -1,0 +1,48 @@
+{%- if ci_platform == "github" -%}
+{%- if ci_platform == "github" -%}
+name: Deploy mdBook
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    if: {% raw %}${{ github.repository_owner == '{% endraw %}{{ repo_owner }}{% raw %}' }}{% endraw %}
+    runs-on: ubuntu-latest
+    env:
+      MDBOOK_VERSION: "0.4.40"
+    steps:
+      - uses: {{ pin_github_action("actions/checkout", "v6") }}
+      - name: Install mdBook
+        run: |
+          curl -sSL "https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+            | tar -xz -C /usr/local/bin
+      - uses: {{ pin_github_action("actions/configure-pages", "v5") }}
+      - run: mdbook build
+      - uses: {{ pin_github_action("actions/upload-pages-artifact", "v3") }}
+        with:
+          path: ./book
+
+  deploy:
+    if: {% raw %}${{ github.repository_owner == '{% endraw %}{{ repo_owner }}{% raw %}' }}{% endraw %}
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: {% raw %}${{ steps.deployment.outputs.page_url }}{% endraw %}
+    steps:
+      - id: deployment
+        uses: {{ pin_github_action("actions/deploy-pages", "v4") }}
+{%- endif %}
+{%- endif %}

--- a/battery-packs/ci-battery-pack/templates/mdbook/.github/workflows/mdbook.yml
+++ b/battery-packs/ci-battery-pack/templates/mdbook/.github/workflows/mdbook.yml
@@ -25,6 +25,8 @@ jobs:
       MDBOOK_VERSION: "0.4.40"
     steps:
       - uses: {{ pin_github_action("actions/checkout", "v6") }}
+        with:
+          persist-credentials: false
       - name: Install mdBook
         run: |
           curl -sSL "https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \

--- a/battery-packs/ci-battery-pack/templates/mdbook/book.toml
+++ b/battery-packs/ci-battery-pack/templates/mdbook/book.toml
@@ -1,0 +1,6 @@
+[book]
+title = "{{ project_name }}"
+language = "en"
+src = "md"
+
+[output.html]

--- a/battery-packs/ci-battery-pack/templates/mdbook/bp-template.toml
+++ b/battery-packs/ci-battery-pack/templates/mdbook/bp-template.toml
@@ -1,0 +1,10 @@
+[placeholders.ci_platform]
+type = "select"
+prompt = "CI platform"
+options = ["github", "none"]
+default = "github"
+
+[placeholders.repo_owner]
+type = "string"
+prompt = "Repository owner (org or user)"
+default = "OWNER"

--- a/battery-packs/ci-battery-pack/templates/mdbook/md/SUMMARY.md
+++ b/battery-packs/ci-battery-pack/templates/mdbook/md/SUMMARY.md
@@ -1,0 +1,3 @@
+# Summary
+
+- [Introduction](./intro.md)

--- a/battery-packs/ci-battery-pack/templates/mdbook/md/intro.md
+++ b/battery-packs/ci-battery-pack/templates/mdbook/md/intro.md
@@ -1,0 +1,3 @@
+# {{ project_name }}
+
+Welcome to the {{ project_name }} documentation.

--- a/battery-packs/ci-battery-pack/templates/mutation-testing/.github/workflows/mutants.yml
+++ b/battery-packs/ci-battery-pack/templates/mutation-testing/.github/workflows/mutants.yml
@@ -1,0 +1,17 @@
+{%- if ci_platform == "github" -%}
+# cargo-mutants: find code not covered by tests
+# https://mutants.rs/
+name: Mutation Testing
+
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+{% include "snippets/github/jobs/mutants.yml" %}
+{%- endif %}

--- a/battery-packs/ci-battery-pack/templates/mutation-testing/bp-template.toml
+++ b/battery-packs/ci-battery-pack/templates/mutation-testing/bp-template.toml
@@ -1,0 +1,10 @@
+[placeholders.ci_platform]
+type = "select"
+prompt = "CI platform"
+options = ["github", "none"]
+default = "github"
+
+[placeholders.repo_owner]
+type = "string"
+prompt = "Repository owner (org or user)"
+default = "OWNER"

--- a/battery-packs/ci-battery-pack/templates/spellcheck/.github/workflows/typos.yml
+++ b/battery-packs/ci-battery-pack/templates/spellcheck/.github/workflows/typos.yml
@@ -1,0 +1,15 @@
+{%- if ci_platform == "github" -%}
+name: Typos
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+{% include "snippets/github/jobs/spellcheck.yml" %}
+{%- endif %}

--- a/battery-packs/ci-battery-pack/templates/spellcheck/_typos.toml
+++ b/battery-packs/ci-battery-pack/templates/spellcheck/_typos.toml
@@ -1,0 +1,5 @@
+# https://github.com/crate-ci/typos
+[default.extend-words]
+
+[files]
+extend-exclude = ["*.lock"]

--- a/battery-packs/ci-battery-pack/templates/spellcheck/bp-template.toml
+++ b/battery-packs/ci-battery-pack/templates/spellcheck/bp-template.toml
@@ -1,0 +1,10 @@
+[placeholders.ci_platform]
+type = "select"
+prompt = "CI platform"
+options = ["github", "none"]
+default = "github"
+
+[placeholders.repo_owner]
+type = "string"
+prompt = "Repository owner (org or user)"
+default = "OWNER"

--- a/battery-packs/ci-battery-pack/templates/stress-test/.github/workflows/stress-test.yml
+++ b/battery-packs/ci-battery-pack/templates/stress-test/.github/workflows/stress-test.yml
@@ -1,4 +1,5 @@
 {%- if ci_platform == "github" -%}
+# https://nexte.st/ (--stress-duration)
 name: Stress Test
 
 on:

--- a/battery-packs/ci-battery-pack/templates/stress-test/.github/workflows/stress-test.yml
+++ b/battery-packs/ci-battery-pack/templates/stress-test/.github/workflows/stress-test.yml
@@ -24,6 +24,8 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
+        with:
+          save-if: {% raw %}${{ github.ref == 'refs/heads/main' }}{% endraw %}
       - uses: {{ pin_github_action("taiki-e/install-action", "v2") }}
         with:
           tool: nextest

--- a/battery-packs/ci-battery-pack/templates/stress-test/.github/workflows/stress-test.yml
+++ b/battery-packs/ci-battery-pack/templates/stress-test/.github/workflows/stress-test.yml
@@ -1,0 +1,28 @@
+{%- if ci_platform == "github" -%}
+name: Stress Test
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+    inputs:
+      duration_minutes:
+        description: "Stress test duration in minutes"
+        default: "60"
+
+permissions:
+  contents: read
+
+jobs:
+  stress-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
+    steps:
+      - uses: {{ pin_github_action("actions/checkout", "v6") }}
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
+      - uses: {{ pin_github_action("taiki-e/install-action", "v2") }}
+        with:
+          tool: nextest
+      - run: cargo nextest run --all-features --stress-duration '{% raw %}${{ inputs.duration_minutes || '60' }}{% endraw %}m'
+{%- endif %}

--- a/battery-packs/ci-battery-pack/templates/stress-test/.github/workflows/stress-test.yml
+++ b/battery-packs/ci-battery-pack/templates/stress-test/.github/workflows/stress-test.yml
@@ -20,6 +20,8 @@ jobs:
     timeout-minutes: 75
     steps:
       - uses: {{ pin_github_action("actions/checkout", "v6") }}
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: {{ pin_github_action("Swatinem/rust-cache", "v2") }}
       - uses: {{ pin_github_action("taiki-e/install-action", "v2") }}

--- a/battery-packs/ci-battery-pack/templates/stress-test/bp-template.toml
+++ b/battery-packs/ci-battery-pack/templates/stress-test/bp-template.toml
@@ -1,0 +1,10 @@
+[placeholders.ci_platform]
+type = "select"
+prompt = "CI platform"
+options = ["github", "none"]
+default = "github"
+
+[placeholders.repo_owner]
+type = "string"
+prompt = "Repository owner (org or user)"
+default = "OWNER"

--- a/battery-packs/ci-battery-pack/templates/trusted-publishing/.github/workflows/release.yml
+++ b/battery-packs/ci-battery-pack/templates/trusted-publishing/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+{%- if ci_platform == "github" -%}
+name: Release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
+jobs:
+  release-plz-release:
+    if: {% raw %}${{ github.repository_owner == '{% endraw %}{{ repo_owner }}{% raw %}' }}{% endraw %}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: {{ pin_github_action("actions/checkout", "v6") }}
+        with:
+          fetch-depth: 0
+{%- if all or binary_release %}
+          token: {% raw %}${{ secrets.RELEASE_PLZ_TOKEN }}{% endraw %}
+{%- endif %}
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: {{ pin_github_action("rust-lang/crates-io-auth-action", "v1") }}
+      - uses: {{ pin_github_action("release-plz/action", "v0") }}
+        with:
+          command: release
+        env:
+{%- if all or binary_release %}
+          GITHUB_TOKEN: {% raw %}${{ secrets.RELEASE_PLZ_TOKEN }}{% endraw %}
+{%- else %}
+          GITHUB_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
+{%- endif %}
+
+  release-plz-pr:
+    if: {% raw %}${{ !failure() && github.repository_owner == '{% endraw %}{{ repo_owner }}{% raw %}' }}{% endraw %}
+    needs: release-plz-release
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-plz-{% raw %}${{ github.ref }}{% endraw %}
+      cancel-in-progress: false
+    steps:
+      - uses: {{ pin_github_action("actions/checkout", "v6") }}
+        with:
+          fetch-depth: 0
+{%- if all or binary_release %}
+          token: {% raw %}${{ secrets.RELEASE_PLZ_TOKEN }}{% endraw %}
+{%- endif %}
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: {{ pin_github_action("release-plz/action", "v0") }}
+        with:
+          command: release-pr
+        env:
+{%- if all or binary_release %}
+          GITHUB_TOKEN: {% raw %}${{ secrets.RELEASE_PLZ_TOKEN }}{% endraw %}
+{%- else %}
+          GITHUB_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
+{%- endif %}
+{%- endif %}

--- a/battery-packs/ci-battery-pack/templates/trusted-publishing/.github/workflows/release.yml
+++ b/battery-packs/ci-battery-pack/templates/trusted-publishing/.github/workflows/release.yml
@@ -1,4 +1,9 @@
 {%- if ci_platform == "github" -%}
+# release-plz: automated releases to crates.io (https://release-plz.dev/docs)
+# Setup: configure trusted publishing on crates.io
+#   https://doc.rust-lang.org/cargo/reference/registry-authentication.html#trusted-publishing
+# If using binary_release, also add a RELEASE_PLZ_TOKEN PAT (contents + pull-requests: write)
+#   https://github.com/settings/personal-access-tokens/new
 name: Release
 
 on:

--- a/battery-packs/ci-battery-pack/templates/trusted-publishing/.github/workflows/release.yml
+++ b/battery-packs/ci-battery-pack/templates/trusted-publishing/.github/workflows/release.yml
@@ -9,7 +9,6 @@ name: Release
 on:
   push:
     branches: [main]
-  workflow_dispatch:
 
 permissions:
   contents: write

--- a/battery-packs/ci-battery-pack/templates/trusted-publishing/.github/workflows/release.yml
+++ b/battery-packs/ci-battery-pack/templates/trusted-publishing/.github/workflows/release.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   release-plz-release:
-    if: {% raw %}${{ github.repository_owner == '{% endraw %}{{ repo_owner }}{% raw %}' && !contains(github.event.head_commit.message, 'chore: release') }}{% endraw %}
+    if: {% raw %}${{ github.repository_owner == '{% endraw %}{{ repo_owner }}{% raw %}' }}{% endraw %}
     runs-on: ubuntu-latest
     steps:
       - uses: {{ pin_github_action("actions/checkout", "v6") }}
@@ -35,7 +35,7 @@ jobs:
 {%- endif %}
 
   release-plz-pr:
-    if: {% raw %}${{ !failure() && github.repository_owner == '{% endraw %}{{ repo_owner }}{% raw %}' && !contains(github.event.head_commit.message, 'chore: release') }}{% endraw %}
+    if: {% raw %}${{ !failure() && github.repository_owner == '{% endraw %}{{ repo_owner }}{% raw %}' }}{% endraw %}
     needs: release-plz-release
     runs-on: ubuntu-latest
     concurrency:

--- a/battery-packs/ci-battery-pack/templates/trusted-publishing/.github/workflows/release.yml
+++ b/battery-packs/ci-battery-pack/templates/trusted-publishing/.github/workflows/release.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   release-plz-release:
-    if: {% raw %}${{ github.repository_owner == '{% endraw %}{{ repo_owner }}{% raw %}' }}{% endraw %}
+    if: {% raw %}${{ github.repository_owner == '{% endraw %}{{ repo_owner }}{% raw %}' && !contains(github.event.head_commit.message, 'chore: release') }}{% endraw %}
     runs-on: ubuntu-latest
     steps:
       - uses: {{ pin_github_action("actions/checkout", "v6") }}
@@ -35,7 +35,7 @@ jobs:
 {%- endif %}
 
   release-plz-pr:
-    if: {% raw %}${{ !failure() && github.repository_owner == '{% endraw %}{{ repo_owner }}{% raw %}' }}{% endraw %}
+    if: {% raw %}${{ !failure() && github.repository_owner == '{% endraw %}{{ repo_owner }}{% raw %}' && !contains(github.event.head_commit.message, 'chore: release') }}{% endraw %}
     needs: release-plz-release
     runs-on: ubuntu-latest
     concurrency:
@@ -45,17 +45,10 @@ jobs:
       - uses: {{ pin_github_action("actions/checkout", "v6") }}
         with:
           fetch-depth: 0
-{%- if all or binary_release %}
-          token: {% raw %}${{ secrets.RELEASE_PLZ_TOKEN }}{% endraw %}
-{%- endif %}
       - uses: dtolnay/rust-toolchain@stable
       - uses: {{ pin_github_action("release-plz/action", "v0") }}
         with:
           command: release-pr
         env:
-{%- if all or binary_release %}
-          GITHUB_TOKEN: {% raw %}${{ secrets.RELEASE_PLZ_TOKEN }}{% endraw %}
-{%- else %}
           GITHUB_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
-{%- endif %}
 {%- endif %}

--- a/battery-packs/ci-battery-pack/templates/trusted-publishing/bp-template.toml
+++ b/battery-packs/ci-battery-pack/templates/trusted-publishing/bp-template.toml
@@ -1,0 +1,10 @@
+[placeholders.ci_platform]
+type = "select"
+prompt = "CI platform"
+options = ["github", "none"]
+default = "github"
+
+[placeholders.repo_owner]
+type = "string"
+prompt = "Repository owner (org or user)"
+default = "OWNER"

--- a/battery-packs/ci-battery-pack/templates/trusted-publishing/release-plz.toml
+++ b/battery-packs/ci-battery-pack/templates/trusted-publishing/release-plz.toml
@@ -1,0 +1,5 @@
+# https://release-plz.dev/docs/config
+
+[workspace]
+git_release_enable = true
+changelog_update = true

--- a/battery-packs/ci-battery-pack/templates/xtask/.cargo/config.toml
+++ b/battery-packs/ci-battery-pack/templates/xtask/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --package xtask --bin xtask --"

--- a/battery-packs/ci-battery-pack/templates/xtask/.github/workflows/xtask.yml
+++ b/battery-packs/ci-battery-pack/templates/xtask/.github/workflows/xtask.yml
@@ -1,0 +1,15 @@
+{%- if ci_platform == "github" -%}
+name: Xtask
+
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+{% include "snippets/github/jobs/xtask.yml" %}
+{%- endif %}

--- a/battery-packs/ci-battery-pack/templates/xtask/bp-template.toml
+++ b/battery-packs/ci-battery-pack/templates/xtask/bp-template.toml
@@ -1,0 +1,10 @@
+[placeholders.ci_platform]
+type = "select"
+prompt = "CI platform"
+options = ["github", "none"]
+default = "github"
+
+[placeholders.repo_owner]
+type = "string"
+prompt = "Repository owner (org or user)"
+default = "OWNER"

--- a/battery-packs/ci-battery-pack/templates/xtask/xtask/Cargo.toml
+++ b/battery-packs/ci-battery-pack/templates/xtask/xtask/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xtask"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 [dependencies]

--- a/battery-packs/ci-battery-pack/templates/xtask/xtask/Cargo.toml
+++ b/battery-packs/ci-battery-pack/templates/xtask/xtask/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+xshell.bp-managed = true
+xflags.bp-managed = true
+
+[package.metadata.battery-pack]
+ci-battery-pack = { features = ["xtask"] }

--- a/battery-packs/ci-battery-pack/templates/xtask/xtask/src/main.rs
+++ b/battery-packs/ci-battery-pack/templates/xtask/xtask/src/main.rs
@@ -1,0 +1,60 @@
+use std::path::{Path, PathBuf};
+use xshell::{cmd, Shell};
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    match args.first().map(|s| s.as_str()) {
+        Some("codegen") => {
+            let check = args.iter().any(|a| a == "--check");
+            codegen(check)
+        }
+        Some("tidy") => tidy(),
+        Some(cmd) => {
+            eprintln!("unknown command: {cmd}");
+            eprintln!("usage: cargo xtask <codegen [--check] | tidy>");
+            std::process::exit(1);
+        }
+        None => {
+            eprintln!("usage: cargo xtask <codegen [--check] | tidy>");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn project_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("xtask should be in a subdirectory")
+        .to_path_buf()
+}
+
+/// TODO: Replace with your codegen logic.
+fn codegen(check: bool) -> Result<()> {
+    let _sh = Shell::new()?;
+
+    // TODO: Add your codegen logic here.
+
+    if check {
+        println!("codegen --check: all generated files are up to date");
+    } else {
+        println!("codegen: nothing to generate (add your logic here)");
+    }
+    Ok(())
+}
+
+/// Check for trailing whitespace across the repo.
+fn tidy() -> Result<()> {
+    let sh = Shell::new()?;
+    let root = project_root();
+    let _dir = sh.push_dir(&root);
+    let output = cmd!(sh, "grep -rn --include=*.rs [[:space:]]$$ src/")
+        .ignore_status()
+        .read()?;
+    if !output.is_empty() {
+        return Err(format!("trailing whitespace found:\n{output}").into());
+    }
+    println!("tidy: no trailing whitespace found");
+    Ok(())
+}

--- a/battery-packs/ci-battery-pack/templates/xtask/xtask/src/main.rs
+++ b/battery-packs/ci-battery-pack/templates/xtask/xtask/src/main.rs
@@ -1,5 +1,5 @@
 use std::path::{Path, PathBuf};
-use xshell::{cmd, Shell};
+use xshell::{Shell, cmd};
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 

--- a/md/creating.md
+++ b/md/creating.md
@@ -198,6 +198,46 @@ The template engine also provides built-in variables (no declaration needed):
 - `{{ project_name }}` — the project name passed via `--name`
 - `{{ crate_name }}` — derived from `project_name` with `-` replaced by `_`
 
+### Built-in functions
+
+Templates can call these functions in MiniJinja expressions:
+
+- `{{ pin_github_action("actions/checkout", "v6") }}` — resolves a GitHub
+  Action tag to a SHA-pinned reference at generation time (e.g.
+  `actions/checkout@abc123 # v6.0.2`). Semver-aware: finds the latest
+  version under the given major tag. Supports an optional subpath:
+  `{{ pin_github_action("github/codeql-action", "v3", "upload-sarif") }}`.
+- `{{ rust_stable_version() }}` — returns the current stable Rust version
+  from `rustc --version` (e.g. `1.80.0`).
+
+### Placeholder types
+
+Placeholders support three types:
+
+```toml
+# String (default)
+[placeholders.description]
+type = "string"
+prompt = "Project description"
+default = "A new project"
+
+# Bool — interactive: yes/no prompt, non-interactive: defaults to false
+[placeholders.benchmarks]
+type = "bool"
+prompt = "Include benchmarks?"
+
+# Select — interactive: arrow-key selection, requires explicit default
+[placeholders.ci_platform]
+type = "select"
+prompt = "CI platform"
+options = ["github", "none"]
+default = "github"
+```
+
+Bool values are registered as actual booleans in MiniJinja, so
+`{% if benchmarks %}` works naturally. Bare `-d benchmarks` on the
+command line implies `=true`.
+
 To include files from outside the template directory (e.g. shared
 license files), use `[[files]]`:
 

--- a/src/battery-pack/bphelper-cli/Cargo.toml
+++ b/src/battery-pack/bphelper-cli/Cargo.toml
@@ -28,6 +28,7 @@ ratatui = "0.30"
 crossterm = "0.28"
 open = "5"
 dialoguer = "0.11"
+regex = "1"
 syn = { version = "2", features = ["full"] }
 toml_edit = "0.22"
 semver = "1"

--- a/src/battery-pack/bphelper-cli/src/commands/mod.rs
+++ b/src/battery-pack/bphelper-cli/src/commands/mod.rs
@@ -1412,10 +1412,10 @@ fn generate_from_path(opts: NewOpts, crate_path: &Path, template_path: &str) -> 
 
 /// Parse a `key=value` string for clap's `value_parser`.
 fn parse_define(s: &str) -> Result<(String, String), String> {
-    let (key, value) = s
-        .split_once('=')
-        .ok_or_else(|| format!("invalid define '{s}': expected key=value"))?;
-    Ok((key.to_string(), value.to_string()))
+    match s.split_once('=') {
+        Some((key, value)) => Ok((key.to_string(), value.to_string())),
+        None => Ok((s.to_string(), "true".to_string())),
+    }
 }
 
 fn parse_template_metadata(

--- a/src/battery-pack/bphelper-cli/src/lib.rs
+++ b/src/battery-pack/bphelper-cli/src/lib.rs
@@ -12,3 +12,71 @@ mod validate;
 pub use commands::main;
 pub use registry::resolve_bp_managed_content;
 pub use validate::validate_templates;
+
+/// A rendered file from a template preview.
+#[non_exhaustive]
+pub struct PreviewFile {
+    pub path: String,
+    pub content: String,
+}
+
+/// Builder for previewing a template.
+///
+/// ```rust,ignore
+/// let files = battery_pack::testing::PreviewBuilder::new(env!("CARGO_MANIFEST_DIR"))
+///     .template("templates/full")
+///     .project_name("my-project")
+///     .define("fuzzing", "true")
+///     .preview()
+///     .unwrap();
+/// ```
+pub struct PreviewBuilder {
+    crate_root: std::path::PathBuf,
+    template_path: String,
+    project_name: String,
+    defines: std::collections::BTreeMap<String, String>,
+}
+
+impl PreviewBuilder {
+    pub fn new(crate_root: impl Into<std::path::PathBuf>) -> Self {
+        Self {
+            crate_root: crate_root.into(),
+            template_path: String::new(),
+            project_name: "test-project".to_string(),
+            defines: std::collections::BTreeMap::new(),
+        }
+    }
+
+    pub fn template(mut self, path: impl Into<String>) -> Self {
+        self.template_path = path.into();
+        self
+    }
+
+    pub fn project_name(mut self, name: impl Into<String>) -> Self {
+        self.project_name = name.into();
+        self
+    }
+
+    pub fn define(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.defines.insert(key.into(), value.into());
+        self
+    }
+
+    pub fn preview(self) -> anyhow::Result<Vec<PreviewFile>> {
+        let opts = template_engine::RenderOpts {
+            crate_root: self.crate_root,
+            template_path: self.template_path,
+            project_name: self.project_name,
+            defines: self.defines,
+            interactive_override: Some(false),
+        };
+        let files = template_engine::preview(opts)?;
+        Ok(files
+            .into_iter()
+            .map(|f| PreviewFile {
+                path: f.path,
+                content: f.content,
+            })
+            .collect())
+    }
+}

--- a/src/battery-pack/bphelper-cli/src/template_engine.rs
+++ b/src/battery-pack/bphelper-cli/src/template_engine.rs
@@ -35,6 +35,9 @@ struct PlaceholderDef {
     default: Option<String>,
     #[serde(default, rename = "type")]
     placeholder_type: PlaceholderType,
+    /// Valid options for `select` type placeholders.
+    #[serde(default)]
+    options: Vec<String>,
 }
 
 #[derive(Debug, Default, Deserialize, PartialEq)]
@@ -42,7 +45,8 @@ struct PlaceholderDef {
 enum PlaceholderType {
     #[default]
     String,
-    // TODO: support more types (bool, etc).
+    Bool,
+    Select,
 }
 
 #[derive(Debug, Deserialize)]
@@ -141,6 +145,7 @@ fn render(
     variables: &BTreeMap<String, String>,
 ) -> Result<Vec<RenderedFile>> {
     let env = build_jinja_env(crate_root, variables)?;
+    prefetch_pin_github_actions(crate_root);
     let ignore_set: Vec<&str> = config.ignore.iter().map(|s| s.as_str()).collect();
 
     let mut files = Vec::new();
@@ -173,6 +178,9 @@ fn render(
     }
 
     // Process [[files]] includes
+    // TODO: support conditional file includes (e.g. a `condition` field evaluated as a
+    // MiniJinja expression, or grouped tables like [[files.fuzzing]]) so battery pack
+    // authors don't need to wrap entire file contents in {% if %}...{% endif %}.
     for file_include in &config.files {
         let src_path = crate_root.join(&file_include.src);
         if !src_path.exists() {
@@ -193,6 +201,9 @@ fn render(
     }
 
     files.sort_by(|a, b| a.path.cmp(&b.path));
+
+    // Filter out files whose rendered content is empty (e.g. wrapped in {% if false %}...{% endif %}).
+    files.retain(|f| !f.content.trim().is_empty());
 
     // Resolve bp-managed dependencies in all rendered Cargo.toml files.
     // Resolution can fail for nested templates (e.g. battery-pack-of-battery-packs)
@@ -291,6 +302,56 @@ fn resolve_placeholders(
                     })?
                 }
             }
+            PlaceholderType::Bool => {
+                if interactive {
+                    let prompt = def.prompt.as_deref().unwrap_or(name);
+                    let default_val = def
+                        .default
+                        .as_deref()
+                        .map(|d| d.eq_ignore_ascii_case("true"))
+                        .unwrap_or(false);
+                    let val = dialoguer::Confirm::new()
+                        .with_prompt(prompt)
+                        .default(default_val)
+                        .interact()
+                        .with_context(|| format!("failed to read placeholder '{name}'"))?;
+                    val.to_string()
+                } else {
+                    def.default.clone().unwrap_or_else(|| "false".to_string())
+                }
+            }
+            PlaceholderType::Select => {
+                if def.options.is_empty() {
+                    bail!("select placeholder '{name}' has no options");
+                }
+                if interactive {
+                    let prompt = def.prompt.as_deref().unwrap_or(name);
+                    let default_idx = def
+                        .default
+                        .as_ref()
+                        .and_then(|d| def.options.iter().position(|o| o == d))
+                        .unwrap_or(0);
+                    let idx = dialoguer::Select::new()
+                        .with_prompt(prompt)
+                        .items(&def.options)
+                        .default(default_idx)
+                        .interact()
+                        .with_context(|| format!("failed to read placeholder '{name}'"))?;
+                    def.options[idx].clone()
+                } else {
+                    let val = def.default.clone().ok_or_else(|| {
+                        anyhow::anyhow!("placeholder '{name}' has no default and no value provided")
+                    })?;
+                    if !def.options.contains(&val) {
+                        bail!(
+                            "placeholder '{name}' default '{}' is not in options: {:?}",
+                            val,
+                            def.options
+                        );
+                    }
+                    val
+                }
+            }
         };
         variables.insert(name.clone(), value);
     }
@@ -320,12 +381,217 @@ fn build_jinja_env(
         }
     });
 
-    // Register all variables as globals
+    // Register all variables as globals.
+    // "true"/"false" strings are registered as actual bools so {% if flag %} works.
     for (key, value) in variables {
-        env.add_global(key.clone(), value.clone());
+        match value.as_str() {
+            "true" => env.add_global(key.clone(), true),
+            "false" => env.add_global(key.clone(), false),
+            _ => env.add_global(key.clone(), value.clone()),
+        }
     }
 
+    // Register pin_github_action — reads from the global cache (populated by prefetch or on-demand).
+    env.add_function(
+        "pin_github_action",
+        |owner_repo: &str, tag: &str| -> String {
+            let key = (owner_repo.to_string(), tag.to_string());
+            let mut cache = PIN_GITHUB_ACTION_CACHE.lock().unwrap();
+            if let Some(cached) = cache.get(&key) {
+                return cached.clone();
+            }
+            // On-demand resolution for callers that skip prefetch (tests, direct build_jinja_env).
+            let result =
+                resolve_latest_tag(owner_repo, tag).or_else(|_| resolve_ref(owner_repo, tag));
+            let output = match result {
+                Ok((sha, resolved_tag)) => format!("{owner_repo}@{sha} # {resolved_tag}"),
+                Err(_) => {
+                    let url = format!("https://github.com/{owner_repo}.git");
+                    format!(
+                        "{owner_repo}@could-not-resolve-git-sha-for-{tag} \
+                     # TODO: run 'git ls-remote --tags {url} \"refs/tags/{tag}.*\"' and pin"
+                    )
+                }
+            };
+            cache.insert(key, output.clone());
+            output
+        },
+    );
+
+    // Register rust_stable_version() — returns the current stable Rust version (e.g. "1.91.1").
+    env.add_function("rust_stable_version", rust_stable_version);
+
     Ok(env)
+}
+
+/// Returns the current stable Rust version from `rustc --version`.
+fn rust_stable_version() -> String {
+    let output = std::process::Command::new("rustc")
+        .args(["--version"])
+        .output()
+        .expect("rustc must be on PATH");
+    let s = String::from_utf8_lossy(&output.stdout);
+    s.split_whitespace()
+        .nth(1)
+        .expect("unexpected rustc --version output")
+        .to_string()
+}
+
+/// Global cache for resolved pin_github_action results. Persists across preview/render calls.
+static PIN_GITHUB_ACTION_CACHE: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<(String, String), String>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+
+/// Pre-resolve all `pin_github_action` calls in parallel, then register the cached results.
+fn prefetch_pin_github_actions(crate_root: &Path) {
+    use std::collections::HashSet;
+
+    let re = regex::Regex::new(r#"pin_github_action\(\s*"([^"]+)"\s*,\s*"([^"]+)"\s*\)"#).unwrap();
+    let mut pairs: HashSet<(String, String)> = HashSet::new();
+
+    // Scan all templates and snippets for pin_github_action calls.
+    // We scan broadly because templates can {% include %} from other template dirs.
+    for dir in [crate_root.join("templates"), crate_root.join("snippets")] {
+        if !dir.is_dir() {
+            continue;
+        }
+        for entry in walkdir::WalkDir::new(dir).into_iter().flatten() {
+            if entry.file_type().is_file() {
+                let Ok(content) = std::fs::read_to_string(entry.path()) else {
+                    continue;
+                };
+                for cap in re.captures_iter(&content) {
+                    pairs.insert((cap[1].to_string(), cap[2].to_string()));
+                }
+            }
+        }
+    }
+
+    if pairs.is_empty() {
+        return;
+    }
+
+    // Filter out already-cached pairs.
+    {
+        let cache = PIN_GITHUB_ACTION_CACHE.lock().unwrap();
+        pairs.retain(|key| !cache.contains_key(key));
+    }
+
+    // Resolve uncached pairs in parallel.
+    if !pairs.is_empty() {
+        std::thread::scope(|s| {
+            for (owner_repo, tag) in &pairs {
+                let owner_repo = owner_repo.clone();
+                let tag = tag.clone();
+                s.spawn(move || {
+                    let result = resolve_latest_tag(&owner_repo, &tag)
+                        .or_else(|_| resolve_ref(&owner_repo, &tag));
+                    let output = match result {
+                        Ok((sha, resolved_tag)) => {
+                            format!("{owner_repo}@{sha} # {resolved_tag}")
+                        }
+                        Err(_) => {
+                            let url = format!("https://github.com/{owner_repo}.git");
+                            format!(
+                                "{owner_repo}@could-not-resolve-git-sha-for-{tag} \
+                                 # TODO: run 'git ls-remote --tags {url} \"refs/tags/{tag}.*\"' and pin"
+                            )
+                        }
+                    };
+                    PIN_GITHUB_ACTION_CACHE
+                        .lock()
+                        .unwrap()
+                        .insert((owner_repo, tag), output);
+                });
+            }
+        });
+    }
+}
+
+/// Find the latest semver tag matching a prefix and return (sha, tag_name).
+///
+/// For `tag = "v4"`, lists all `v4*` tags, parses semver, picks the highest,
+/// and returns its SHA. Falls back to the exact tag if no semver matches exist.
+fn resolve_latest_tag(owner_repo: &str, tag: &str) -> Result<(String, String)> {
+    let url = format!("https://github.com/{owner_repo}.git");
+    let output = std::process::Command::new("git")
+        .args(["ls-remote", "--tags", &url, &format!("refs/tags/{tag}*")])
+        .output()
+        .context("failed to run git ls-remote")?;
+
+    if !output.status.success() {
+        bail!("git ls-remote failed for {owner_repo}@{tag}");
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Parse all tags into (sha, tag_name) pairs.
+    // For annotated tags, prefer the ^{} (dereferenced) line.
+    let mut tags: Vec<(String, String)> = Vec::new();
+    for line in stdout.lines() {
+        let Some((sha, ref_name)) = line.split_once('\t') else {
+            continue;
+        };
+        let tag_name = ref_name.strip_prefix("refs/tags/").unwrap_or(ref_name);
+
+        // ^{} is the dereferenced commit for annotated tags — update the SHA
+        if let Some(base) = tag_name.strip_suffix("^{}") {
+            if let Some(entry) = tags.iter_mut().find(|(_, t)| t == base) {
+                entry.0 = sha.to_string();
+            } else {
+                tags.push((sha.to_string(), base.to_string()));
+            }
+        } else {
+            tags.push((sha.to_string(), tag_name.to_string()));
+        }
+    }
+
+    if tags.is_empty() {
+        bail!("no tags matching '{tag}*' found in {owner_repo}");
+    }
+
+    // Find the highest semver tag.
+    let best = tags
+        .iter()
+        .filter_map(|(sha, name)| {
+            let version_str = name.strip_prefix('v').unwrap_or(name);
+            let version = semver::Version::parse(version_str).ok()?;
+            Some((sha.clone(), name.clone(), version))
+        })
+        .max_by(|(_, _, a), (_, _, b)| a.cmp(b));
+
+    match best {
+        Some((sha, name, _)) => Ok((sha, name)),
+        // No semver tags found — fall back to exact tag match
+        None => tags
+            .into_iter()
+            .find(|(_, name)| name == tag)
+            .ok_or_else(|| anyhow::anyhow!("tag '{tag}' not found in {owner_repo}")),
+    }
+}
+
+/// Resolve a non-tag ref (branch name like "stable", "master") to its commit SHA.
+fn resolve_ref(owner_repo: &str, ref_name: &str) -> Result<(String, String)> {
+    let url = format!("https://github.com/{owner_repo}.git");
+    let output = std::process::Command::new("git")
+        .args(["ls-remote", &url, ref_name])
+        .output()
+        .context("failed to run git ls-remote")?;
+
+    if !output.status.success() {
+        bail!("git ls-remote failed for {owner_repo}@{ref_name}");
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let sha = stdout
+        .lines()
+        .find_map(|line| {
+            let (sha, _) = line.split_once('\t')?;
+            Some(sha.to_string())
+        })
+        .ok_or_else(|| anyhow::anyhow!("ref '{ref_name}' not found in {owner_repo}"))?;
+
+    Ok((sha, ref_name.to_string()))
 }
 
 /// Check if a relative path should be ignored.

--- a/src/battery-pack/bphelper-cli/src/template_engine.rs
+++ b/src/battery-pack/bphelper-cli/src/template_engine.rs
@@ -394,27 +394,33 @@ fn build_jinja_env(
     // Register pin_github_action — reads from the global cache (populated by prefetch or on-demand).
     env.add_function(
         "pin_github_action",
-        |owner_repo: &str, tag: &str| -> String {
+        |owner_repo: &str, tag: &str, subpath: Option<&str>| -> String {
             let key = (owner_repo.to_string(), tag.to_string());
             let mut cache = PIN_GITHUB_ACTION_CACHE.lock().unwrap();
-            if let Some(cached) = cache.get(&key) {
-                return cached.clone();
-            }
-            // On-demand resolution for callers that skip prefetch (tests, direct build_jinja_env).
-            let result =
-                resolve_latest_tag(owner_repo, tag).or_else(|_| resolve_ref(owner_repo, tag));
-            let output = match result {
-                Ok((sha, resolved_tag)) => format!("{owner_repo}@{sha} # {resolved_tag}"),
-                Err(_) => {
-                    let url = format!("https://github.com/{owner_repo}.git");
-                    format!(
-                        "{owner_repo}@could-not-resolve-git-sha-for-{tag} \
-                     # TODO: run 'git ls-remote --tags {url} \"refs/tags/{tag}.*\"' and pin"
-                    )
-                }
+            let resolved = if let Some(cached) = cache.get(&key) {
+                cached.clone()
+            } else {
+                let result =
+                    resolve_latest_tag(owner_repo, tag).or_else(|_| resolve_ref(owner_repo, tag));
+                let output = match result {
+                    Ok((sha, resolved_tag)) => format!("{owner_repo}@{sha} # {resolved_tag}"),
+                    Err(_) => {
+                        let url = format!("https://github.com/{owner_repo}.git");
+                        format!(
+                            "{owner_repo}@could-not-resolve-git-sha-for-{tag} \
+                         # TODO: run 'git ls-remote --tags {url} \"refs/tags/{tag}.*\"' and pin"
+                        )
+                    }
+                };
+                cache.insert(key, output.clone());
+                output
             };
-            cache.insert(key, output.clone());
-            output
+            // Insert subpath between owner/repo and @sha
+            if let Some(sub) = subpath {
+                resolved.replacen(owner_repo, &format!("{owner_repo}/{sub}"), 1)
+            } else {
+                resolved
+            }
         },
     );
 

--- a/src/battery-pack/bphelper-cli/src/template_engine/tests.rs
+++ b/src/battery-pack/bphelper-cli/src/template_engine/tests.rs
@@ -53,6 +53,7 @@ PlaceholderDef {
     prompt: None,
     default: None,
     placeholder_type: String,
+    options: [],
 }
 
 "#]]
@@ -103,6 +104,7 @@ fn resolve_uses_define_over_default() {
             prompt: None,
             default: Some("fallback".to_string()),
             placeholder_type: PlaceholderType::String,
+            options: vec![],
         },
     );
     let mut defines = BTreeMap::new();
@@ -122,6 +124,7 @@ fn resolve_uses_default_non_interactive() {
             prompt: None,
             default: Some("fallback".to_string()),
             placeholder_type: PlaceholderType::String,
+            options: vec![],
         },
     );
     let defines = BTreeMap::new();
@@ -141,6 +144,7 @@ fn resolve_no_default_non_interactive_errors() {
             prompt: Some("Describe it".to_string()),
             default: None,
             placeholder_type: PlaceholderType::String,
+            options: vec![],
         },
     );
     let defines = BTreeMap::new();
@@ -162,6 +166,7 @@ fn resolve_rejects_kebab_case_name() {
             prompt: None,
             default: Some("val".to_string()),
             placeholder_type: PlaceholderType::String,
+            options: vec![],
         },
     );
     let err =
@@ -228,10 +233,40 @@ fn crate_name_derived_from_project_name() {
 }
 
 #[test]
-fn parse_config_unsupported_type_errors() {
+fn parse_config_bool_placeholder() {
     let toml = r#"
             [placeholders.flag]
             type = "bool"
+            prompt = "Enable it?"
+            default = "true"
+        "#;
+    let config: BpTemplateConfig = toml::from_str(toml).unwrap();
+    let p = &config.placeholders["flag"];
+    assert_eq!(p.placeholder_type, PlaceholderType::Bool);
+    assert_eq!(p.default.as_deref(), Some("true"));
+}
+
+#[test]
+fn parse_config_select_placeholder() {
+    let toml = r#"
+            [placeholders.platform]
+            type = "select"
+            prompt = "CI platform"
+            options = ["github", "gitlab"]
+            default = "github"
+        "#;
+    let config: BpTemplateConfig = toml::from_str(toml).unwrap();
+    let p = &config.placeholders["platform"];
+    assert_eq!(p.placeholder_type, PlaceholderType::Select);
+    assert_eq!(p.options, vec!["github", "gitlab"]);
+    assert_eq!(p.default.as_deref(), Some("github"));
+}
+
+#[test]
+fn parse_config_unknown_type_errors() {
+    let toml = r#"
+            [placeholders.flag]
+            type = "number"
         "#;
     let err = toml::from_str::<BpTemplateConfig>(toml).unwrap_err();
     assert_data_eq!(
@@ -239,11 +274,285 @@ fn parse_config_unsupported_type_errors() {
         str![[r#"
 TOML parse error at line 3, column 20
   |
-3 |             type = "bool"
-  |                    ^^^^^^
-unknown variant `bool`, expected `string`
+3 |             type = "number"
+  |                    ^^^^^^^^
+unknown variant `number`, expected one of `string`, `bool`, `select`
 
 "#]]
+    );
+}
+
+// -- Bool placeholder resolution --
+
+#[test]
+fn resolve_bool_true_non_interactive() {
+    let mut defs = BTreeMap::new();
+    defs.insert(
+        "flag".to_string(),
+        PlaceholderDef {
+            prompt: None,
+            default: Some("true".to_string()),
+            placeholder_type: PlaceholderType::Bool,
+            options: vec![],
+        },
+    );
+    let mut vars = BTreeMap::new();
+    resolve_placeholders(&defs, &BTreeMap::new(), &mut vars, None).unwrap();
+    assert_eq!(vars["flag"], "true");
+}
+
+#[test]
+fn resolve_bool_false_non_interactive() {
+    let mut defs = BTreeMap::new();
+    defs.insert(
+        "flag".to_string(),
+        PlaceholderDef {
+            prompt: None,
+            default: Some("false".to_string()),
+            placeholder_type: PlaceholderType::Bool,
+            options: vec![],
+        },
+    );
+    let mut vars = BTreeMap::new();
+    resolve_placeholders(&defs, &BTreeMap::new(), &mut vars, None).unwrap();
+    assert_eq!(vars["flag"], "false");
+}
+
+#[test]
+fn resolve_bool_no_default_is_false() {
+    let mut defs = BTreeMap::new();
+    defs.insert(
+        "flag".to_string(),
+        PlaceholderDef {
+            prompt: None,
+            default: None,
+            placeholder_type: PlaceholderType::Bool,
+            options: vec![],
+        },
+    );
+    let mut vars = BTreeMap::new();
+    resolve_placeholders(&defs, &BTreeMap::new(), &mut vars, None).unwrap();
+    assert_eq!(vars["flag"], "false");
+}
+
+#[test]
+fn resolve_bool_define_override() {
+    let mut defs = BTreeMap::new();
+    defs.insert(
+        "flag".to_string(),
+        PlaceholderDef {
+            prompt: None,
+            default: Some("false".to_string()),
+            placeholder_type: PlaceholderType::Bool,
+            options: vec![],
+        },
+    );
+    let mut defines = BTreeMap::new();
+    defines.insert("flag".to_string(), "true".to_string());
+    let mut vars = BTreeMap::new();
+    resolve_placeholders(&defs, &defines, &mut vars, None).unwrap();
+    assert_eq!(vars["flag"], "true");
+}
+
+// -- Select placeholder resolution --
+
+#[test]
+fn resolve_select_non_interactive() {
+    let mut defs = BTreeMap::new();
+    defs.insert(
+        "platform".to_string(),
+        PlaceholderDef {
+            prompt: None,
+            default: Some("github".to_string()),
+            placeholder_type: PlaceholderType::Select,
+            options: vec!["github".to_string(), "gitlab".to_string()],
+        },
+    );
+    let mut vars = BTreeMap::new();
+    resolve_placeholders(&defs, &BTreeMap::new(), &mut vars, None).unwrap();
+    assert_eq!(vars["platform"], "github");
+}
+
+#[test]
+fn resolve_select_invalid_default_errors() {
+    let mut defs = BTreeMap::new();
+    defs.insert(
+        "platform".to_string(),
+        PlaceholderDef {
+            prompt: None,
+            default: Some("bitbucket".to_string()),
+            placeholder_type: PlaceholderType::Select,
+            options: vec!["github".to_string(), "gitlab".to_string()],
+        },
+    );
+    let err =
+        resolve_placeholders(&defs, &BTreeMap::new(), &mut BTreeMap::new(), None).unwrap_err();
+    assert!(err.to_string().contains("bitbucket"), "{err}");
+    assert!(err.to_string().contains("not in options"), "{err}");
+}
+
+#[test]
+fn resolve_select_empty_options_errors() {
+    let mut defs = BTreeMap::new();
+    defs.insert(
+        "platform".to_string(),
+        PlaceholderDef {
+            prompt: None,
+            default: Some("github".to_string()),
+            placeholder_type: PlaceholderType::Select,
+            options: vec![],
+        },
+    );
+    let err =
+        resolve_placeholders(&defs, &BTreeMap::new(), &mut BTreeMap::new(), None).unwrap_err();
+    assert!(err.to_string().contains("no options"), "{err}");
+}
+
+#[test]
+fn resolve_select_define_override() {
+    let mut defs = BTreeMap::new();
+    defs.insert(
+        "platform".to_string(),
+        PlaceholderDef {
+            prompt: None,
+            default: Some("github".to_string()),
+            placeholder_type: PlaceholderType::Select,
+            options: vec!["github".to_string(), "gitlab".to_string()],
+        },
+    );
+    let mut defines = BTreeMap::new();
+    defines.insert("platform".to_string(), "gitlab".to_string());
+    let mut vars = BTreeMap::new();
+    resolve_placeholders(&defs, &defines, &mut vars, None).unwrap();
+    assert_eq!(vars["platform"], "gitlab");
+}
+
+// -- Bool values in MiniJinja --
+
+#[test]
+fn jinja_bool_true_is_truthy() {
+    let mut vars = BTreeMap::new();
+    vars.insert("flag".to_string(), "true".to_string());
+    let env = build_jinja_env(Path::new("."), &vars).unwrap();
+    let result = env
+        .render_str(
+            "{% if flag %}yes{% else %}no{% endif %}",
+            minijinja::context! {},
+        )
+        .unwrap();
+    assert_eq!(result, "yes");
+}
+
+#[test]
+fn jinja_bool_false_is_falsy() {
+    let mut vars = BTreeMap::new();
+    vars.insert("flag".to_string(), "false".to_string());
+    let env = build_jinja_env(Path::new("."), &vars).unwrap();
+    let result = env
+        .render_str(
+            "{% if flag %}yes{% else %}no{% endif %}",
+            minijinja::context! {},
+        )
+        .unwrap();
+    assert_eq!(result, "no");
+}
+
+// -- pin_github_action --
+
+#[test]
+fn pin_github_action_resolves_known_repo() {
+    let vars = BTreeMap::new();
+    let env = build_jinja_env(Path::new("."), &vars).unwrap();
+    let result = env
+        .render_str(
+            r#"{{ pin_github_action("actions/checkout", "v4") }}"#,
+            minijinja::context! {},
+        )
+        .unwrap();
+    assert!(
+        result.starts_with("actions/checkout@"),
+        "should start with owner/repo@: {result}"
+    );
+    if result.contains("could-not-resolve") {
+        assert!(
+            result.contains("TODO"),
+            "failure should include TODO: {result}"
+        );
+    } else {
+        let comment = result.split("# ").nth(1).unwrap();
+        assert!(
+            comment.contains('.'),
+            "should resolve to a specific version (e.g. v4.2.2), got: {comment}"
+        );
+        let sha = result.split('@').nth(1).unwrap().split(' ').next().unwrap();
+        assert_eq!(sha.len(), 40, "SHA should be 40 chars: {sha}");
+        assert!(
+            sha.chars().all(|c| c.is_ascii_hexdigit()),
+            "SHA should be hex: {sha}"
+        );
+    }
+}
+
+#[test]
+fn pin_github_action_bad_repo_returns_error_marker() {
+    let vars = BTreeMap::new();
+    let env = build_jinja_env(Path::new("."), &vars).unwrap();
+    let result = env
+        .render_str(
+            r#"{{ pin_github_action("nonexistent-owner-xyz/nonexistent-repo-xyz", "v999") }}"#,
+            minijinja::context! {},
+        )
+        .unwrap();
+    assert!(
+        result.contains("could-not-resolve"),
+        "should contain error marker: {result}"
+    );
+    assert!(result.contains("TODO"), "should contain TODO: {result}");
+}
+
+#[test]
+fn rust_stable_version_returns_semver() {
+    let version = rust_stable_version();
+    let parts: Vec<&str> = version.split('.').collect();
+    assert!(parts.len() >= 2, "should be semver-like: {version}");
+    assert!(
+        parts[0].parse::<u32>().is_ok(),
+        "major should be numeric: {version}"
+    );
+    assert!(
+        parts[1].parse::<u32>().is_ok(),
+        "minor should be numeric: {version}"
+    );
+}
+
+#[test]
+fn rust_stable_version_available_in_jinja() {
+    let vars = BTreeMap::new();
+    let env = build_jinja_env(Path::new("."), &vars).unwrap();
+    let result = env
+        .render_str("{{ rust_stable_version() }}", minijinja::context! {})
+        .unwrap();
+    assert!(result.contains('.'), "should contain a dot: {result}");
+    assert!(!result.is_empty(), "should not be empty");
+}
+
+#[test]
+fn pin_github_action_available_in_jinja() {
+    let vars = BTreeMap::new();
+    let env = build_jinja_env(Path::new("."), &vars).unwrap();
+    let result = env
+        .render_str(
+            r#"uses: {{ pin_github_action("nonexistent-owner-xyz/nonexistent-repo-xyz", "v1") }}"#,
+            minijinja::context! {},
+        )
+        .unwrap();
+    assert!(
+        result.contains("could-not-resolve"),
+        "should contain error marker: {result}"
+    );
+    assert!(
+        result.starts_with("uses: "),
+        "should preserve prefix: {result}"
     );
 }
 

--- a/src/battery-pack/bphelper-cli/src/template_engine/tests.rs
+++ b/src/battery-pack/bphelper-cli/src/template_engine/tests.rs
@@ -460,57 +460,6 @@ fn jinja_bool_false_is_falsy() {
 // -- pin_github_action --
 
 #[test]
-fn pin_github_action_resolves_known_repo() {
-    let vars = BTreeMap::new();
-    let env = build_jinja_env(Path::new("."), &vars).unwrap();
-    let result = env
-        .render_str(
-            r#"{{ pin_github_action("actions/checkout", "v4") }}"#,
-            minijinja::context! {},
-        )
-        .unwrap();
-    assert!(
-        result.starts_with("actions/checkout@"),
-        "should start with owner/repo@: {result}"
-    );
-    if result.contains("could-not-resolve") {
-        assert!(
-            result.contains("TODO"),
-            "failure should include TODO: {result}"
-        );
-    } else {
-        let comment = result.split("# ").nth(1).unwrap();
-        assert!(
-            comment.contains('.'),
-            "should resolve to a specific version (e.g. v4.2.2), got: {comment}"
-        );
-        let sha = result.split('@').nth(1).unwrap().split(' ').next().unwrap();
-        assert_eq!(sha.len(), 40, "SHA should be 40 chars: {sha}");
-        assert!(
-            sha.chars().all(|c| c.is_ascii_hexdigit()),
-            "SHA should be hex: {sha}"
-        );
-    }
-}
-
-#[test]
-fn pin_github_action_bad_repo_returns_error_marker() {
-    let vars = BTreeMap::new();
-    let env = build_jinja_env(Path::new("."), &vars).unwrap();
-    let result = env
-        .render_str(
-            r#"{{ pin_github_action("nonexistent-owner-xyz/nonexistent-repo-xyz", "v999") }}"#,
-            minijinja::context! {},
-        )
-        .unwrap();
-    assert!(
-        result.contains("could-not-resolve"),
-        "should contain error marker: {result}"
-    );
-    assert!(result.contains("TODO"), "should contain TODO: {result}");
-}
-
-#[test]
 fn rust_stable_version_returns_semver() {
     let version = rust_stable_version();
     let parts: Vec<&str> = version.split('.').collect();
@@ -536,13 +485,42 @@ fn rust_stable_version_available_in_jinja() {
     assert!(!result.is_empty(), "should not be empty");
 }
 
+// -- pin_github_action tests (require network, run with `cargo test -- --ignored`) --
+
 #[test]
-fn pin_github_action_available_in_jinja() {
+fn pin_github_action_resolves_known_repo() {
     let vars = BTreeMap::new();
     let env = build_jinja_env(Path::new("."), &vars).unwrap();
     let result = env
         .render_str(
-            r#"uses: {{ pin_github_action("nonexistent-owner-xyz/nonexistent-repo-xyz", "v1") }}"#,
+            r#"{{ pin_github_action("actions/checkout", "v4") }}"#,
+            minijinja::context! {},
+        )
+        .unwrap();
+    assert!(
+        result.starts_with("actions/checkout@"),
+        "should start with owner/repo@: {result}"
+    );
+    assert!(
+        !result.contains("could-not-resolve"),
+        "should resolve successfully: {result}"
+    );
+    let comment = result.split("# ").nth(1).unwrap();
+    assert!(
+        comment.contains('.'),
+        "should resolve to a specific version: {comment}"
+    );
+    let sha = result.split('@').nth(1).unwrap().split(' ').next().unwrap();
+    assert_eq!(sha.len(), 40, "SHA should be 40 chars: {sha}");
+}
+
+#[test]
+fn pin_github_action_bad_repo_returns_error_marker() {
+    let vars = BTreeMap::new();
+    let env = build_jinja_env(Path::new("."), &vars).unwrap();
+    let result = env
+        .render_str(
+            r#"{{ pin_github_action("nonexistent-owner-xyz/nonexistent-repo-xyz", "v999") }}"#,
             minijinja::context! {},
         )
         .unwrap();
@@ -550,9 +528,21 @@ fn pin_github_action_available_in_jinja() {
         result.contains("could-not-resolve"),
         "should contain error marker: {result}"
     );
+}
+
+#[test]
+fn pin_github_action_subpath() {
+    let vars = BTreeMap::new();
+    let env = build_jinja_env(Path::new("."), &vars).unwrap();
+    let result = env
+        .render_str(
+            r#"{{ pin_github_action("github/codeql-action", "v3", "upload-sarif") }}"#,
+            minijinja::context! {},
+        )
+        .unwrap();
     assert!(
-        result.starts_with("uses: "),
-        "should preserve prefix: {result}"
+        result.contains("github/codeql-action/upload-sarif@"),
+        "should contain subpath: {result}"
     );
 }
 

--- a/src/battery-pack/src/lib.rs
+++ b/src/battery-pack/src/lib.rs
@@ -58,7 +58,7 @@ pub mod build {
 /// ```
 #[cfg(feature = "cli")]
 pub mod testing {
-    pub use bphelper_cli::validate_templates;
+    pub use bphelper_cli::{PreviewBuilder, PreviewFile, validate_templates};
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# ci-battery-pack

Closes #79.

## Overview

New battery pack that generates CI/CD infrastructure for Rust projects — the kind of thing you'd copy from tokio or hyper, but generated fresh with pinned SHAs and your project's MSRV.

The `full` template generates a stub Rust project with CI. Standalone templates are available for adding individual features to existing projects. See the [README](battery-packs/ci-battery-pack/README.md) for usage and setup.

Sample run with everything enabled: https://github.com/jlizen/ci-battery-pack-test/actions

### Core (always included)

| What | How |
|------|-----|
| Build + test matrix | stable × nightly, all-features × no-default-features |
| Linting | cargo fmt (nightly), clippy |
| Warnings check | Dedicated job so warnings don't hide test failures |
| Docs check | docsrs cfg validation on nightly |
| Feature powerset | cargo-hack --feature-powerset --depth 2 |
| MSRV validation | cargo hack --rust-version --locked |
| Lockfile sync | cargo update --workspace --locked |
| Minimal versions | cargo +nightly generate-lockfile -Z minimal-versions |
| Semver checks | cargo-semver-checks |
| Security audit | cargo-deny (advisories non-blocking, licenses/bans/sources blocking) |
| Dependabot | Cargo + GitHub Actions updates |
| Gate job | ci-pass (single required status check) |
| SHA pinning | Resolved at generation time |
| Caching | Swatinem/rust-cache |
| Canary | rust-next.yml: latest deps + beta Rust (non-blocking, scheduled) |
| README | Generated with CI, crates.io, docs.rs badges |

### Optional (toggle with `-d flag`)

| Flag | Default | What |
|------|---------|------|
| `trusted_publishing` | true | release-plz with OIDC trusted publishing |
| `binary_release` | false | Cross-platform binary builds for GitHub Releases + cargo-binstall |
| `benchmarks` | false | Criterion + Bencher regression detection |
| `fuzzing` | false | cargo-fuzz PR smoke (60s) + nightly extended (300s) |
| `stress_tests` | false | nextest --stress-duration (5m CI, 60m scheduled) |
| `mdbook` | false | mdBook + GitHub Pages deployment |
| `spellcheck` | false | crate-ci/typos |
| `xtask` | false | cargo-xtask with codegen --check |
| `mutation_testing` | false | cargo-mutants |
| `clippy_sarif` | false | Clippy with GitHub PR annotations via SARIF |

## Design decisions

**Single ci.yml with a gate job.** All PR-triggered jobs live in one workflow with a `ci-pass` gate job, following the pattern from hyper/cargo/rust-analyzer. One required status check in branch protection.

**Snippets as source of truth.** Job definitions live in `snippets/github/jobs/`. Both the `full` template and standalone templates `{% include %}` from them.

**Warnings in a dedicated job.** Per epage's recommendation, `-Dwarnings` is not global. A dedicated `warnings` job runs `cargo check` with `-Dwarnings`, and a separate `docsrs` job validates docs. Test jobs run without `-Dwarnings` so warnings don't hide test failures.

**Audit split.** Advisories are non-blocking (`continue-on-error: true`) so new advisories don't break CI for unrelated PRs. Licenses, bans, and sources are blocking.

**SHA pinning via `pin_github_action()`.** Semver-aware resolution at generation time. Branch-based actions (dtolnay/rust-toolchain) left unpinned per community convention.

**`persist-credentials: false`** on all checkouts except release (which needs credentials for pushing).

**`ci_platform` select with `none`.** Strips all `.github/` files, leaving only config files.

**Trusted publishing is opt-out.** `binary_release` users need a `RELEASE_PLZ_TOKEN` PAT; without it, `GITHUB_TOKEN` works fine.

## Template engine additions

**Bool and Select placeholders.** `type = "bool"` (dialoguer::Confirm, defaults to false) and `type = "select"` (dialoguer::Select with options list). Bare `-d benchmarks` now implies `=true`.

**`pin_github_action()`.** Semver-aware SHA resolution via `git ls-remote`. Uses the `semver` crate. Parallel prefetch with global session cache.

**`rust_stable_version()`.** Returns current stable Rust version from `rustc --version`.

**`PreviewBuilder`.** Public API for testing template rendering without disk writes. `PreviewFile` is `#[non_exhaustive]`.

## Known limitations

- **Preview shows defaults only** — no way to preview different placeholder configurations in the TUI
- **First preview is slow** (~2-3s) — SHAs resolved on open, not prefetched
- **Conditional `[[files]]`** — TODO in engine
- **Identical `bp-template.toml`** across standalone templates — no shared config mechanism

## Engine follow-ups

- Conditional `[[files]]` (#102)
- Template engine performance: eager prefetch, async, disk cache (#103)
- Placeholder selection in TUI preview (#104)
- Shared bp-template.toml (#105)
