### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "battery-pack"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "battery-pack",
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "bphelper-cli"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "bphelper-manifest",
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-bp"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -512,7 +512,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "ci-battery-pack"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "arbitrary",
  "battery-pack",

--- a/battery-packs/ci-battery-pack/CHANGELOG.md
+++ b/battery-packs/ci-battery-pack/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/battery-pack-rs/battery-pack/compare/ci-battery-pack-v0.1.2...ci-battery-pack-v0.1.3) - 2026-04-22
+
+### Added
+
+- *(ci)* add post-merge hints to CI templates
+
 ## [0.1.2](https://github.com/battery-pack-rs/battery-pack/compare/ci-battery-pack-v0.1.1...ci-battery-pack-v0.1.2) - 2026-04-21
 
 ### Other

--- a/battery-packs/ci-battery-pack/Cargo.toml
+++ b/battery-packs/ci-battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ci-battery-pack"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = "Battery pack for CI/CD workflows in Rust projects"
 license = "MIT OR Apache-2.0"

--- a/src/battery-pack/CHANGELOG.md
+++ b/src/battery-pack/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.5.0...battery-pack-v0.5.1) - 2026-04-22
+
+### Added
+
+- *(merge)* colored diffs and single-key shortcuts for prompts
+- *(tui)* add "Use in project" action for templates
+- *(template)* add [[hints]] support to bp-template.toml
+- *(cli)* add -t/--template flag to `cargo bp add`
+- *(merge)* add format-aware file merge engine
+
+### Fixed
+
+- address clippy warnings in merge tests
+- *(tui)* propagate --path flag to UseTemplate action
+- *(merge)* distinguish "unchanged" from "skipped" in summary
+
+### Other
+
+- add merge unit tests and integration tests
+
 ## [0.5.0](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.4.13...battery-pack-v0.5.0) - 2026-04-21
 
 ### Added

--- a/src/battery-pack/Cargo.toml
+++ b/src/battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "battery-pack"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 description = "Curated crate bundles with docs, templates, and agentic skills"
 license = "MIT OR Apache-2.0"
@@ -22,7 +22,7 @@ cli = ["bphelper-cli"]
 
 [dependencies]
 bphelper-build = { path = "bphelper-build", version = "0.4.6", optional = true }
-bphelper-cli = { path = "bphelper-cli", version = "0.7.5", optional = true }
+bphelper-cli = { path = "bphelper-cli", version = "0.7.6", optional = true }
 bphelper-manifest = { path = "bphelper-manifest", version = "0.5.4" }
 anyhow.workspace = true
 

--- a/src/battery-pack/bphelper-cli/CHANGELOG.md
+++ b/src/battery-pack/bphelper-cli/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.6](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.7.5...bphelper-cli-v0.7.6) - 2026-04-22
+
+### Added
+
+- *(merge)* colored diffs and single-key shortcuts for prompts
+- *(tui)* add "Use in project" action for templates
+- *(template)* add [[hints]] support to bp-template.toml
+- *(cli)* add -t/--template flag to `cargo bp add`
+- *(merge)* add format-aware file merge engine
+
+### Fixed
+
+- address clippy warnings in merge tests
+- *(tui)* propagate --path flag to UseTemplate action
+- *(merge)* distinguish "unchanged" from "skipped" in summary
+
+### Other
+
+- add merge unit tests and integration tests
+
 ## [0.7.5](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.7.4...bphelper-cli-v0.7.5) - 2026-04-21
 
 ### Added

--- a/src/battery-pack/bphelper-cli/Cargo.toml
+++ b/src/battery-pack/bphelper-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bphelper-cli"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2024"
 description = "CLI for creating and managing battery packs"
 license = "MIT OR Apache-2.0"

--- a/src/cargo-bp/CHANGELOG.md
+++ b/src/cargo-bp/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-v0.5.1...cargo-bp-v0.5.2) - 2026-04-22
+
+### Added
+
+- *(merge)* colored diffs and single-key shortcuts for prompts
+- *(tui)* add "Use in project" action for templates
+- *(template)* add [[hints]] support to bp-template.toml
+- *(cli)* add -t/--template flag to `cargo bp add`
+- *(merge)* add format-aware file merge engine
+
+### Fixed
+
+- address clippy warnings in merge tests
+- *(tui)* propagate --path flag to UseTemplate action
+- *(merge)* distinguish "unchanged" from "skipped" in summary
+
+### Other
+
+- add merge unit tests and integration tests
+
 ## [0.5.1](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-v0.5.0...cargo-bp-v0.5.1) - 2026-04-21
 
 ### Added

--- a/src/cargo-bp/Cargo.toml
+++ b/src/cargo-bp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-bp"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 description = "CLI for creating and managing battery packs (cargo bp)"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `bphelper-cli`: 0.7.5 -> 0.7.6 (✓ API compatible changes)
* `battery-pack`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `cargo-bp`: 0.5.1 -> 0.5.2
* `ci-battery-pack`: 0.1.2 -> 0.1.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `bphelper-cli`

<blockquote>

## [0.7.6](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.7.5...bphelper-cli-v0.7.6) - 2026-04-22

### Added

- *(merge)* colored diffs and single-key shortcuts for prompts
- *(tui)* add "Use in project" action for templates
- *(template)* add [[hints]] support to bp-template.toml
- *(cli)* add -t/--template flag to `cargo bp add`
- *(merge)* add format-aware file merge engine

### Fixed

- address clippy warnings in merge tests
- *(tui)* propagate --path flag to UseTemplate action
- *(merge)* distinguish "unchanged" from "skipped" in summary

### Other

- add merge unit tests and integration tests
</blockquote>

## `battery-pack`

<blockquote>

## [0.5.1](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.5.0...battery-pack-v0.5.1) - 2026-04-22

### Added

- *(merge)* colored diffs and single-key shortcuts for prompts
- *(tui)* add "Use in project" action for templates
- *(template)* add [[hints]] support to bp-template.toml
- *(cli)* add -t/--template flag to `cargo bp add`
- *(merge)* add format-aware file merge engine

### Fixed

- address clippy warnings in merge tests
- *(tui)* propagate --path flag to UseTemplate action
- *(merge)* distinguish "unchanged" from "skipped" in summary

### Other

- add merge unit tests and integration tests
</blockquote>

## `cargo-bp`

<blockquote>

## [0.5.2](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-v0.5.1...cargo-bp-v0.5.2) - 2026-04-22

### Added

- *(merge)* colored diffs and single-key shortcuts for prompts
- *(tui)* add "Use in project" action for templates
- *(template)* add [[hints]] support to bp-template.toml
- *(cli)* add -t/--template flag to `cargo bp add`
- *(merge)* add format-aware file merge engine

### Fixed

- address clippy warnings in merge tests
- *(tui)* propagate --path flag to UseTemplate action
- *(merge)* distinguish "unchanged" from "skipped" in summary

### Other

- add merge unit tests and integration tests
</blockquote>

## `ci-battery-pack`

<blockquote>

## [0.1.3](https://github.com/battery-pack-rs/battery-pack/compare/ci-battery-pack-v0.1.2...ci-battery-pack-v0.1.3) - 2026-04-22

### Added

- *(ci)* add post-merge hints to CI templates
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).