### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "battery-pack"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "battery-pack",
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "bphelper-cli"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "bphelper-manifest",
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-bp"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1125,7 +1125,7 @@ dependencies = [
 
 [[package]]
 name = "error-battery-pack"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "battery-pack",

--- a/battery-packs/error-battery-pack/CHANGELOG.md
+++ b/battery-packs/error-battery-pack/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3](https://github.com/battery-pack-rs/battery-pack/compare/error-battery-pack-v0.6.2...error-battery-pack-v0.6.3) - 2026-05-17
+
+### Other
+
+- Merge pull request #127 from jlizen/error-bp-cleanup-symposium
+- remove SYMPOSIUM.toml manifests
+
 ## [0.6.2](https://github.com/battery-pack-rs/battery-pack/compare/error-battery-pack-v0.6.1...error-battery-pack-v0.6.2) - 2026-05-11
 
 ### Added

--- a/battery-packs/error-battery-pack/Cargo.toml
+++ b/battery-packs/error-battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "error-battery-pack"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2024"
 description = "Error handling done well — anyhow for apps, thiserror for libraries"
 license = "MIT OR Apache-2.0"

--- a/src/battery-pack/CHANGELOG.md
+++ b/src/battery-pack/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.4](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.5.3...battery-pack-v0.5.4) - 2026-05-17
+
+### Added
+
+- add cargo bp status --json + cargo-bp-script schema crate
+
+### Other
+
+- *(status)* split text/JSON output into render_status_* fns
+- Merge pull request #132 from nikomatsakis/cargo-bp-status-json
+- Merge pull request #127 from jlizen/error-bp-cleanup-symposium
+- remove SYMPOSIUM.toml manifests
+
 ## [0.5.3](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.5.2...battery-pack-v0.5.3) - 2026-05-11
 
 ### Added

--- a/src/battery-pack/Cargo.toml
+++ b/src/battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "battery-pack"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2024"
 description = "Curated crate bundles with docs, templates, and agentic skills"
 license = "MIT OR Apache-2.0"
@@ -22,7 +22,7 @@ cli = ["bphelper-cli"]
 
 [dependencies]
 bphelper-build = { path = "bphelper-build", version = "0.4.7", optional = true }
-bphelper-cli = { path = "bphelper-cli", version = "0.8.1", optional = true }
+bphelper-cli = { path = "bphelper-cli", version = "0.8.2", optional = true }
 bphelper-manifest = { path = "bphelper-manifest", version = "0.5.5" }
 anyhow.workspace = true
 

--- a/src/battery-pack/bphelper-cli/CHANGELOG.md
+++ b/src/battery-pack/bphelper-cli/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.2](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.8.1...bphelper-cli-v0.8.2) - 2026-05-17
+
+### Added
+
+- add cargo bp status --json + cargo-bp-script schema crate
+
+### Other
+
+- *(status)* split text/JSON output into render_status_* fns
+- Merge pull request #132 from nikomatsakis/cargo-bp-status-json
+
 ## [0.8.1](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.8.0...bphelper-cli-v0.8.1) - 2026-05-11
 
 ### Fixed

--- a/src/battery-pack/bphelper-cli/Cargo.toml
+++ b/src/battery-pack/bphelper-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bphelper-cli"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 description = "CLI for creating and managing battery packs"
 license = "MIT OR Apache-2.0"

--- a/src/cargo-bp/CHANGELOG.md
+++ b/src/cargo-bp/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.5](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-v0.5.4...cargo-bp-v0.5.5) - 2026-05-17
+
+### Added
+
+- add cargo bp status --json + cargo-bp-script schema crate
+
+### Other
+
+- *(status)* split text/JSON output into render_status_* fns
+- Merge pull request #132 from nikomatsakis/cargo-bp-status-json
+
 ## [0.5.4](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-v0.5.3...cargo-bp-v0.5.4) - 2026-05-11
 
 ### Fixed

--- a/src/cargo-bp/Cargo.toml
+++ b/src/cargo-bp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-bp"
-version = "0.5.4"
+version = "0.5.5"
 edition = "2024"
 description = "CLI for creating and managing battery packs (cargo bp)"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `bphelper-cli`: 0.8.1 -> 0.8.2 (✓ API compatible changes)
* `battery-pack`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `cargo-bp`: 0.5.4 -> 0.5.5
* `error-battery-pack`: 0.6.2 -> 0.6.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `bphelper-cli`

<blockquote>

## [0.8.2](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.8.1...bphelper-cli-v0.8.2) - 2026-05-17

### Added

- add cargo bp status --json + cargo-bp-script schema crate

### Other

- *(status)* split text/JSON output into render_status_* fns
- Merge pull request #132 from nikomatsakis/cargo-bp-status-json
</blockquote>

## `battery-pack`

<blockquote>

## [0.5.4](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.5.3...battery-pack-v0.5.4) - 2026-05-17

### Added

- add cargo bp status --json + cargo-bp-script schema crate

### Other

- *(status)* split text/JSON output into render_status_* fns
- Merge pull request #132 from nikomatsakis/cargo-bp-status-json
- Merge pull request #127 from jlizen/error-bp-cleanup-symposium
- remove SYMPOSIUM.toml manifests
</blockquote>

## `cargo-bp`

<blockquote>

## [0.5.5](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-v0.5.4...cargo-bp-v0.5.5) - 2026-05-17

### Added

- add cargo bp status --json + cargo-bp-script schema crate

### Other

- *(status)* split text/JSON output into render_status_* fns
- Merge pull request #132 from nikomatsakis/cargo-bp-status-json
</blockquote>

## `error-battery-pack`

<blockquote>

## [0.6.3](https://github.com/battery-pack-rs/battery-pack/compare/error-battery-pack-v0.6.2...error-battery-pack-v0.6.3) - 2026-05-17

### Other

- Merge pull request #127 from jlizen/error-bp-cleanup-symposium
- remove SYMPOSIUM.toml manifests
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).