### PR TITLE
docs(ci-battery-pack): expand hints

### DIFF
--- a/battery-packs/ci-battery-pack/snippets/github/jobs/clippy-sarif.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/clippy-sarif.yml
@@ -1,4 +1,5 @@
   # Clippy with GitHub PR annotations via SARIF (https://github.com/psastras/sarif-rs)
+  # For private repos, enable Code Scanning at Settings → Security → Code security.
   clippy-sarif:
     runs-on: ubuntu-latest
     permissions:

--- a/battery-packs/ci-battery-pack/templates/benchmarks/bp-template.toml
+++ b/battery-packs/ci-battery-pack/templates/benchmarks/bp-template.toml
@@ -11,3 +11,6 @@ default = "OWNER"
 
 [[hints]]
 message = "Edit benches/example_bench.rs with your benchmarks"
+
+[[hints]]
+message = "Create a Bencher project at https://bencher.dev/docs, then add BENCHER_API_TOKEN as a repo secret and BENCHER_PROJECT as a repo variable"

--- a/battery-packs/ci-battery-pack/templates/binary-release/.github/workflows/build-binaries.yml
+++ b/battery-packs/ci-battery-pack/templates/binary-release/.github/workflows/build-binaries.yml
@@ -2,6 +2,10 @@
 # Builds cross-platform binaries and uploads to GitHub Releases.
 # Binaries are discoverable by cargo-binstall (https://github.com/cargo-bins/cargo-binstall).
 # Triggered automatically when release-plz publishes a release.
+# Requires the trusted-publishing template. Add a RELEASE_PLZ_TOKEN PAT
+# (contents:write + pull-requests:write) as a repo secret so release events
+# trigger this workflow.
+# https://github.com/settings/personal-access-tokens/new
 name: Build Binaries
 
 on:

--- a/battery-packs/ci-battery-pack/templates/binary-release/bp-template.toml
+++ b/battery-packs/ci-battery-pack/templates/binary-release/bp-template.toml
@@ -11,3 +11,6 @@ default = "OWNER"
 
 [[hints]]
 message = "Update the [[bin]] name in Cargo.toml to match your binary"
+
+[[hints]]
+message = "Requires the trusted-publishing template. Create a fine-grained PAT with contents:write and pull-requests:write, then add it as a RELEASE_PLZ_TOKEN repo secret so release events trigger the binary build"

--- a/battery-packs/ci-battery-pack/templates/clippy-sarif/.github/workflows/clippy-sarif.yml
+++ b/battery-packs/ci-battery-pack/templates/clippy-sarif/.github/workflows/clippy-sarif.yml
@@ -1,6 +1,8 @@
 {%- if ci_platform == "github" -%}
 # Clippy with GitHub PR annotations via SARIF
 # https://github.com/psastras/sarif-rs
+# Works automatically on public repos. For private repos, enable Code Scanning
+# at Settings → Security → Code security.
 name: Clippy SARIF
 
 on:

--- a/battery-packs/ci-battery-pack/templates/clippy-sarif/bp-template.toml
+++ b/battery-packs/ci-battery-pack/templates/clippy-sarif/bp-template.toml
@@ -8,3 +8,6 @@ default = "github"
 type = "string"
 prompt = "Repository owner (org or user)"
 default = "OWNER"
+
+[[hints]]
+message = "Works automatically on public repos. For private repos, enable Code Scanning at Settings → Security → Code security"

--- a/battery-packs/ci-battery-pack/templates/full/bp-template.toml
+++ b/battery-packs/ci-battery-pack/templates/full/bp-template.toml
@@ -75,4 +75,4 @@ prompt = "Repository URL (leave empty for GitHub default)"
 default = ""
 
 [[hints]]
-message = "Review the generated workflows in .github/workflows/ and adjust to your project"
+message = "See setup instructions at https://crates.io/crates/ci-battery-pack#setup"

--- a/battery-packs/ci-battery-pack/templates/mdbook/.github/workflows/mdbook.yml
+++ b/battery-packs/ci-battery-pack/templates/mdbook/.github/workflows/mdbook.yml
@@ -1,5 +1,6 @@
 {%- if ci_platform == "github" -%}
 # https://rust-lang.github.io/mdBook/
+# Setup: enable GitHub Pages in repo Settings → Pages → Source: GitHub Actions
 name: Deploy mdBook
 
 on:

--- a/battery-packs/ci-battery-pack/templates/mdbook/bp-template.toml
+++ b/battery-packs/ci-battery-pack/templates/mdbook/bp-template.toml
@@ -10,6 +10,9 @@ prompt = "Repository owner (org or user)"
 default = "OWNER"
 
 [[hints]]
+message = "Enable GitHub Pages in repo Settings → Pages → Source: GitHub Actions"
+
+[[hints]]
 message = "Install mdbook: cargo install mdbook"
 
 [[hints]]

--- a/battery-packs/ci-battery-pack/templates/trusted-publishing/.github/workflows/release.yml
+++ b/battery-packs/ci-battery-pack/templates/trusted-publishing/.github/workflows/release.yml
@@ -1,9 +1,15 @@
 {%- if ci_platform == "github" -%}
 # release-plz: automated releases to crates.io (https://release-plz.dev/docs)
-# Setup: configure trusted publishing on crates.io
-#   https://doc.rust-lang.org/cargo/reference/registry-authentication.html#trusted-publishing
-# If using binary_release, also add a RELEASE_PLZ_TOKEN PAT (contents + pull-requests: write)
-#   https://github.com/settings/personal-access-tokens/new
+# Setup:
+# 1. Configure trusted publishing on crates.io
+#    https://doc.rust-lang.org/cargo/reference/registry-authentication.html#trusted-publishing
+# 2. In repo Settings → Actions → General, enable
+#    "Allow GitHub Actions to create and approve pull requests"
+{%- if all or binary_release %}
+# 3. Create a fine-grained PAT (contents:write + pull-requests:write) and add
+#    it as a RELEASE_PLZ_TOKEN repo secret so release events trigger binary builds
+#    https://github.com/settings/personal-access-tokens/new
+{%- endif %}
 name: Release
 
 on:

--- a/battery-packs/ci-battery-pack/templates/trusted-publishing/bp-template.toml
+++ b/battery-packs/ci-battery-pack/templates/trusted-publishing/bp-template.toml
@@ -10,4 +10,7 @@ prompt = "Repository owner (org or user)"
 default = "OWNER"
 
 [[hints]]
-message = "Set up trusted publishing for your crate on crates.io (see https://doc.rust-lang.org/cargo/reference/registry-authentication.html#trusted-publishing)"
+message = "Configure trusted publishing on crates.io: https://doc.rust-lang.org/cargo/reference/registry-authentication.html#trusted-publishing"
+
+[[hints]]
+message = "In repo Settings → Actions → General, enable 'Allow GitHub Actions to create and approve pull requests'"


### PR DESCRIPTION
Tweaking the ci-battery-pack docs to be clearer about setting up token permissions in two places:
- inline in templates
- in post-install hints

Previously the README was the source of truth. But, that is less discoverable for actual `cargo bp use/new` usage. We can have it in all three places.