### PR TITLE
feat(error): add Symposium-compatible error handling skills

### DIFF
--- a/SYMPOSIUM.toml
+++ b/SYMPOSIUM.toml
@@ -1,0 +1,11 @@
+name = "battery-pack"
+crates = ["anyhow", "thiserror", "eyre", "color-eyre", "miette", "snafu", "displaydoc", "error-stack", "error-battery-pack"]
+
+[[skills]]
+source.path = "battery-packs/error-battery-pack/skills/error-handling-basics"
+
+[[skills]]
+source.path = "battery-packs/error-battery-pack/skills/library-errors"
+
+[[skills]]
+source.path = "battery-packs/error-battery-pack/skills/application-errors"

--- a/battery-packs/error-battery-pack/Cargo.toml
+++ b/battery-packs/error-battery-pack/Cargo.toml
@@ -6,7 +6,7 @@ description = "Error handling done well — anyhow for apps, thiserror for libra
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/battery-pack-rs/battery-pack"
 readme = "README.md"
-keywords = ["battery-pack", "error-handling", "anyhow", "thiserror"]
+keywords = ["battery-pack", "error-handling", "anyhow", "thiserror", "symposium"]
 
 [dependencies]
 battery-pack = { workspace = true }

--- a/battery-packs/error-battery-pack/README.md
+++ b/battery-packs/error-battery-pack/README.md
@@ -39,6 +39,10 @@ cargo run --example custom-errors -p error-battery-pack
 cargo run --example context-chain -p error-battery-pack
 ```
 
+## Acknowledgments
+
+The skill files in `skills/` are adapted from an error handling guide originally authored by [@terminalwitchcraft](https://github.com/terminalwitchcraft).
+
 ## License
 
 Licensed under either of:

--- a/battery-packs/error-battery-pack/skills/SYMPOSIUM.toml
+++ b/battery-packs/error-battery-pack/skills/SYMPOSIUM.toml
@@ -1,0 +1,11 @@
+name = "error-battery-pack"
+crates = ["anyhow", "thiserror", "eyre", "color-eyre", "miette", "snafu", "displaydoc", "error-stack", "error-battery-pack"]
+
+[[skills]]
+source.path = "error-handling-basics"
+
+[[skills]]
+source.path = "library-errors"
+
+[[skills]]
+source.path = "application-errors"

--- a/battery-packs/error-battery-pack/skills/application-errors/SKILL.md
+++ b/battery-packs/error-battery-pack/skills/application-errors/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: application-errors
+description: Propagating and formatting errors in Rust applications with anyhow
+---
+
+# Application Errors
+
+Propagating and formatting errors in binaries, CLI tools, and services.
+
+> **Prerequisites:** This skill references examples from the error battery pack.
+> ```sh
+> cargo install cargo-bp   # install the battery-pack CLI
+> cargo bp add error       # add anyhow + thiserror to your project
+> ```
+
+## main() Return Type
+
+For CLIs and tools, return `anyhow::Result` from `main()` to get automatic error printing:
+
+```rust
+fn main() -> anyhow::Result<()> {
+    let config = load_config()?;
+    run(config)
+}
+```
+
+For services or when you want control over error formatting, handle errors explicitly:
+
+```rust
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{e:?}");  // full chain with backtrace
+        std::process::exit(1);
+    }
+}
+```
+
+## Context Chains with anyhow
+
+When propagating errors, attach context describing what operation was being attempted (not what went wrong, since the source error already says that):
+
+```rust
+use anyhow::{Context, Result};
+
+fn read_config(path: &str) -> Result<Config> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read config from \"{path}\""))?;
+
+    let config: Config = toml::from_str(&content)
+        .context("failed to parse config")?;
+
+    Ok(config)
+}
+
+fn start_server() -> Result<()> {
+    let config = read_config("server.toml")
+        .context("failed to initialize server")?;
+    // ...
+    Ok(())
+}
+```
+
+This produces:
+
+```text
+failed to initialize server
+
+Caused by:
+    0: failed to read config from "server.toml"
+    1: No such file or directory (os error 2)
+```
+
+`.with_context(|| ...)` is the lazy variant for expensive format strings. Both also work on `Option<T>`, converting `None` into an error.
+
+```sh
+cargo run --example context-chain -p error-battery-pack
+```
+
+## Formatting for Logs vs Terminals
+
+| Formatter | Output |
+|-----------|--------|
+| `{:#}` | Single line, colon-separated: `outer: middle: root cause` |
+| `{:?}` | Multi-line "Caused by:" chain, plus backtrace if captured |
+
+Use `{:#}` for structured log fields. Use `{:?}` for terminal output.
+
+For structured logging with `tracing`, walk the chain explicitly:
+
+```rust
+fn error_chain(error: &anyhow::Error) -> Vec<String> {
+    error.chain().map(|e| e.to_string()).collect()
+}
+
+tracing::error!(
+    error = %err,
+    causes = ?error_chain(&err),
+    "request failed"
+);
+```
+
+## Backtrace Configuration
+
+| Variable | Effect |
+|----------|--------|
+| `RUST_BACKTRACE=1` | Capture backtraces on panic |
+| `RUST_LIB_BACKTRACE=1` | Capture backtraces inside `anyhow::Error` at creation |
+| `RUST_LIB_BACKTRACE=0` | Disable anyhow backtraces even when `RUST_BACKTRACE=1` |
+
+**For production services, set `RUST_BACKTRACE=1 RUST_LIB_BACKTRACE=0`.** Backtrace capture can be expensive under contention, and under high error rates the overhead can cause cascading latency spikes.
+
+## When to Reach for Custom Types
+
+`anyhow` is the right default, but define a custom error type when you need to branch on the error programmatically:
+
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum AppError {
+    #[error("not found: {0}")]
+    NotFound(String),
+
+    #[error("invalid input")]
+    BadRequest(#[source] anyhow::Error),
+
+    #[error("internal error")]
+    Internal(#[from] anyhow::Error),
+}
+
+impl AppError {
+    pub fn status_code(&self) -> u16 {
+        match self {
+            Self::NotFound(_) => 404,
+            Self::BadRequest(_) => 400,
+            Self::Internal(_) => 500,
+        }
+    }
+}
+
+// Wire into your HTTP framework's error response trait
+// (e.g., axum's IntoResponse, actix's ResponseError)
+```
+
+This composes with `anyhow`: library layers use `anyhow::Result` with `.context()`, and the outer handler maps into `AppError` at the boundary. `#[from] anyhow::Error` acts as a catch-all for unexpected failures.
+
+For errors that cross crate boundaries or need semver stability, see the **library-errors** skill.

--- a/battery-packs/error-battery-pack/skills/error-handling-basics/SKILL.md
+++ b/battery-packs/error-battery-pack/skills/error-handling-basics/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: error-handling-basics
+description: Essential Rust error handling rules for anyhow and thiserror users
+---
+
+# Error Handling Basics
+
+## Display must not include the source
+
+Error reporters walk `.source()` separately. Including it in `Display` causes double-printing:
+
+```rust
+// Wrong
+#[error("operation failed: {0}")]
+MyError(#[source] io::Error)
+
+// Right
+#[error("operation failed")]
+MyError(#[source] io::Error)
+```
+
+## Context describes what was attempted, not what failed
+
+```rust
+// Wrong: repeats what the source error already says
+.context("file not found")
+
+// Right: says what you were trying to do
+.context("failed to load user config")
+```
+
+## Production backtrace config
+
+Set `RUST_BACKTRACE=1 RUST_LIB_BACKTRACE=0`. This gives panic backtraces without the performance cost of capturing one on every `anyhow::Error`.
+
+## More guidance
+
+For comprehensive patterns (opaque library errors, internal error composition, structured logging, custom application error types), install the error battery pack:
+
+```sh
+cargo install cargo-bp
+cargo bp add error
+```

--- a/battery-packs/error-battery-pack/skills/library-errors/SKILL.md
+++ b/battery-packs/error-battery-pack/skills/library-errors/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: library-errors
+description: Modeling, exposing, and formatting errors in Rust libraries
+---
+
+# Library Errors
+
+How to model errors inside a crate, make them opaque at public boundaries, and control how they render.
+
+> **Prerequisites:** This skill references examples from the error battery pack.
+> ```sh
+> cargo install cargo-bp   # install the battery-pack CLI
+> cargo bp add error       # add anyhow + thiserror to your project
+> ```
+
+## Internal Error Types
+
+Within your crate boundary, use `thiserror` freely. No semver concerns since consumers never see these types.
+
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub(crate) enum StorageError {
+    #[error("failed to read from disk")]
+    Io(#[from] std::io::Error),
+
+    #[error("corrupt data at offset {offset}")]
+    Corrupt { offset: u64 },
+
+    #[error("item not found: {0}")]
+    NotFound(String),
+}
+```
+
+Guidelines for internal errors:
+
+- **One enum per module or subsystem.** Don't create a single god-error for the whole crate.
+- **Use `#[from]` liberally.** It generates `From` impls so `?` works across internal boundaries.
+- **Include diagnostic data in variants** (offsets, keys, paths). You control the match sites, so adding fields is free.
+- **No `#[non_exhaustive]` needed.** You own all the match arms.
+
+### Composing internal errors across modules
+
+```rust
+// in src/indexer.rs
+#[derive(Error, Debug)]
+pub(crate) enum IndexError {
+    #[error("storage failure")]
+    Storage(#[from] StorageError),
+
+    #[error("index corrupted")]
+    Corrupted,
+}
+```
+
+## Public API Boundary
+
+At the crate's public API, wrap internal errors in an opaque type. This decouples your internal structure from your consumers' code.
+
+### The Error+ErrorKind Pattern
+
+This is the same pattern used by `std::io::Error`. Private fields, `#[non_exhaustive]` kind enum, boxed cause:
+
+```rust
+use std::fmt::Display;
+
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum MyLibErrorKind {
+    QueueFull,
+    Storage,
+    NotFound,
+}
+
+#[derive(Debug)]
+pub struct MyLibError {
+    kind: MyLibErrorKind,
+    cause: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
+}
+
+impl MyLibError {
+    pub fn kind(&self) -> MyLibErrorKind {
+        self.kind
+    }
+
+    pub(crate) fn new(kind: MyLibErrorKind, cause: impl std::error::Error + Send + Sync + 'static) -> Self {
+        Self { kind, cause: Some(Box::new(cause)) }
+    }
+
+    pub(crate) fn from_kind(kind: MyLibErrorKind) -> Self {
+        Self { kind, cause: None }
+    }
+}
+
+impl Display for MyLibError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.kind {
+            MyLibErrorKind::QueueFull => write!(f, "queue is full"),
+            MyLibErrorKind::Storage => write!(f, "storage operation failed"),
+            MyLibErrorKind::NotFound => write!(f, "not found"),
+        }
+    }
+}
+
+impl std::error::Error for MyLibError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.cause.as_deref()
+    }
+}
+```
+
+This gives semver freedom: private fields hide internals, `#[non_exhaustive]` allows adding variants, and the boxed cause hides dependency types. `Copy` on the kind lets `.kind()` return by value; if you later need variants carrying data, derive only `Clone` and return `&MyLibErrorKind` instead.
+
+### Converting internal errors to the public type
+
+```rust
+impl From<StorageError> for MyLibError {
+    fn from(e: StorageError) -> Self {
+        let kind = match &e {
+            StorageError::NotFound(_) => MyLibErrorKind::NotFound,
+            _ => MyLibErrorKind::Storage,
+        };
+        MyLibError::new(kind, e)
+    }
+}
+```
+
+Map your rich internal taxonomy to the coarser public kinds. The internal error becomes the opaque `.source()`.
+
+### Using thiserror at the boundary (middle ground)
+
+`thiserror` with boxed sources gives derive convenience without exposing dependency types:
+
+```rust
+#[non_exhaustive]
+#[derive(Error, Debug)]
+pub enum MyLibError {
+    #[error("queue is full")]
+    QueueFull,
+
+    #[error("storage operation failed")]
+    Storage { #[source] source: Box<dyn std::error::Error + Send + Sync + 'static> },
+
+    #[error("not found")]
+    NotFound,
+}
+```
+
+Use this only for crates with stable, well-understood error categories. For evolving APIs, prefer the struct pattern: any public enum has a larger semver surface than a struct (variant names, field arity, and tuple positions are all public API).
+
+### How consumers use your error type
+
+```rust
+match client.upload(data) {
+    Ok(()) => {}
+    Err(e) => match e.kind() {
+        MyLibErrorKind::QueueFull => retry_later(),
+        MyLibErrorKind::NotFound => create_and_retry(),
+        _ => return Err(e.into()),
+    }
+}
+```
+
+## Formatting Rules
+
+### Display: only this error's message
+
+`Display` must not include the source. Reporters walk `.source()` separately:
+
+```rust
+// Wrong: source appears twice in output
+write!(f, "storage failed: {}", self.cause.as_ref().unwrap())
+
+// Right
+write!(f, "storage failed")
+```
+
+### Messages: lowercase, no trailing punctuation
+
+```rust
+// Good: composes well when reporters join with ": "
+"connection refused"
+"invalid header: expected utf-8"
+
+// Bad
+"Connection refused."
+"Error: Invalid header"
+```
+
+## Re-exporting Dependency Types
+
+If consumers need to downcast to your dependency's error type, re-export it:
+
+```rust
+pub use aws_sdk_s3::error::SdkError;
+```
+
+Prefer exposing information through your error kind or accessor methods over requiring consumers to downcast.
+
+## Checklist
+
+- [ ] Internal errors: `thiserror` enum per module, `#[from]` for conversions
+- [ ] Public errors: `#[non_exhaustive]`, private fields, accessor methods
+- [ ] `From` impls map internal errors to public error kinds
+- [ ] `Box<dyn Error + Send + Sync + 'static>` for causes (not concrete types)
+- [ ] `Display` prints only this error's message, never the source
+- [ ] `source()` returns the underlying cause
+- [ ] Messages lowercase, no trailing punctuation
+- [ ] Re-export dependency types only if consumers need to downcast
+
+## Related
+
+See the **application-errors** skill for the consumer side: propagating errors with `anyhow`, formatting for logs and terminals, backtrace configuration.
+
+```sh
+cargo run --example custom-errors -p error-battery-pack
+```

--- a/benchmarks/error-skills/EXPECTED.md
+++ b/benchmarks/error-skills/EXPECTED.md
@@ -1,0 +1,54 @@
+# Expected Outcomes
+
+## Tool usage analysis (run against `$LOG.raw`)
+
+```bash
+# Skills loaded and invoked
+jq -r 'select(.type == "assistant") | .message.content[]? | select(.type == "tool_use" and .name == "Skill") | .input.skill' "$LOG.raw"
+
+# All tool calls (summary of what the agent did)
+jq -r 'select(.type == "assistant") | .message.content[]? | select(.type == "tool_use") | .name' "$LOG.raw" | sort | uniq -c | sort -rn
+
+# Files read (codebase exploration)
+jq -r 'select(.type == "assistant") | .message.content[]? | select(.type == "tool_use" and .name == "Read") | .input.file_path // .input.path // empty' "$LOG.raw"
+
+# Bash commands run
+jq -r 'select(.type == "assistant") | .message.content[]? | select(.type == "tool_use" and .name == "Bash") | .input.command' "$LOG.raw"
+
+# Total turns
+jq -r 'select(.type == "result") | "Turns: \(.num_turns), Cost: $\(.total_cost_usd)"' "$LOG.raw"
+```
+
+## Skill activation
+
+- [ ] `error-handling-basics` appears in init skills list
+- [ ] `library-errors` appears in init skills list
+- [ ] `application-errors` appears in init skills list
+- [ ] Agent invoked `library-errors` skill
+- [ ] Agent invoked `application-errors` skill
+- [ ] Agent read project source files before proposing changes
+
+## Library error types (from library-errors skill)
+
+- [ ] Internal errors use `thiserror` with `pub(crate)` visibility
+- [ ] Separate error enums per subsystem (connection, parsing, storage)
+- [ ] Internal errors use `#[from]` for cross-module conversions
+- [ ] Public error type uses Error+ErrorKind pattern OR thiserror with boxed sources
+- [ ] Public error kind enum is `#[non_exhaustive]`
+- [ ] Public error struct has private fields with accessor methods
+- [ ] `From` impls convert internal errors to public error kinds
+- [ ] `Display` does not include the source message
+- [ ] Error messages are lowercase, no trailing punctuation
+- [ ] `source()` is implemented and returns the underlying cause
+
+## Application layer (from application-errors skill)
+
+- [ ] Binary uses `anyhow::Result` (either via `main()` return or explicit handling)
+- [ ] Context is added with `.context()` describing what was attempted
+- [ ] No `unwrap()` in non-test code
+
+## Anti-patterns to flag
+
+- [ ] Does NOT expose dependency types in public error variants
+- [ ] Does NOT include source in Display format strings
+- [ ] Does NOT use a single god-error enum for the whole crate

--- a/benchmarks/error-skills/README.md
+++ b/benchmarks/error-skills/README.md
@@ -1,0 +1,57 @@
+# Error Skills Benchmark
+
+Manual testing harness for verifying skills work correctly via Symposium integration.
+
+## Quick start
+
+```bash
+# Full run with default target (/tmp/error-skills-bench-target)
+# Clones mini-redis automatically if target doesn't exist
+./run.sh
+
+# With explicit target
+./run.sh --target /path/to/mini-redis
+
+# Regenerate from scratch
+./run.sh --clean
+```
+
+## What it does
+
+1. `setup.sh`: clones mini-redis if needed, runs `cargo bp add error`, then `cargo agents sync`
+2. `run.sh`: calls setup if skills aren't installed, then runs `claude -p` with streaming output
+
+## Output files
+
+Each run produces (in `/tmp/`):
+- `skill-benchmark-*.md` (agent text output)
+- `skill-benchmark-*.raw` (full JSON stream)
+- `skill-benchmark-*.tools` (tool usage summary)
+- `skill-benchmark-*.skills` (skills invoked)
+- `skill-benchmark-*.commands` (bash commands run)
+
+## Evaluating results
+
+```
+Evaluate /tmp/skill-benchmark-<timestamp>.md against benchmarks/error-skills/EXPECTED.md
+```
+
+## Prerequisites
+
+- `cargo-bp` installed (`cargo install cargo-bp`)
+- `symposium` installed (`cargo install symposium`)
+- `claude` CLI authenticated
+- Battery-pack plugin source registered in `~/.symposium/config.toml`:
+  ```toml
+  plugin-source = [
+      { name = "battery-pack", path = "/path/to/battery-pack/battery-packs/error-battery-pack" },
+  ]
+  ```
+
+## Agent support
+
+Currently Claude Code only (`claude -p`). Future harnesses:
+
+- Kiro (`kiro chat`)
+- Codex (`codex --quiet`)
+- Interactive session evaluation (manual paste + human scoring)

--- a/benchmarks/error-skills/run.sh
+++ b/benchmarks/error-skills/run.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET="/tmp/error-skills-bench-target"
+BP_SOURCE=""
+CLEAN=""
+MODEL=""
+AGENT=""
+
+usage() {
+    echo "Usage: ./run.sh [--target <path>] [--bp-source <path>] [--model <model>] [--agent <agent>] [--clean]"
+    echo ""
+    echo "Options:"
+    echo "  --target      Path to the test project (default: /tmp/error-skills-bench-target)"
+    echo "  --bp-source   Path to the battery-pack repo (default: inferred from script location)"
+    echo "  --model       Model to use (default: agent's configured default)"
+    echo "  --agent       Agent to use (default: agent's configured default)"
+    echo "  --clean       Reset the target project before setup"
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --target) TARGET="$2"; shift 2 ;;
+        --bp-source) BP_SOURCE="$2"; shift 2 ;;
+        --model) MODEL="$2"; shift 2 ;;
+        --agent) AGENT="$2"; shift 2 ;;
+        --clean) CLEAN="--clean"; shift ;;
+        --help|-h) usage ;;
+        *) usage ;;
+    esac
+done
+
+BP_SOURCE="${BP_SOURCE:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+
+# Setup if skills aren't installed or --clean
+if [[ ! -d "$TARGET/.claude/skills/library-errors" ]] || [[ -n "$CLEAN" ]]; then
+    "$SCRIPT_DIR/setup.sh" --target "$TARGET" --bp-source "$BP_SOURCE" $CLEAN
+fi
+
+LOG="/tmp/skill-benchmark-$(date +%Y%m%d-%H%M%S)"
+
+PROMPT="Set up error handling for this mini-redis implementation following Rust best practices. The crate is a library with a public API (clients import it), so errors need to be opaque and evolvable. Internally there are multiple subsystems (connection handling, command parsing, storage) that should have their own error types. The binary should use anyhow for the application layer. Follow the guidance from the skills available in this project. Present the full implementation plan with complete code for each file in your response. Do not summarize, show all the code."
+
+echo ""
+echo "Running benchmark..."
+echo "Target: $TARGET"
+echo "Log: $LOG.md"
+echo "---"
+echo ""
+
+START_TIME=$(date +%s)
+
+MODEL_FLAG=""
+if [[ -n "$MODEL" ]]; then
+    MODEL_FLAG="--model $MODEL"
+fi
+
+EXTRA_FLAGS=""
+[[ -n "$MODEL" ]] && EXTRA_FLAGS="$EXTRA_FLAGS --model $MODEL"
+[[ -n "$AGENT" ]] && EXTRA_FLAGS="$EXTRA_FLAGS --agent $AGENT"
+
+cd "$TARGET"
+echo "$PROMPT" | claude -p --verbose --output-format stream-json \
+    --allowed-tools "Read,Glob,Grep,Skill,Bash(cargo *)" \
+    $EXTRA_FLAGS \
+    $MODEL_FLAG \
+    | tee "$LOG.raw" \
+    | jq -r --unbuffered 'select(.type == "assistant") | .message.content[]? | select(.type == "text" or .type == "thinking") | if .type == "thinking" then "<thinking>\n\(.thinking)\n</thinking>" else .text // empty end' \
+    | tee "$LOG.md"
+
+echo ""
+echo "---"
+echo "Output: $LOG.md"
+echo "Raw JSON: $LOG.raw"
+
+END_TIME=$(date +%s)
+DURATION=$((END_TIME - START_TIME))
+echo "Duration: ${DURATION}s (started $(date -d @$START_TIME +%H:%M:%S), ended $(date -d @$END_TIME +%H:%M:%S))"
+
+# Write run metadata
+cat > "$LOG.meta" <<EOF
+start: $(date -d @$START_TIME --iso-8601=seconds)
+end: $(date -d @$END_TIME --iso-8601=seconds)
+duration_s: $DURATION
+target: $TARGET
+model: ${MODEL:-default}
+agent: ${AGENT:-default}
+EOF
+
+# Extract tool usage summary
+jq -r 'select(.type == "assistant") | .message.content[]? | select(.type == "tool_use") | .name' "$LOG.raw" \
+    | sort | uniq -c | sort -rn > "$LOG.tools"
+
+# Extract skills invoked
+jq -r 'select(.type == "assistant") | .message.content[]? | select(.type == "tool_use" and .name == "Skill") | .input.skill' "$LOG.raw" \
+    > "$LOG.skills"
+
+# Extract all tool invocations with inputs
+jq -r 'select(.type == "assistant") | .message.content[]? | select(.type == "tool_use") | "\(.name): \(.input | tostring)"' "$LOG.raw" \
+    > "$LOG.invocations"
+
+# Extract internal reasoning
+jq -r 'select(.type == "assistant") | .message.content[]? | select(.type == "thinking") | .thinking' "$LOG.raw" \
+    > "$LOG.thinking"
+
+echo "Tools: $LOG.tools"
+echo "Skills: $LOG.skills"
+echo "Invocations: $LOG.invocations"
+echo "Thinking: $LOG.thinking"
+echo ""
+echo "Evaluate with:"
+echo "  Evaluate $LOG.md against $SCRIPT_DIR/EXPECTED.md"

--- a/benchmarks/error-skills/setup.sh
+++ b/benchmarks/error-skills/setup.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET=""
+BP_SOURCE=""
+CLEAN=false
+
+usage() {
+    echo "Usage: ./setup.sh --target <path> [--bp-source <path>] [--clean]"
+    echo ""
+    echo "Options:"
+    echo "  --target      Path to the test project (must be a git repo with Cargo.toml)"
+    echo "  --bp-source   Path to the battery-pack repo (default: inferred from script location)"
+    echo "  --clean       Reset the target project to a clean git state before setup"
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --target) TARGET="$2"; shift 2 ;;
+        --bp-source) BP_SOURCE="$2"; shift 2 ;;
+        --clean) CLEAN=true; shift ;;
+        --help|-h) usage ;;
+        *) usage ;;
+    esac
+done
+
+[[ -z "$TARGET" ]] && usage
+BP_SOURCE="${BP_SOURCE:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+
+# Clone mini-redis if target doesn't exist
+if [[ ! -d "$TARGET" ]]; then
+    echo "Cloning tokio-rs/mini-redis into $TARGET..."
+    git clone --depth 1 https://github.com/tokio-rs/mini-redis.git "$TARGET"
+fi
+
+cd "$TARGET"
+
+if [[ "$CLEAN" == true ]]; then
+    echo "Cleaning $TARGET..."
+    git checkout -- .
+    git clean -fd
+fi
+
+echo "Installing error battery pack..."
+cargo bp add error --path "$BP_SOURCE/battery-packs/error-battery-pack" --non-interactive
+
+echo "Syncing symposium skills..."
+cargo agents sync --update fetch
+
+echo ""
+echo "Done."
+cargo agents plugin list


### PR DESCRIPTION
### Summary

Adds [Symposium](https://github.com/symposium-dev/symposium)-compatible skills that teach AI agents how to implement error handling in Rust. The content is open-sourced from a closed-source error handling guide, with permission from [@terminalwitchcraft](https://github.com/terminalwitchcraft).

[sample test run](https://gist.github.com/jlizen/aba07990073526c613288e6da48809f5)

Three skills, scoped by concern:

- **error-handling-basics**: lightweight stub targeting any project with `anyhow`/`thiserror`/`eyre`/etc. Critical rules only, points to `cargo bp add error` for the full guides.
- **library-errors**: the Error+ErrorKind pattern for public APIs, internal `thiserror` types per subsystem, `From` conversions, Display/source formatting rules.
- **application-errors**: `anyhow` context chains, `main()` return types, structured logging, backtrace config, custom `thiserror` enums for HTTP status codes.

The `error-handling-basics` stub exists as a workaround for Symposium lacking on-demand/lazy skill loading ([symposium-dev/symposium#201](https://github.com/symposium-dev/symposium/issues/201)). Without it, the full guides (~370 lines) would be injected into every session for any project using `anyhow`. The stub provides the most critical rules in ~30 lines and advertises the battery pack for the rest.

### Symposium layout

```
SYMPOSIUM.toml                                    # repo-root plugin (GitHub-based sources)
battery-packs/error-battery-pack/
  skills/
    SYMPOSIUM.toml                                # crate-level plugin (crates.io publishing)
    error-handling-basics/SKILL.md                # broad: any error crate
    library-errors/SKILL.md                       # broad: any error crate
    application-errors/SKILL.md                   # broad: any error crate
```

Plugin manifests at both levels: the repo root for when Symposium points at the GitHub repo as a custom source, and inside the battery pack for future crates.io integration. The `crates` predicate targets `anyhow`, `thiserror`, `eyre`, `color-eyre`, `miette`, `snafu`, `displaydoc`, `error-stack`, and `error-battery-pack`.

### Benchmark harness

`benchmarks/error-skills/` provides scripts to validate the end-to-end Symposium integration:

1. `setup.sh --target <project>`: runs `cargo bp add error` then `cargo agents sync`
2. `run.sh --target <project> --clean`: setup + `claude -p` with streaming JSON output

The harness is Claude Code specific for now. `EXPECTED.md` includes `jq` commands to verify skill activation from the raw JSON stream, plus a checklist for evaluating the agent's output.

### Testing

Cold-start benchmark against tokio-rs/mini-redis went fine. Agent loaded all skills, explored 21 files, produced a complete Error+ErrorKind implementation across 18 files. All evaluation criteria pass.

sample run](https://gist.github.com/jlizen/aba07990073526c613288e6da48809f5)
