### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "battery-pack"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "battery-pack",
@@ -335,7 +335,7 @@ dependencies = [
 
 [[package]]
 name = "bphelper-build"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "bphelper-manifest",
  "cargo_metadata",
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "bphelper-cli"
-version = "0.7.6"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "bphelper-manifest",
@@ -384,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "bphelper-manifest"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "serde",
  "tempfile",
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-bp"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -514,7 +514,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "ci-battery-pack"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "arbitrary",
  "battery-pack",
@@ -606,7 +606,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "cli-battery-pack"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anstream 1.0.0",
  "anstyle",
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "error-battery-pack"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "battery-pack",
@@ -1996,7 +1996,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "logging-battery-pack"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "battery-pack",
  "tracing",

--- a/battery-packs/ci-battery-pack/CHANGELOG.md
+++ b/battery-packs/ci-battery-pack/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/battery-pack-rs/battery-pack/compare/ci-battery-pack-v0.1.3...ci-battery-pack-v0.1.4) - 2026-04-30
+
+### Added
+
+- rename validate_templates to validate
+- *(ci-battery-pack)* add validate test, merged snapshot tests for all templates
+
+### Fixed
+
+- rename template Cargo.toml to _Cargo.toml, flip assertions
+
+### Other
+
+- Merge pull request #120 from jlizen/feat/defines-in-show
+- *(ci-battery-pack)* replace file list and contains tests with merged snapshots
+- *(ci-battery-pack)* expand hints
+- *(ci)* restructure README for template merging ([#115](https://github.com/battery-pack-rs/battery-pack/pull/115))
+
 ## [0.1.3](https://github.com/battery-pack-rs/battery-pack/compare/ci-battery-pack-v0.1.2...ci-battery-pack-v0.1.3) - 2026-04-22
 
 ### Added

--- a/battery-packs/ci-battery-pack/Cargo.toml
+++ b/battery-packs/ci-battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ci-battery-pack"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "Battery pack for CI/CD workflows in Rust projects"
 license = "MIT OR Apache-2.0"

--- a/battery-packs/cli-battery-pack/CHANGELOG.md
+++ b/battery-packs/cli-battery-pack/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/battery-pack-rs/battery-pack/compare/cli-battery-pack-v0.6.0...cli-battery-pack-v0.6.1) - 2026-04-30
+
+### Added
+
+- rename validate_templates to validate
+- validate templates from packaged tarball (inverted assertions)
+
+### Fixed
+
+- rename template Cargo.toml to _Cargo.toml, flip assertions
+
 ## [0.6.0](https://github.com/battery-pack-rs/battery-pack/compare/cli-battery-pack-v0.5.1...cli-battery-pack-v0.6.0) - 2026-04-21
 
 ### Added

--- a/battery-packs/cli-battery-pack/Cargo.toml
+++ b/battery-packs/cli-battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli-battery-pack"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 description = "Battery pack for building CLI applications in Rust"
 license = "MIT OR Apache-2.0"

--- a/battery-packs/error-battery-pack/CHANGELOG.md
+++ b/battery-packs/error-battery-pack/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/battery-pack-rs/battery-pack/compare/error-battery-pack-v0.6.0...error-battery-pack-v0.6.1) - 2026-04-30
+
+### Added
+
+- rename validate_templates to validate
+
 ## [0.6.0](https://github.com/battery-pack-rs/battery-pack/compare/error-battery-pack-v0.5.3...error-battery-pack-v0.6.0) - 2026-04-21
 
 ### Added

--- a/battery-packs/error-battery-pack/Cargo.toml
+++ b/battery-packs/error-battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "error-battery-pack"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 description = "Error handling done well — anyhow for apps, thiserror for libraries"
 license = "MIT OR Apache-2.0"

--- a/battery-packs/logging-battery-pack/CHANGELOG.md
+++ b/battery-packs/logging-battery-pack/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/battery-pack-rs/battery-pack/compare/logging-battery-pack-v0.5.0...logging-battery-pack-v0.5.1) - 2026-04-30
+
+### Added
+
+- rename validate_templates to validate
+
 ## [0.5.0](https://github.com/battery-pack-rs/battery-pack/compare/logging-battery-pack-v0.4.3...logging-battery-pack-v0.5.0) - 2026-04-21
 
 ### Added

--- a/battery-packs/logging-battery-pack/Cargo.toml
+++ b/battery-packs/logging-battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logging-battery-pack"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 description = "Battery pack for logging and tracing in Rust"
 license = "MIT OR Apache-2.0"

--- a/src/battery-pack/CHANGELOG.md
+++ b/src/battery-pack/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.5.1...battery-pack-v0.5.2) - 2026-04-30
+
+### Added
+
+- use bp-managed in templates, add with_template snapshot tests
+- *(bp-managed)* allow features and other keys alongside bp-managed
+- rename validate_templates to validate
+- *(template-engine)* map _Cargo.toml to Cargo.toml in rendered output
+- *(manifest)* add format.templates.cargo-toml validation rule
+- validate templates from packaged tarball (inverted assertions)
+
+### Fixed
+
+- *(validate)* fall back to source tree when workspace deps are unpublished
+- rename template Cargo.toml to _Cargo.toml, flip assertions
+- remove trailing newline from with_template snapshot
+
+### Other
+
+- Merge pull request #120 from jlizen/feat/defines-in-show
+- Merge pull request #121 from jlizen/fix/preserve-cargo-toml-in-tarball
+- *(test)* add spirit asserts alongside snapshots, inline small file snapshots
+
 ## [0.5.1](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.5.0...battery-pack-v0.5.1) - 2026-04-22
 
 ### Added

--- a/src/battery-pack/Cargo.toml
+++ b/src/battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "battery-pack"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 description = "Curated crate bundles with docs, templates, and agentic skills"
 license = "MIT OR Apache-2.0"
@@ -21,9 +21,9 @@ build = ["bphelper-build"]
 cli = ["bphelper-cli"]
 
 [dependencies]
-bphelper-build = { path = "bphelper-build", version = "0.4.6", optional = true }
-bphelper-cli = { path = "bphelper-cli", version = "0.7.6", optional = true }
-bphelper-manifest = { path = "bphelper-manifest", version = "0.5.4" }
+bphelper-build = { path = "bphelper-build", version = "0.4.7", optional = true }
+bphelper-cli = { path = "bphelper-cli", version = "0.8.0", optional = true }
+bphelper-manifest = { path = "bphelper-manifest", version = "0.5.5" }
 anyhow.workspace = true
 
 [dev-dependencies]

--- a/src/battery-pack/bphelper-build/CHANGELOG.md
+++ b/src/battery-pack/bphelper-build/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.7](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-build-v0.4.6...bphelper-build-v0.4.7) - 2026-04-30
+
+### Added
+
+- rename validate_templates to validate
+
+### Other
+
+- *(test)* add spirit asserts alongside snapshots, inline small file snapshots
+
 ## [0.4.6](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-build-v0.4.5...bphelper-build-v0.4.6) - 2026-04-21
 
 ### Added

--- a/src/battery-pack/bphelper-build/Cargo.toml
+++ b/src/battery-pack/bphelper-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bphelper-build"
-version = "0.4.6"
+version = "0.4.7"
 edition = "2024"
 description = "Build-time documentation generation for battery packs"
 license = "MIT OR Apache-2.0"
@@ -8,7 +8,7 @@ repository = "https://github.com/battery-pack-rs/battery-pack"
 keywords = ["battery-pack"]
 
 [dependencies]
-bphelper-manifest = { path = "../bphelper-manifest", version = "0.5.4" }
+bphelper-manifest = { path = "../bphelper-manifest", version = "0.5.5" }
 handlebars.workspace = true
 cargo_metadata.workspace = true
 serde.workspace = true

--- a/src/battery-pack/bphelper-cli/CHANGELOG.md
+++ b/src/battery-pack/bphelper-cli/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.7.6...bphelper-cli-v0.8.0) - 2026-04-30
+
+### Added
+
+- use bp-managed in templates, add with_template snapshot tests
+- *(bp-managed)* allow features and other keys alongside bp-managed
+- rename validate_templates to validate
+- *(template-engine)* map _Cargo.toml to Cargo.toml in rendered output
+- validate templates from packaged tarball (inverted assertions)
+
+### Fixed
+
+- *(validate)* fall back to source tree when workspace deps are unpublished
+- rename template Cargo.toml to _Cargo.toml, flip assertions
+
+### Other
+
+- Merge pull request #120 from jlizen/feat/defines-in-show
+- Merge pull request #121 from jlizen/fix/preserve-cargo-toml-in-tarball
+- *(test)* add spirit asserts alongside snapshots, inline small file snapshots
+
 ## [0.7.6](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.7.5...bphelper-cli-v0.7.6) - 2026-04-22
 
 ### Added

--- a/src/battery-pack/bphelper-cli/Cargo.toml
+++ b/src/battery-pack/bphelper-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bphelper-cli"
-version = "0.7.6"
+version = "0.8.0"
 edition = "2024"
 description = "CLI for creating and managing battery packs"
 license = "MIT OR Apache-2.0"
@@ -8,7 +8,7 @@ repository = "https://github.com/battery-pack-rs/battery-pack"
 keywords = ["battery-pack", "cli", "cargo"]
 
 [dependencies]
-bphelper-manifest = { path = "../bphelper-manifest", version = "0.5.4" }
+bphelper-manifest = { path = "../bphelper-manifest", version = "0.5.5" }
 clap.workspace = true
 clap_complete = { workspace = true, features = ["unstable-dynamic"] }
 minijinja.workspace = true

--- a/src/battery-pack/bphelper-manifest/CHANGELOG.md
+++ b/src/battery-pack/bphelper-manifest/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.5](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-manifest-v0.5.4...bphelper-manifest-v0.5.5) - 2026-04-30
+
+### Added
+
+- *(bp-managed)* allow features and other keys alongside bp-managed
+- *(manifest)* add format.templates.cargo-toml validation rule
+
+### Fixed
+
+- rename template Cargo.toml to _Cargo.toml, flip assertions
+
 ## [0.5.4](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-manifest-v0.5.3...bphelper-manifest-v0.5.4) - 2026-04-13
 
 ### Other

--- a/src/battery-pack/bphelper-manifest/Cargo.toml
+++ b/src/battery-pack/bphelper-manifest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bphelper-manifest"
-version = "0.5.4"
+version = "0.5.5"
 edition = "2024"
 description = "Shared battery pack manifest parsing"
 license = "MIT OR Apache-2.0"

--- a/src/cargo-bp/CHANGELOG.md
+++ b/src/cargo-bp/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.3](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-v0.5.2...cargo-bp-v0.5.3) - 2026-04-30
+
+### Added
+
+- use bp-managed in templates, add with_template snapshot tests
+- rename validate_templates to validate
+- validate templates from packaged tarball (inverted assertions)
+- *(bp-managed)* allow features and other keys alongside bp-managed
+- *(template-engine)* map _Cargo.toml to Cargo.toml in rendered output
+
+### Fixed
+
+- remove trailing newline from with_template snapshot
+- rename template Cargo.toml to _Cargo.toml, flip assertions
+- *(validate)* fall back to source tree when workspace deps are unpublished
+
+### Other
+
+- Merge pull request #120 from jlizen/feat/defines-in-show
+- Merge pull request #121 from jlizen/fix/preserve-cargo-toml-in-tarball
+- *(test)* add spirit asserts alongside snapshots, inline small file snapshots
+
 ## [0.5.2](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-v0.5.1...cargo-bp-v0.5.2) - 2026-04-22
 
 ### Added

--- a/src/cargo-bp/Cargo.toml
+++ b/src/cargo-bp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-bp"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2024"
 description = "CLI for creating and managing battery packs (cargo bp)"
 license = "MIT OR Apache-2.0"
@@ -23,7 +23,7 @@ name = "cargo-bp"
 path = "src/main.rs"
 
 [dependencies]
-bphelper-cli = { path = "../battery-pack/bphelper-cli", version = "0.7" }
+bphelper-cli = { path = "../battery-pack/bphelper-cli", version = "0.8" }
 anyhow.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION



## 🤖 New release

* `bphelper-manifest`: 0.5.4 -> 0.5.5 (✓ API compatible changes)
* `bphelper-build`: 0.4.6 -> 0.4.7 (✓ API compatible changes)
* `bphelper-cli`: 0.7.6 -> 0.8.0 (⚠ API breaking changes)
* `battery-pack`: 0.5.1 -> 0.5.2 (✓ API compatible changes)
* `cargo-bp`: 0.5.2 -> 0.5.3
* `cli-battery-pack`: 0.6.0 -> 0.6.1 (✓ API compatible changes)
* `ci-battery-pack`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `error-battery-pack`: 0.6.0 -> 0.6.1 (✓ API compatible changes)
* `logging-battery-pack`: 0.5.0 -> 0.5.1 (✓ API compatible changes)

### ⚠ `bphelper-cli` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function bphelper_cli::validate_templates, previously in file /tmp/.tmpn4oqIv/bphelper-cli/src/validate/mod.rs:101
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `bphelper-manifest`

<blockquote>

## [0.5.5](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-manifest-v0.5.4...bphelper-manifest-v0.5.5) - 2026-04-30

### Added

- *(bp-managed)* allow features and other keys alongside bp-managed
- *(manifest)* add format.templates.cargo-toml validation rule

### Fixed

- rename template Cargo.toml to _Cargo.toml, flip assertions
</blockquote>

## `bphelper-build`

<blockquote>

## [0.4.7](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-build-v0.4.6...bphelper-build-v0.4.7) - 2026-04-30

### Added

- rename validate_templates to validate

### Other

- *(test)* add spirit asserts alongside snapshots, inline small file snapshots
</blockquote>

## `bphelper-cli`

<blockquote>

## [0.8.0](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.7.6...bphelper-cli-v0.8.0) - 2026-04-30

### Added

- use bp-managed in templates, add with_template snapshot tests
- *(bp-managed)* allow features and other keys alongside bp-managed
- rename validate_templates to validate
- *(template-engine)* map _Cargo.toml to Cargo.toml in rendered output
- validate templates from packaged tarball (inverted assertions)

### Fixed

- *(validate)* fall back to source tree when workspace deps are unpublished
- rename template Cargo.toml to _Cargo.toml, flip assertions

### Other

- Merge pull request #120 from jlizen/feat/defines-in-show
- Merge pull request #121 from jlizen/fix/preserve-cargo-toml-in-tarball
- *(test)* add spirit asserts alongside snapshots, inline small file snapshots
</blockquote>

## `battery-pack`

<blockquote>

## [0.5.2](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.5.1...battery-pack-v0.5.2) - 2026-04-30

### Added

- use bp-managed in templates, add with_template snapshot tests
- *(bp-managed)* allow features and other keys alongside bp-managed
- rename validate_templates to validate
- *(template-engine)* map _Cargo.toml to Cargo.toml in rendered output
- *(manifest)* add format.templates.cargo-toml validation rule
- validate templates from packaged tarball (inverted assertions)

### Fixed

- *(validate)* fall back to source tree when workspace deps are unpublished
- rename template Cargo.toml to _Cargo.toml, flip assertions
- remove trailing newline from with_template snapshot

### Other

- Merge pull request #120 from jlizen/feat/defines-in-show
- Merge pull request #121 from jlizen/fix/preserve-cargo-toml-in-tarball
- *(test)* add spirit asserts alongside snapshots, inline small file snapshots
</blockquote>

## `cargo-bp`

<blockquote>

## [0.5.3](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-v0.5.2...cargo-bp-v0.5.3) - 2026-04-30

### Added

- use bp-managed in templates, add with_template snapshot tests
- rename validate_templates to validate
- validate templates from packaged tarball (inverted assertions)
- *(bp-managed)* allow features and other keys alongside bp-managed
- *(template-engine)* map _Cargo.toml to Cargo.toml in rendered output

### Fixed

- remove trailing newline from with_template snapshot
- rename template Cargo.toml to _Cargo.toml, flip assertions
- *(validate)* fall back to source tree when workspace deps are unpublished

### Other

- Merge pull request #120 from jlizen/feat/defines-in-show
- Merge pull request #121 from jlizen/fix/preserve-cargo-toml-in-tarball
- *(test)* add spirit asserts alongside snapshots, inline small file snapshots
</blockquote>

## `cli-battery-pack`

<blockquote>

## [0.6.1](https://github.com/battery-pack-rs/battery-pack/compare/cli-battery-pack-v0.6.0...cli-battery-pack-v0.6.1) - 2026-04-30

### Added

- rename validate_templates to validate
- validate templates from packaged tarball (inverted assertions)

### Fixed

- rename template Cargo.toml to _Cargo.toml, flip assertions
</blockquote>

## `ci-battery-pack`

<blockquote>

## [0.1.4](https://github.com/battery-pack-rs/battery-pack/compare/ci-battery-pack-v0.1.3...ci-battery-pack-v0.1.4) - 2026-04-30

### Added

- rename validate_templates to validate
- *(ci-battery-pack)* add validate test, merged snapshot tests for all templates

### Fixed

- rename template Cargo.toml to _Cargo.toml, flip assertions

### Other

- Merge pull request #120 from jlizen/feat/defines-in-show
- *(ci-battery-pack)* replace file list and contains tests with merged snapshots
- *(ci-battery-pack)* expand hints
- *(ci)* restructure README for template merging ([#115](https://github.com/battery-pack-rs/battery-pack/pull/115))
</blockquote>

## `error-battery-pack`

<blockquote>

## [0.6.1](https://github.com/battery-pack-rs/battery-pack/compare/error-battery-pack-v0.6.0...error-battery-pack-v0.6.1) - 2026-04-30

### Added

- rename validate_templates to validate
</blockquote>

## `logging-battery-pack`

<blockquote>

## [0.5.1](https://github.com/battery-pack-rs/battery-pack/compare/logging-battery-pack-v0.5.0...logging-battery-pack-v0.5.1) - 2026-04-30

### Added

- rename validate_templates to validate
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).