### PR TITLE
fix(tui): make Enter on template show preview instead of opening browser

### DIFF
--- a/src/battery-pack/bphelper-cli/src/registry/mod.rs
+++ b/src/battery-pack/bphelper-cli/src/registry/mod.rs
@@ -146,9 +146,6 @@ pub(crate) struct TemplateInfo {
     pub name: String,
     pub path: String,
     pub description: Option<String>,
-    /// Full path in the repository (e.g., "src/cli-battery-pack/templates/simple")
-    /// Resolved by searching the GitHub tree API
-    pub repo_path: Option<String>,
 }
 
 #[derive(Clone)]
@@ -777,16 +774,10 @@ pub(crate) fn build_battery_pack_detail(
     let templates = spec
         .templates
         .iter()
-        .map(|(name, tmpl)| {
-            let repo_path = repo_tree
-                .as_ref()
-                .and_then(|tree| find_template_path(tree, &tmpl.path));
-            TemplateInfo {
-                name: name.clone(),
-                path: tmpl.path.clone(),
-                description: tmpl.description.clone(),
-                repo_path,
-            }
+        .map(|(name, tmpl)| TemplateInfo {
+            name: name.clone(),
+            path: tmpl.path.clone(),
+            description: tmpl.description.clone(),
         })
         .collect();
 
@@ -930,13 +921,6 @@ pub(crate) fn find_example_path(tree: &[String], example_name: &str) -> Option<S
 
 /// Find the full repository path for a template directory.
 /// Searches the tree for a path matching "templates/{name}" or "{name}".
-pub(crate) fn find_template_path(tree: &[String], template_path: &str) -> Option<String> {
-    // The template path from config might be "templates/simple" or just the relative path
-    tree.iter()
-        .find(|path| path.ends_with(template_path))
-        .cloned()
-}
-
 /// A resolved battery pack crate directory. Owns the temp dir (if any) to keep it alive.
 pub(crate) struct ResolvedCrate {
     pub dir: PathBuf,

--- a/src/battery-pack/bphelper-cli/src/registry/mod.rs
+++ b/src/battery-pack/bphelper-cli/src/registry/mod.rs
@@ -747,8 +747,7 @@ fn fetch_battery_pack_detail_from_path(path: &str) -> Result<BatteryPackDetail> 
 
 /// Build `BatteryPackDetail` from a parsed `BatteryPackSpec`.
 ///
-/// Derives extends/crates from the spec's crate keys, fetches repo tree for
-/// template path resolution, and scans for examples.
+/// Derives extends/crates from the spec's crate keys and scans for examples.
 pub(crate) fn build_battery_pack_detail(
     crate_dir: &Path,
     spec: &bphelper_manifest::BatteryPackSpec,
@@ -767,10 +766,14 @@ pub(crate) fn build_battery_pack_detail(
         .collect();
     let crates: Vec<String> = crates_raw.into_iter().map(|s| s.to_string()).collect();
 
-    // Fetch the GitHub repository tree to resolve paths
-    let repo_tree = spec.repository.as_ref().and_then(|r| fetch_github_tree(r));
+    // Fetch the GitHub repository tree to resolve example paths (only if examples exist)
+    let has_examples = crate_dir.join("examples").exists();
+    let repo_tree = if has_examples {
+        spec.repository.as_ref().and_then(|r| fetch_github_tree(r))
+    } else {
+        None
+    };
 
-    // Convert templates with resolved repo paths
     let templates = spec
         .templates
         .iter()
@@ -919,8 +922,6 @@ pub(crate) fn find_example_path(tree: &[String], example_name: &str) -> Option<S
     tree.iter().find(|path| path.ends_with(&suffix)).cloned()
 }
 
-/// Find the full repository path for a template directory.
-/// Searches the tree for a path matching "templates/{name}" or "{name}".
 /// A resolved battery pack crate directory. Owns the temp dir (if any) to keep it alive.
 pub(crate) struct ResolvedCrate {
     pub dir: PathBuf,

--- a/src/battery-pack/bphelper-cli/src/tui.rs
+++ b/src/battery-pack/bphelper-cli/src/tui.rs
@@ -1033,9 +1033,7 @@ impl App {
                             Err(e) => Text::from(format!("Failed to render preview: {e}")),
                         }
                     }
-                    Err(e) => Text::from(format!(
-                        "Template preview unavailable: {e}\nUse --crate-source or install the pack first."
-                    )),
+                    Err(e) => Text::from(format!("Template preview unavailable: {e:#}")),
                 };
 
                 let line_count = content.lines.len() as u16;

--- a/src/battery-pack/bphelper-cli/src/tui.rs
+++ b/src/battery-pack/bphelper-cli/src/tui.rs
@@ -157,11 +157,8 @@ enum DetailItem {
     Crate(String),
     /// An extended battery pack - opens crates.io
     Extends(String),
-    /// A template - opens GitHub tree URL (stores local path and resolved repo path)
-    Template {
-        _path: String,
-        repo_path: Option<String>,
-    },
+    /// A template - previews rendered output
+    Template { path: String },
     /// An example - opens GitHub blob URL (stores name and resolved repo path)
     Example {
         _name: String,
@@ -223,8 +220,7 @@ impl DetailScreen {
         let crates = self.detail.crates.iter().cloned().map(DetailItem::Crate);
         let extends = self.detail.extends.iter().cloned().map(DetailItem::Extends);
         let templates = self.detail.templates.iter().map(|t| DetailItem::Template {
-            _path: t.path.clone(),
-            repo_path: t.repo_path.clone(),
+            path: t.path.clone(),
         });
         let examples = self.detail.examples.iter().map(|e| DetailItem::Example {
             _name: e.name.clone(),
@@ -606,10 +602,6 @@ impl App {
             DetailNext,
             DetailPrev,
             OpenCratesIoUrl(String),
-            OpenTemplate {
-                repository: Option<String>,
-                repo_path: Option<String>,
-            },
             OpenExample {
                 repository: Option<String>,
                 repo_path: Option<String>,
@@ -677,13 +669,12 @@ impl App {
                                 };
                                 Action::OpenCratesIoUrl(full_name)
                             }
-                            DetailItem::Template {
-                                _path: _,
-                                repo_path,
-                            } => Action::OpenTemplate {
-                                repository: state.detail.repository.clone(),
-                                repo_path,
-                            },
+                            DetailItem::Template { path, .. } => Action::PreviewTemplate(
+                                Rc::clone(&state.detail),
+                                path,
+                                state.selected_index,
+                                state.came_from_list,
+                            ),
                             DetailItem::Example {
                                 _name: _,
                                 repo_path,
@@ -716,17 +707,13 @@ impl App {
                 }
                 KeyCode::Char('n') => {
                     // 'n' creates new project with currently selected template (if a template is selected)
-                    if let Some(DetailItem::Template {
-                        _path,
-                        repo_path: _,
-                    }) = state.selected_item()
-                    {
+                    if let Some(DetailItem::Template { path }) = state.selected_item() {
                         // Find the template name from the path
                         let template_name = state
                             .detail
                             .templates
                             .iter()
-                            .find(|t| t.path == _path)
+                            .find(|t| t.path == path)
                             .map(|t| t.name.clone());
                         Action::DetailNewProject(
                             Rc::clone(&state.detail),
@@ -740,10 +727,10 @@ impl App {
                 }
                 KeyCode::Char('p') => {
                     // 'p' previews the currently selected template
-                    if let Some(DetailItem::Template { _path, .. }) = state.selected_item() {
+                    if let Some(DetailItem::Template { path, .. }) = state.selected_item() {
                         Action::PreviewTemplate(
                             Rc::clone(&state.detail),
-                            _path,
+                            path,
                             state.selected_index,
                             state.came_from_list,
                         )
@@ -755,12 +742,12 @@ impl App {
                     // 'u' merges the selected template into the current project
                     if !state.in_project {
                         Action::None
-                    } else if let Some(DetailItem::Template { _path, .. }) = state.selected_item() {
+                    } else if let Some(DetailItem::Template { path, .. }) = state.selected_item() {
                         let template_name = state
                             .detail
                             .templates
                             .iter()
-                            .find(|t| t.path == _path)
+                            .find(|t| t.path == path)
                             .map(|t| t.name.clone());
                         if let Some(name) = template_name {
                             Action::DetailUseTemplate(
@@ -867,16 +854,6 @@ impl App {
             }
             Action::OpenCratesIoUrl(crate_name) => {
                 let url = format!("https://crates.io/crates/{}", crate_name);
-                self.pending_action = Some(PendingAction::OpenUrl { url });
-            }
-            Action::OpenTemplate {
-                repository,
-                repo_path,
-            } => {
-                let url = match repo_path {
-                    Some(path) => build_github_url(repository.as_deref(), &path),
-                    None => repository.unwrap_or_else(|| "https://crates.io".to_string()),
-                };
                 self.pending_action = Some(PendingAction::OpenUrl { url });
             }
             Action::OpenExample {
@@ -1037,28 +1014,15 @@ impl App {
                     .map(|t| t.name.clone())
                     .unwrap_or_else(|| template_path.clone());
 
-                // Find the crate root to render the template from.
-                // For registry packs the detail was built from a downloaded
-                // crate, but we don't keep that temp dir around. Use
-                // --crate-source / --path if available, otherwise try cargo
-                // metadata.
-                let crate_root = match &self.source {
-                    CrateSource::Local(ws) => {
-                        crate::registry::find_local_battery_pack_dir(ws, &detail.name).ok()
-                    }
-                    CrateSource::Registry => {
-                        // Try to locate via cargo metadata (works if already
-                        // installed as a build-dep).
-                        crate::manifest::resolve_battery_pack_manifest(&detail.name)
-                            .ok()
-                            .and_then(|p| p.parent().map(|p| p.to_path_buf()))
-                    }
-                };
-
-                let content = match crate_root {
-                    Some(root) => {
+                // Resolve the crate directory (downloads from registry if needed).
+                let content = match crate::registry::resolve_crate_dir(
+                    &detail.name,
+                    self.pack_path.as_deref(),
+                    &self.source,
+                ) {
+                    Ok(resolved) => {
                         let opts = crate::template_engine::RenderOpts {
-                            crate_root: root,
+                            crate_root: resolved.dir,
                             template_path,
                             project_name: "my-project".to_string(),
                             defines: BTreeMap::new(),
@@ -1069,9 +1033,9 @@ impl App {
                             Err(e) => Text::from(format!("Failed to render preview: {e}")),
                         }
                     }
-                    None => Text::from(
-                        "Template preview unavailable — battery pack not found locally.\nUse --crate-source or install the pack first.",
-                    ),
+                    Err(e) => Text::from(format!(
+                        "Template preview unavailable: {e}\nUse --crate-source or install the pack first."
+                    )),
                 };
 
                 let line_count = content.lines.len() as u16;
@@ -1663,10 +1627,6 @@ fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
 /// Build a GitHub tree URL for a directory path.
 /// If repository is set and looks like a GitHub URL, construct a tree URL.
 /// Otherwise fall back to a crates.io search or just open the repo root.
-fn build_github_url(repository: Option<&str>, path: &str) -> String {
-    build_github_ref_url(repository, "tree", path)
-}
-
 /// Build a GitHub blob URL for a file path.
 fn build_github_blob_url(repository: Option<&str>, path: &str) -> String {
     build_github_ref_url(repository, "blob", path)

--- a/src/battery-pack/bphelper-cli/src/tui/tests.rs
+++ b/src/battery-pack/bphelper-cli/src/tui/tests.rs
@@ -23,7 +23,6 @@ fn make_detail(crates: &[&str], templates: &[&str], examples: &[&str]) -> Batter
                 name: name.to_string(),
                 path: format!("templates/{}", name),
                 description: None,
-                repo_path: None,
             })
             .collect(),
         examples: examples

--- a/src/battery-pack/bphelper-cli/src/tui/tests.rs
+++ b/src/battery-pack/bphelper-cli/src/tui/tests.rs
@@ -270,6 +270,26 @@ fn detail_q_quits() {
     app.handle_key(KeyCode::Char('q'));
     assert!(app.should_quit);
 }
+
+/// [verify tui.nav.keyboard]
+#[test]
+fn detail_enter_on_template_opens_preview() {
+    let detail = make_detail(&[], &["basic"], &[]);
+    let mut app = make_app(Screen::Detail(DetailScreen {
+        detail: Rc::new(detail),
+        selected_index: 0, // first item is the template
+        came_from_list: false,
+        in_project: true,
+        is_installed: false,
+    }));
+
+    app.handle_key(KeyCode::Enter);
+
+    // Enter on a template transitions to the Preview screen (even if crate
+    // resolution fails, the screen still shows the error in a preview).
+    assert!(matches!(app.screen, Screen::Preview(_)));
+}
+
 // ====================================================================
 // Tier 3: Rendering tests
 // ====================================================================

--- a/src/battery-pack/bphelper-cli/tests/snapshots/bphelper_cli__tui__tests__detail_selectable_items_includes_all_sections.txt
+++ b/src/battery-pack/bphelper-cli/tests/snapshots/bphelper_cli__tui__tests__detail_selectable_items_includes_all_sections.txt
@@ -6,12 +6,10 @@
         "tokio",
     ),
     Template {
-        _path: "templates/basic",
-        repo_path: None,
+        path: "templates/basic",
     },
     Template {
-        _path: "templates/advanced",
-        repo_path: None,
+        path: "templates/advanced",
     },
     Example {
         _name: "hello-world",


### PR DESCRIPTION
Ref: https://rust-lang.zulipchat.com/#narrow/channel/575623-battery-packs-rs/topic/publicity/near/594416142

Two fixes:

## Load crate source for preview from within tui

Currently, this properly jumps into the tui with template materialized;
```
cargo bp show ci -t full
```

However this:
```
cargo bp show ci
```
followed by hitting "p" (preview) on the template shows:

```
 Template preview unavailable — battery pack not found locally.
 Use --crate-source or install the pack first.
```

This is a strictly worse experience, updating to also actively download for the tui navigation if needed.

## "return" on templates opens preview

Currently, "return" attempts to open them in github tree (or if on a headless server, generally just fails). Opening a browser makes more sense for inspecting individual crates, but much less for templates.

Since, templates have (potentially complex, branching) jinja syntax and are generally not optimized for human readability. Instead, we can just serve the preview, which is already materialized and works in more environments.

The new behavior is, "return" opens the preview for templates (but still opens the browser for everything else). And, i left in place a redundant "p" for "preview" for symmetric with `cargo add`, where hitting "return" does something different (add template to your project).

A side benefit of this is that it let us remove a bunch of code :) 

## Testing

Went through the worfklows myself, manually.

We don't have great automated testing of our tui navigation and I don't have it in me to add now. The view was already well-tested, so there is no snap to change, really.