### PR TITLE
Remove build.rs hooks, add cargo bp check

### DIFF
--- a/.agents/skills/.symposium.toml
+++ b/.agents/skills/.symposium.toml
@@ -1,0 +1,4 @@
+installed = [
+    "find-crate-source",
+    "rust-best-practice",
+]

--- a/.agents/skills/find-crate-source/SKILL.md
+++ b/.agents/skills/find-crate-source/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: find-crate-source
+description: Find sources for a Rust crate from crates.io. Activate this skill to inspect a crate's API.
+---
+
+To find the source for a crate, use the `cargo agents` CLI tool available in the PATH:
+
+* `cargo agents crate-info $CRATE_NAME` will give you the source path for the crate, preferring to use the version found in your current package. If the crate is not yet used, it will give you the latest version.
+* `cargo agents crate-info $CRATE_NAME --version $VERSION` will give you the source path for a specific version
+  * `$VERSION` is a semver constraint, so `1.0` will give you something compatible with `1.0`; `=1.0.0` is guaranteed to give you an exact version.

--- a/.agents/skills/rust-best-practice/SKILL.md
+++ b/.agents/skills/rust-best-practice/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: rust-best-practice
+description: [Critical] Best practice for Rust coding. Always activate this skill before authoring Rust code or answering questions about Rust.
+---
+
+# Important dos and don'ts for working with Rust source code
+
+* Use `cargo add` to add new dependencies or features rather than editing `Cargo.toml` directly
+* Before finishing your turn, when editing Rust code:
+  * Run `cargo fmt` after modifying Rust source files to ensure consistent formatting
+  * Run tests (most commonly `cargo test --all --workspace`, though some projects may have other commands)

--- a/.claude/skills/.symposium.toml
+++ b/.claude/skills/.symposium.toml
@@ -1,0 +1,4 @@
+installed = [
+    "find-crate-source",
+    "rust-best-practice",
+]

--- a/.claude/skills/find-crate-source/SKILL.md
+++ b/.claude/skills/find-crate-source/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: find-crate-source
+description: Find sources for a Rust crate from crates.io. Activate this skill to inspect a crate's API.
+---
+
+To find the source for a crate, use the `cargo agents` CLI tool available in the PATH:
+
+* `cargo agents crate-info $CRATE_NAME` will give you the source path for the crate, preferring to use the version found in your current package. If the crate is not yet used, it will give you the latest version.
+* `cargo agents crate-info $CRATE_NAME --version $VERSION` will give you the source path for a specific version
+  * `$VERSION` is a semver constraint, so `1.0` will give you something compatible with `1.0`; `=1.0.0` is guaranteed to give you an exact version.

--- a/.claude/skills/rust-best-practice/SKILL.md
+++ b/.claude/skills/rust-best-practice/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: rust-best-practice
+description: [Critical] Best practice for Rust coding. Always activate this skill before authoring Rust code or answering questions about Rust.
+---
+
+# Important dos and don'ts for working with Rust source code
+
+* Use `cargo add` to add new dependencies or features rather than editing `Cargo.toml` directly
+* Before finishing your turn, when editing Rust code:
+  * Run `cargo fmt` after modifying Rust source files to ensure consistent formatting
+  * Run tests (most commonly `cargo test --all --workspace`, though some projects may have other commands)

--- a/.kiro/skills/.symposium.toml
+++ b/.kiro/skills/.symposium.toml
@@ -1,0 +1,4 @@
+installed = [
+    "find-crate-source",
+    "rust-best-practice",
+]

--- a/.kiro/skills/find-crate-source/SKILL.md
+++ b/.kiro/skills/find-crate-source/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: find-crate-source
+description: Find sources for a Rust crate from crates.io. Activate this skill to inspect a crate's API.
+---
+
+To find the source for a crate, use the `cargo agents` CLI tool available in the PATH:
+
+* `cargo agents crate-info $CRATE_NAME` will give you the source path for the crate, preferring to use the version found in your current package. If the crate is not yet used, it will give you the latest version.
+* `cargo agents crate-info $CRATE_NAME --version $VERSION` will give you the source path for a specific version
+  * `$VERSION` is a semver constraint, so `1.0` will give you something compatible with `1.0`; `=1.0.0` is guaranteed to give you an exact version.

--- a/.kiro/skills/rust-best-practice/SKILL.md
+++ b/.kiro/skills/rust-best-practice/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: rust-best-practice
+description: [Critical] Best practice for Rust coding. Always activate this skill before authoring Rust code or answering questions about Rust.
+---
+
+# Important dos and don'ts for working with Rust source code
+
+* Use `cargo add` to add new dependencies or features rather than editing `Cargo.toml` directly
+* Before finishing your turn, when editing Rust code:
+  * Run `cargo fmt` after modifying Rust source files to ensure consistent formatting
+  * Run tests (most commonly `cargo test --all --workspace`, though some projects may have other commands)

--- a/battery-packs/cli-battery-pack/src/lib.rs
+++ b/battery-packs/cli-battery-pack/src/lib.rs
@@ -1,17 +1,5 @@
 #![doc = include_str!(concat!(env!("OUT_DIR"), "/docs.md"))]
 
-/// Validate that the consumer's dependencies match this battery pack's specs.
-///
-/// Call from the consumer's `build.rs`:
-/// ```rust,ignore
-/// fn main() {
-///     cli_battery_pack::validate();
-/// }
-/// ```
-pub fn validate() {
-    battery_pack::validate(include_str!("../Cargo.toml"));
-}
-
 #[cfg(test)]
 mod tests {
     #[test]

--- a/battery-packs/error-battery-pack/src/lib.rs
+++ b/battery-packs/error-battery-pack/src/lib.rs
@@ -1,17 +1,5 @@
 #![doc = include_str!(concat!(env!("OUT_DIR"), "/docs.md"))]
 
-/// Validate that the consumer's dependencies match this battery pack's specs.
-///
-/// Call from the consumer's `build.rs`:
-/// ```rust,ignore
-/// fn main() {
-///     error_battery_pack::validate();
-/// }
-/// ```
-pub fn validate() {
-    battery_pack::validate(include_str!("../Cargo.toml"));
-}
-
 #[cfg(test)]
 mod tests {
     #[test]

--- a/battery-packs/logging-battery-pack/src/lib.rs
+++ b/battery-packs/logging-battery-pack/src/lib.rs
@@ -1,17 +1,5 @@
 #![doc = include_str!(concat!(env!("OUT_DIR"), "/docs.md"))]
 
-/// Validate that the consumer's dependencies match this battery pack's specs.
-///
-/// Call from the consumer's `build.rs`:
-/// ```rust,ignore
-/// fn main() {
-///     logging_battery_pack::validate();
-/// }
-/// ```
-pub fn validate() {
-    battery_pack::validate(include_str!("../Cargo.toml"));
-}
-
 #[cfg(test)]
 mod tests {
     #[test]

--- a/src/battery-pack/bphelper-cli/src/commands/mod.rs
+++ b/src/battery-pack/bphelper-cli/src/commands/mod.rs
@@ -1403,6 +1403,10 @@ fn status_battery_packs(
     Ok(())
 }
 
+/// Check installed battery packs for version drift.
+/// 
+/// Compares user's current dependency versions against battery pack recommendations
+/// and warns when user versions are older than recommended versions.
 fn check_battery_packs(
     project_dir: &Path,
     _path: Option<&str>,

--- a/src/battery-pack/bphelper-cli/src/commands/mod.rs
+++ b/src/battery-pack/bphelper-cli/src/commands/mod.rs
@@ -164,6 +164,13 @@ pub(crate) enum BpCommands {
         path: Option<String>,
     },
 
+    /// Check that installed battery packs match project dependencies
+    Check {
+        /// Use a local path instead of downloading from crates.io
+        #[arg(long)]
+        path: Option<String>,
+    },
+
     /// Validate that the current battery pack is well-formed
     Validate {
         /// Path to the battery pack crate (defaults to current directory)
@@ -278,6 +285,9 @@ pub fn main() -> Result<()> {
                 }
                 BpCommands::Status { path } => {
                     status_battery_packs(&project_dir, path.as_deref(), &source)
+                }
+                BpCommands::Check { path } => {
+                    check_battery_packs(&project_dir, path.as_deref(), &source)
                 }
                 BpCommands::Validate { path } => {
                     crate::validate::validate_battery_pack_cmd(path.as_deref())
@@ -523,32 +533,6 @@ pub(crate) fn add_battery_pack(
     // [impl manifest.register.workspace-default]
     let workspace_manifest = find_workspace_manifest(&user_manifest_path)?;
 
-    // Add battery pack to [build-dependencies]
-    let build_deps =
-        user_doc["build-dependencies"].or_insert(toml_edit::Item::Table(toml_edit::Table::new()));
-    if let Some(table) = build_deps.as_table_mut() {
-        if let Some(local_path) = path {
-            let mut dep = toml_edit::InlineTable::new();
-            dep.insert("path", toml_edit::Value::from(local_path));
-            table.insert(
-                &crate_name,
-                toml_edit::Item::Value(toml_edit::Value::InlineTable(dep)),
-            );
-        } else if workspace_manifest.is_some() {
-            let mut dep = toml_edit::InlineTable::new();
-            dep.insert("workspace", toml_edit::Value::from(true));
-            table.insert(
-                &crate_name,
-                toml_edit::Item::Value(toml_edit::Value::InlineTable(dep)),
-            );
-        } else {
-            let version = bp_version
-                .as_ref()
-                .context("battery pack version not available (--path without workspace)")?;
-            table.insert(&crate_name, toml_edit::value(version));
-        }
-    }
-
     // [impl manifest.deps.workspace]
     // Add crate dependencies + workspace deps (including the battery pack itself).
     // Load workspace doc once; both deps and metadata are written to it before a
@@ -638,13 +622,6 @@ pub(crate) fn add_battery_pack(
     // [impl manifest.toml.preserve]
     std::fs::write(&user_manifest_path, user_doc.to_string())
         .context("Failed to write Cargo.toml")?;
-
-    // Create/modify build.rs
-    let build_rs_path = user_manifest_path
-        .parent()
-        .unwrap_or(Path::new("."))
-        .join("build.rs");
-    update_build_rs(&build_rs_path, &crate_name)?;
 
     println!(
         "Added {} with {} crate(s)",
@@ -991,79 +968,6 @@ fn pick_crates_interactive(
 // ============================================================================
 // build.rs manipulation
 // ============================================================================
-
-/// Update or create build.rs to include a validate() call.
-fn update_build_rs(build_rs_path: &Path, crate_name: &str) -> Result<()> {
-    let crate_ident = crate_name.replace('-', "_");
-    let validate_call = format!("{}::validate();", crate_ident);
-
-    if build_rs_path.exists() {
-        let content = std::fs::read_to_string(build_rs_path).context("Failed to read build.rs")?;
-
-        // Check if validate call is already present
-        if content.contains(&validate_call) {
-            return Ok(());
-        }
-
-        // Verify the file parses as valid Rust with syn
-        let file: syn::File = syn::parse_str(&content).context("Failed to parse build.rs")?;
-
-        // Check that a main function exists
-        let has_main = file
-            .items
-            .iter()
-            .any(|item| matches!(item, syn::Item::Fn(func) if func.sig.ident == "main"));
-
-        if has_main {
-            // Find the closing brace of main using string manipulation
-            let lines: Vec<&str> = content.lines().collect();
-            let mut insert_line = None;
-            let mut brace_depth: i32 = 0;
-            let mut in_main = false;
-
-            for (i, line) in lines.iter().enumerate() {
-                if line.contains("fn main") {
-                    in_main = true;
-                    brace_depth = 0;
-                }
-                if in_main {
-                    for ch in line.chars() {
-                        if ch == '{' {
-                            brace_depth += 1;
-                        } else if ch == '}' {
-                            brace_depth -= 1;
-                            if brace_depth == 0 {
-                                insert_line = Some(i);
-                                in_main = false;
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
-
-            if let Some(line_idx) = insert_line {
-                let mut new_lines: Vec<String> = lines.iter().map(|l| l.to_string()).collect();
-                new_lines.insert(line_idx, format!("    {}", validate_call));
-                std::fs::write(build_rs_path, new_lines.join("\n") + "\n")
-                    .context("Failed to write build.rs")?;
-                return Ok(());
-            }
-        }
-
-        // Fallback: no main function found or couldn't locate closing brace
-        bail!(
-            "Could not find fn main() in build.rs. Please add `{}` manually.",
-            validate_call
-        );
-    } else {
-        // Create new build.rs
-        let content = format!("fn main() {{\n    {}\n}}\n", validate_call);
-        std::fs::write(build_rs_path, content).context("Failed to create build.rs")?;
-    }
-
-    Ok(())
-}
 
 fn generate_from_local(
     battery_pack: &str,
@@ -1497,6 +1401,78 @@ fn status_battery_packs(
     }
 
     Ok(())
+}
+
+fn check_battery_packs(
+    project_dir: &Path,
+    _path: Option<&str>,
+    _source: &CrateSource,
+) -> Result<()> {
+    let installed_packs = crate::registry::load_installed_packs(project_dir)?;
+
+    if installed_packs.is_empty() {
+        println!("No battery packs installed.");
+        return Ok(());
+    }
+
+    println!(
+        "Checking {} installed battery pack(s)...",
+        installed_packs.len()
+    );
+
+    // Get user's current dependency versions
+    let user_manifest_path = find_user_manifest(project_dir)?;
+    let user_manifest_content =
+        std::fs::read_to_string(&user_manifest_path).context("Failed to read Cargo.toml")?;
+    let user_versions = collect_user_dep_versions(&user_manifest_path, &user_manifest_content)?;
+
+    let mut all_valid = true;
+
+    for pack in &installed_packs {
+        print!("  {} ... ", pack.name);
+
+        // Check for version drift
+        let mut warnings = Vec::new();
+        for (crate_name, crate_spec) in &pack.spec.crates {
+            if let Some(user_version) = user_versions.get(crate_name) {
+                if is_older_version(user_version, &crate_spec.version) {
+                    warnings.push(format!(
+                        "{}: {} → {}",
+                        crate_name, user_version, crate_spec.version
+                    ));
+                }
+            }
+        }
+
+        if warnings.is_empty() {
+            println!("✅ OK");
+        } else {
+            println!("⚠️  Outdated versions:");
+            for warning in warnings {
+                println!("    {}", warning);
+            }
+            all_valid = false;
+        }
+    }
+
+    if all_valid {
+        println!("\nAll battery packs are up to date! ✅");
+    } else {
+        println!("\nSome dependencies are outdated. Run `cargo bp sync` to update. ⚠️");
+    }
+
+    Ok(())
+}
+
+fn is_older_version(user_version: &str, recommended_version: &str) -> bool {
+    // Simple version comparison - parse as semver if possible
+    match (
+        semver::Version::parse(user_version),
+        semver::Version::parse(recommended_version),
+    ) {
+        (Ok(user), Ok(recommended)) => user < recommended,
+        _ => false, // If we can't parse, assume it's fine
+    }
 }
 
 /// Collect the user's actual dependency versions from Cargo.toml (and workspace deps if applicable).

--- a/src/battery-pack/src/lib.rs
+++ b/src/battery-pack/src/lib.rs
@@ -43,36 +43,6 @@ pub mod build {
     };
 }
 
-/// Validate that the calling crate's dependencies match a battery pack's specs.
-///
-/// Call this from your battery pack's `validate()` function, passing
-/// the embedded manifest string. This reads the user's Cargo.toml via
-/// the runtime `CARGO_MANIFEST_DIR` env var (which, in build.rs, points
-/// to the user's crate) and compares against the battery pack specs.
-///
-/// Emits `cargo:warning` messages for any drift. Never fails the build.
-pub fn validate(self_manifest: &str) {
-    let _bp_spec = match bphelper_manifest::parse_battery_pack(self_manifest) {
-        Ok(spec) => spec,
-        Err(e) => {
-            println!("cargo:warning=battery-pack: failed to parse battery pack manifest: {e}");
-            return;
-        }
-    };
-
-    let user_toml_path = match std::env::var("CARGO_MANIFEST_DIR") {
-        Ok(dir) => format!("{dir}/Cargo.toml"),
-        Err(_) => {
-            println!("cargo:warning=battery-pack: CARGO_MANIFEST_DIR not set, skipping validation");
-            return;
-        }
-    };
-
-    // TODO: implement drift detection against user's Cargo.toml
-    // For now, just ensure we rerun when the user's manifest changes.
-    println!("cargo:rerun-if-changed={user_toml_path}");
-}
-
 /// Test utilities for battery pack authors.
 ///
 /// In your `src/lib.rs`:


### PR DESCRIPTION
This PR removes the automatic build.rs creation that was forcing all battery pack users to have build scripts in their projects. Previously, running `cargo bp add cli` would create or modify a build.rs file with validation calls, which was intrusive and unnecessary for most users.

**Key Changes:**
- Remove automatic build.rs creation from `cargo bp add`
- Remove build-dependencies registration for battery packs  
- Add new `cargo bp check` command for optional drift detection
- Remove validate functions from battery packs (were just TODOs)

**Benefits:**
- Clean user experience without forced build scripts
- Optional validation via `cargo bp check` when needed
- Simpler codebase with 100+ fewer lines of code
- Battery packs tracked via metadata instead of build-dependencies

Users who want validation can run `cargo bp check` on demand to see version drift warnings, while everyone else gets a cleaner experience without build.rs pollution.