### PR TITLE
feat(cli): add -d/--define flag to `cargo bp show -t`

### DIFF
--- a/battery-packs/ci-battery-pack/README.md
+++ b/battery-packs/ci-battery-pack/README.md
@@ -18,6 +18,13 @@ New files are written directly. For existing files, TOML and YAML are merged (ne
 
 Available standalone templates: `benchmarks`, `binary-release`, `clippy-sarif`, `fuzzing`, `mdbook`, `mutation-testing`, `spellcheck`, `stress-test`, `trusted-publishing`, `xtask`.
 
+Preview any template before applying it:
+
+```sh
+cargo bp show ci -t fuzzing
+cargo bp show ci -t full -d benchmarks -d fuzzing
+```
+
 ## Creating a new project
 
 The `full` template scaffolds a complete project (Cargo.toml, src/lib.rs, README with badges) plus CI configuration:

--- a/md/spec/cli.md
+++ b/md/spec/cli.md
@@ -413,3 +413,8 @@ SHOULD be shown in the interactive TUI preview screen. With
 Placeholders without a default MUST fall back to `<name>` so the
 preview always succeeds. The project name MUST default to
 `my-project`.
+
+r[cli.show.define-flag]
+`cargo bp show <pack> -t <name> --define <key>=<value>` (or `-d`)
+MUST set the named placeholder to the given value in the rendered
+preview. Multiple `-d` flags MAY be provided.

--- a/md/templates.md
+++ b/md/templates.md
@@ -9,6 +9,7 @@ To see what templates a battery pack offers:
 ```bash
 cargo bp show ci                  # lists templates in the detail view
 cargo bp show ci -t spellcheck    # preview the rendered output
+cargo bp show ci -t full -d fuzzing -d repo_owner=myorg  # preview with placeholder overrides
 ```
 
 If a battery pack has multiple templates and you don't pass `-t`, you'll be prompted to pick one.

--- a/src/battery-pack/bphelper-cli/src/commands/mod.rs
+++ b/src/battery-pack/bphelper-cli/src/commands/mod.rs
@@ -177,6 +177,10 @@ pub(crate) enum BpCommands {
         /// Use a local path instead of downloading from crates.io
         #[arg(long)]
         path: Option<String>,
+
+        /// Set a template placeholder value (e.g., -d description="My project")
+        #[arg(long = "define", short = 'd', value_parser = parse_define)]
+        define: Vec<(String, String)>,
     },
 
     /// Show status of installed battery packs and version warnings
@@ -322,12 +326,14 @@ pub fn main() -> Result<()> {
                     battery_pack,
                     template,
                     path,
+                    define,
                 } => {
                     let show_opts = crate::tui::ShowOpts {
                         battery_pack: &battery_pack,
                         template: template.as_deref(),
                         path: path.as_deref(),
                         source,
+                        defines: define.into_iter().collect(),
                     };
                     if interactive {
                         // [impl cli.show.interactive]
@@ -340,6 +346,7 @@ pub fn main() -> Result<()> {
                             template: tmpl,
                             path: show_opts.path,
                             source: &show_opts.source,
+                            defines: show_opts.defines,
                         })
                     } else {
                         // [impl cli.show.non-interactive]

--- a/src/battery-pack/bphelper-cli/src/commands/tests.rs
+++ b/src/battery-pack/bphelper-cli/src/commands/tests.rs
@@ -388,6 +388,75 @@ fn show_without_template_has_none() {
     }
 }
 
+#[test]
+fn show_define_short_flag_is_parsed() {
+    let cli = super::Cli::try_parse_from([
+        "cargo",
+        "bp",
+        "show",
+        "cli",
+        "-t",
+        "default",
+        "-d",
+        "key=value",
+    ])
+    .expect("-d should be accepted");
+
+    match unwrap_bp_command(cli) {
+        super::BpCommands::Show { define, .. } => {
+            assert_eq!(define, vec![("key".into(), "value".into())]);
+        }
+        other => panic!("expected Show, got {:?}", std::mem::discriminant(&other)),
+    }
+}
+
+#[test]
+fn show_define_long_flag_is_parsed() {
+    let cli = super::Cli::try_parse_from([
+        "cargo", "bp", "show", "cli", "-t", "default", "--define", "ci=true",
+    ])
+    .expect("--define should be accepted");
+
+    match unwrap_bp_command(cli) {
+        super::BpCommands::Show { define, .. } => {
+            assert_eq!(define, vec![("ci".into(), "true".into())]);
+        }
+        other => panic!("expected Show, got {:?}", std::mem::discriminant(&other)),
+    }
+}
+
+#[test]
+fn show_define_multiple_values() {
+    let cli = super::Cli::try_parse_from([
+        "cargo", "bp", "show", "cli", "-t", "default", "-d", "a=1", "-d", "b=2",
+    ])
+    .expect("repeated -d should be accepted");
+
+    match unwrap_bp_command(cli) {
+        super::BpCommands::Show { define, .. } => {
+            assert_eq!(
+                define,
+                vec![("a".into(), "1".into()), ("b".into(), "2".into())]
+            );
+        }
+        other => panic!("expected Show, got {:?}", std::mem::discriminant(&other)),
+    }
+}
+
+#[test]
+fn show_define_without_value_defaults_to_true() {
+    let cli =
+        super::Cli::try_parse_from(["cargo", "bp", "show", "cli", "-t", "default", "-d", "flag"])
+            .expect("-d flag (no =) should be accepted");
+
+    match unwrap_bp_command(cli) {
+        super::BpCommands::Show { define, .. } => {
+            assert_eq!(define, vec![("flag".into(), "true".into())]);
+        }
+        other => panic!("expected Show, got {:?}", std::mem::discriminant(&other)),
+    }
+}
+
 // [verify cli.list.non-interactive]
 #[test]
 fn list_non_interactive_flag_is_parsed() {

--- a/src/battery-pack/bphelper-cli/src/template_engine.rs
+++ b/src/battery-pack/bphelper-cli/src/template_engine.rs
@@ -670,6 +670,7 @@ pub(crate) struct PreviewOpts<'a> {
     pub template: &'a str,
     pub path: Option<&'a str>,
     pub source: &'a crate::registry::CrateSource,
+    pub defines: BTreeMap<String, String>,
 }
 
 /// Resolve a battery pack template and render a preview.
@@ -698,7 +699,7 @@ pub(crate) fn preview_template(opts: &PreviewOpts<'_>) -> Result<(String, Vec<Re
         crate_root: resolved.dir,
         template_path: tmpl.path.clone(),
         project_name: "my-project".to_string(),
-        defines: BTreeMap::new(),
+        defines: opts.defines.clone(),
         interactive_override: Some(false),
     };
     let files = preview(opts)?;

--- a/src/battery-pack/bphelper-cli/src/template_engine/tests.rs
+++ b/src/battery-pack/bphelper-cli/src/template_engine/tests.rs
@@ -711,6 +711,7 @@ fn preview_template_resolves_and_renders() {
         template: "default",
         path: None,
         source: &source,
+        defines: BTreeMap::new(),
     };
 
     let (crate_name, files) = preview_template(&opts).unwrap();

--- a/src/battery-pack/bphelper-cli/src/tui.rs
+++ b/src/battery-pack/bphelper-cli/src/tui.rs
@@ -31,6 +31,7 @@ pub(crate) struct ShowOpts<'a> {
     pub template: Option<&'a str>,
     pub path: Option<&'a str>,
     pub source: CrateSource,
+    pub defines: BTreeMap<String, String>,
 }
 
 /// Run the TUI starting from the list view
@@ -59,6 +60,7 @@ fn run_preview(opts: ShowOpts<'_>) -> Result<()> {
             template,
             path: opts.path,
             source: &opts.source,
+            defines: opts.defines,
         })?;
     let content = highlight_preview(&files);
 

--- a/src/cargo-bp/tests/show_preview.rs
+++ b/src/cargo-bp/tests/show_preview.rs
@@ -79,6 +79,62 @@ fn main() {
 }
 
 #[test]
+fn show_template_preview_with_define_flag() {
+    let fixture = fixtures_dir().join("fancy-battery-pack");
+
+    let output = cargo_bp()
+        .args([
+            "bp",
+            "show",
+            "fancy",
+            "-t",
+            "full",
+            "-d",
+            "greeting=Howdy",
+            "--non-interactive",
+            "--path",
+            &fixture.to_string_lossy(),
+        ])
+        .output()
+        .expect("failed to run cargo-bp");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Howdy from full template!"),
+        "define should override the default greeting, got:\n{stdout}"
+    );
+    assert_data_eq!(
+        stdout.as_ref(),
+        str![[r#"
+── Cargo.toml ──
+[package]
+name = "my-project"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+dialoguer = "0.11"
+indicatif = "0.17"
+console = "0.15"
+
+── src/main.rs ──
+fn main() {
+    println!("Howdy from full template!");
+}
+
+
+"#]]
+    );
+}
+
+#[test]
 fn show_template_preview_unknown_template_errors() {
     let fixture = fixtures_dir().join("fancy-battery-pack");
 

--- a/tests/fixtures/fancy-battery-pack/templates/full/bp-template.toml
+++ b/tests/fixtures/fancy-battery-pack/templates/full/bp-template.toml
@@ -1,0 +1,4 @@
+[placeholders.greeting]
+type = "string"
+prompt = "Greeting message"
+default = "Hello"

--- a/tests/fixtures/fancy-battery-pack/templates/full/src/main.rs
+++ b/tests/fixtures/fancy-battery-pack/templates/full/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    println!("Hello from full template!");
+    println!("{{ greeting }} from full template!");
 }


### PR DESCRIPTION
### Summary

Add `-d`/`--define` support to `cargo bp show <bp> -t <template>`, matching the flag already available on `new` and `add`. This lets users preview how template placeholders resolve without generating a project.

Previously placeholders were mostly for filling in free-text strings. But, with the CI battery pack, we are now branching on them to pick what renders. So we want to be able to specify eg `cargo bp show ci full -d all`.

Defines are threaded from the CLI through `ShowOpts` and `PreviewOpts` into the template engine's `RenderOpts`. The TUI interactive preview path (navigating to a template from the detail screen) still uses an empty defines map since there's no way to pass them interactively yet. It might be nice to have TUI support, but I'm not trying to add it now.

### Testing

Added CLI parsing tests for the new flag (short, long, repeated, bare). Added an integration test that sets `-d greeting=Howdy` on a fixture template with a `greeting` placeholder and verifies the rendered output contains the override via both a targeted assertion and a full snapbox snapshot.
