### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "battery-pack"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "battery-pack",
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "bphelper-cli"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "bphelper-manifest",
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-bp"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "error-battery-pack"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "battery-pack",

--- a/battery-packs/error-battery-pack/CHANGELOG.md
+++ b/battery-packs/error-battery-pack/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2](https://github.com/battery-pack-rs/battery-pack/compare/error-battery-pack-v0.6.1...error-battery-pack-v0.6.2) - 2026-05-11
+
+### Added
+
+- *(error-battery-pack)* add error handling skills and benchmark harness
+
+### Other
+
+- *(error-battery-pack)* add symposium to crates.io keywords
+
 ## [0.6.1](https://github.com/battery-pack-rs/battery-pack/compare/error-battery-pack-v0.6.0...error-battery-pack-v0.6.1) - 2026-04-30
 
 ### Added

--- a/battery-packs/error-battery-pack/Cargo.toml
+++ b/battery-packs/error-battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "error-battery-pack"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 description = "Error handling done well — anyhow for apps, thiserror for libraries"
 license = "MIT OR Apache-2.0"

--- a/src/battery-pack/CHANGELOG.md
+++ b/src/battery-pack/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.3](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.5.2...battery-pack-v0.5.3) - 2026-05-11
+
+### Added
+
+- *(error-battery-pack)* add error handling skills and benchmark harness
+
+### Fixed
+
+- symmetric state_name_matches, correct Default, and warn on unmatched package
+
+### Other
+
+- Merge pull request #118 from nikomatsakis/battery-pack-toml
+- address round 2 review feedback
+- address PR #118 review comments
+- store the data in battery-pack.toml
+- *(error-battery-pack)* add symposium to crates.io keywords
+
 ## [0.5.2](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.5.1...battery-pack-v0.5.2) - 2026-04-30
 
 ### Added

--- a/src/battery-pack/Cargo.toml
+++ b/src/battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "battery-pack"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2024"
 description = "Curated crate bundles with docs, templates, and agentic skills"
 license = "MIT OR Apache-2.0"
@@ -22,7 +22,7 @@ cli = ["bphelper-cli"]
 
 [dependencies]
 bphelper-build = { path = "bphelper-build", version = "0.4.7", optional = true }
-bphelper-cli = { path = "bphelper-cli", version = "0.8.0", optional = true }
+bphelper-cli = { path = "bphelper-cli", version = "0.8.1", optional = true }
 bphelper-manifest = { path = "bphelper-manifest", version = "0.5.5" }
 anyhow.workspace = true
 

--- a/src/battery-pack/bphelper-cli/CHANGELOG.md
+++ b/src/battery-pack/bphelper-cli/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.8.0...bphelper-cli-v0.8.1) - 2026-05-11
+
+### Fixed
+
+- symmetric state_name_matches, correct Default, and warn on unmatched package
+
+### Other
+
+- Merge pull request #118 from nikomatsakis/battery-pack-toml
+- address round 2 review feedback
+- address PR #118 review comments
+- store the data in battery-pack.toml
+
 ## [0.8.0](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.7.6...bphelper-cli-v0.8.0) - 2026-04-30
 
 ### Added

--- a/src/battery-pack/bphelper-cli/Cargo.toml
+++ b/src/battery-pack/bphelper-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bphelper-cli"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 description = "CLI for creating and managing battery packs"
 license = "MIT OR Apache-2.0"

--- a/src/cargo-bp/CHANGELOG.md
+++ b/src/cargo-bp/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.4](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-v0.5.3...cargo-bp-v0.5.4) - 2026-05-11
+
+### Fixed
+
+- symmetric state_name_matches, correct Default, and warn on unmatched package
+
+### Other
+
+- Merge pull request #118 from nikomatsakis/battery-pack-toml
+- address round 2 review feedback
+- address PR #118 review comments
+- store the data in battery-pack.toml
+
 ## [0.5.3](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-v0.5.2...cargo-bp-v0.5.3) - 2026-04-30
 
 ### Added

--- a/src/cargo-bp/Cargo.toml
+++ b/src/cargo-bp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-bp"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2024"
 description = "CLI for creating and managing battery packs (cargo bp)"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `bphelper-cli`: 0.8.0 -> 0.8.1 (✓ API compatible changes)
* `battery-pack`: 0.5.2 -> 0.5.3 (✓ API compatible changes)
* `cargo-bp`: 0.5.3 -> 0.5.4
* `error-battery-pack`: 0.6.1 -> 0.6.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `bphelper-cli`

<blockquote>

## [0.8.1](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.8.0...bphelper-cli-v0.8.1) - 2026-05-11

### Fixed

- symmetric state_name_matches, correct Default, and warn on unmatched package

### Other

- Merge pull request #118 from nikomatsakis/battery-pack-toml
- address round 2 review feedback
- address PR #118 review comments
- store the data in battery-pack.toml
</blockquote>

## `battery-pack`

<blockquote>

## [0.5.3](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.5.2...battery-pack-v0.5.3) - 2026-05-11

### Added

- *(error-battery-pack)* add error handling skills and benchmark harness

### Fixed

- symmetric state_name_matches, correct Default, and warn on unmatched package

### Other

- Merge pull request #118 from nikomatsakis/battery-pack-toml
- address round 2 review feedback
- address PR #118 review comments
- store the data in battery-pack.toml
- *(error-battery-pack)* add symposium to crates.io keywords
</blockquote>

## `cargo-bp`

<blockquote>

## [0.5.4](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-v0.5.3...cargo-bp-v0.5.4) - 2026-05-11

### Fixed

- symmetric state_name_matches, correct Default, and warn on unmatched package

### Other

- Merge pull request #118 from nikomatsakis/battery-pack-toml
- address round 2 review feedback
- address PR #118 review comments
- store the data in battery-pack.toml
</blockquote>

## `error-battery-pack`

<blockquote>

## [0.6.2](https://github.com/battery-pack-rs/battery-pack/compare/error-battery-pack-v0.6.1...error-battery-pack-v0.6.2) - 2026-05-11

### Added

- *(error-battery-pack)* add error handling skills and benchmark harness

### Other

- *(error-battery-pack)* add symposium to crates.io keywords
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).