### PR TITLE
feat: add cargo bp status --json + cargo-bp-script schema crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,6 +352,7 @@ version = "0.8.1"
 dependencies = [
  "anyhow",
  "bphelper-manifest",
+ "cargo-bp-script",
  "cargo_metadata",
  "clap",
  "clap_complete",
@@ -438,9 +439,20 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "bphelper-cli",
+ "cargo-bp-script",
+ "serde_json",
  "snapbox",
  "tempfile",
  "toml 0.8.23",
+]
+
+[[package]]
+name = "cargo-bp-script"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,8 @@ members = [
     "src/battery-pack",
 	# --- CLI binary
     "src/cargo-bp",
+	# --- scripting commons + JSON schema
+    "src/cargo-bp-script",
 	# --- helper crates
     "src/battery-pack/bphelper-build",
     "src/battery-pack/bphelper-cli",
@@ -18,6 +20,7 @@ resolver = "2"
 
 [workspace.dependencies]
 battery-pack = { path = "src/battery-pack", version = "0.5" }
+cargo-bp-script = { path = "src/cargo-bp-script", version = "0.1" }
 anyhow = "1"
 minijinja = { version = "2", features = ["loader"] }
 cargo_metadata = "0.23"

--- a/md/spec/cli.md
+++ b/md/spec/cli.md
@@ -259,6 +259,16 @@ r[cli.status.no-project]
 If run outside a Rust project, `cargo bp status` MUST report
 that no project was found.
 
+r[cli.status.json]
+`cargo bp status --json` MUST emit a machine-readable JSON
+document on stdout that conforms to the schema published in
+the [`cargo-bp-script`](https://crates.io/crates/cargo-bp-script)
+crate. The document MUST contain a top-level `schema_version`
+field. With `--json`, no human-readable text MUST be emitted on
+stdout. The same set of installed packs and dependency warnings
+that the text mode shows MUST be represented in the JSON
+payload.
+
 ## `cargo bp sync`
 
 r[cli.sync.update-versions]

--- a/md/using.md
+++ b/md/using.md
@@ -153,6 +153,17 @@ This shows your installed battery packs and highlights any mismatches.
 If a battery pack recommends `clap 4.5` but you have `clap 4.3`, you'll
 see a warning. Having a *newer* version than recommended is fine.
 
+#### Machine-readable output
+
+```bash
+cargo bp status --json
+```
+
+Emits the same information as a JSON document. The schema is provided
+by the [`cargo-bp-script`](https://crates.io/crates/cargo-bp-script)
+crate, which also includes a small library that can spawn `cargo bp`
+and parse the output for you — useful for agent and CI scripting.
+
 ### Syncing
 
 ```bash

--- a/src/battery-pack/bphelper-cli/Cargo.toml
+++ b/src/battery-pack/bphelper-cli/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["battery-pack", "cli", "cargo"]
 
 [dependencies]
 bphelper-manifest = { path = "../bphelper-manifest", version = "0.5.5" }
+cargo-bp-script.workspace = true
 clap.workspace = true
 clap_complete = { workspace = true, features = ["unstable-dynamic"] }
 minijinja.workspace = true

--- a/src/battery-pack/bphelper-cli/src/commands/mod.rs
+++ b/src/battery-pack/bphelper-cli/src/commands/mod.rs
@@ -184,6 +184,11 @@ pub(crate) enum BpCommands {
         /// Use a local path instead of downloading from crates.io
         #[arg(long)]
         path: Option<String>,
+
+        /// Emit machine-readable JSON instead of the default text output
+        // [impl cli.status.json]
+        #[arg(long)]
+        json: bool,
     },
 
     /// Check that installed battery packs match project dependencies
@@ -342,8 +347,8 @@ pub fn main() -> Result<()> {
                         )
                     }
                 }
-                BpCommands::Status { path } => {
-                    status_battery_packs(&project_dir, path.as_deref(), &source)
+                BpCommands::Status { path, json } => {
+                    status_battery_packs(&project_dir, path.as_deref(), &source, json)
                 }
                 BpCommands::Check { path } => {
                     check_battery_packs(&project_dir, path.as_deref(), &source)
@@ -1871,15 +1876,82 @@ fn print_template_preview(opts: &crate::template_engine::PreviewOpts<'_>) -> Res
 // [impl cli.status.list]
 // [impl cli.status.version-warn]
 // [impl cli.status.no-project]
+// [impl cli.status.json]
 // [impl cli.source.subcommands]
 // [impl cli.path.subcommands]
 fn status_battery_packs(
     project_dir: &Path,
     path: Option<&str>,
     source: &CrateSource,
+    json: bool,
 ) -> Result<()> {
     use console::style;
 
+    // --- Build the structured report once; both renderers consume it.
+    let report = build_status_report(project_dir, path, source)?;
+
+    // --- JSON path: emit only the schema payload on stdout.
+    if json {
+        let stdout = std::io::stdout();
+        let mut handle = stdout.lock();
+        serde_json::to_writer(&mut handle, &report).context("Failed to serialize status JSON")?;
+        // Trailing newline so consumers can `read_to_string()` and tools play nice.
+        use std::io::Write as _;
+        writeln!(handle).context("Failed to write status JSON")?;
+        return Ok(());
+    }
+
+    // --- Text path: preserve the existing human-readable rendering.
+    if report.packs.is_empty() {
+        println!("No battery packs installed.");
+        return Ok(());
+    }
+
+    let mut any_warnings = false;
+    for pack in &report.packs {
+        // [impl cli.status.list]
+        println!(
+            "{} ({})",
+            style(&pack.short_name).bold(),
+            style(&pack.version).dim(),
+        );
+
+        if pack.warnings.is_empty() {
+            println!("  {} all dependencies up to date", style("✓").green());
+        } else {
+            any_warnings = true;
+            for warning in &pack.warnings {
+                // [impl cli.status.version-warn]
+                println!(
+                    "  {} {}: {} → {} recommended",
+                    style("⚠").yellow(),
+                    warning.crate_name,
+                    style(&warning.current_version).red(),
+                    style(&warning.recommended_version).green(),
+                );
+            }
+        }
+    }
+
+    if any_warnings {
+        println!();
+        println!("Run {} to update.", style("cargo bp sync").bold());
+    }
+
+    Ok(())
+}
+
+/// Build a [`cargo_bp_script::StatusReport`] for the project rooted at
+/// `project_dir`. Pure data — no terminal output. Both the text renderer
+/// and the `--json` mode consume the same report.
+// [impl cli.status.list]
+// [impl cli.status.version-warn]
+// [impl cli.status.no-project]
+fn build_status_report(
+    project_dir: &Path,
+    path: Option<&str>,
+    source: &CrateSource,
+) -> Result<cargo_bp_script::StatusReport> {
     // [impl cli.status.no-project]
     let user_manifest_path =
         find_user_manifest(project_dir).context("are you inside a Rust project?")?;
@@ -1906,66 +1978,47 @@ fn status_battery_packs(
         })
         .collect::<Result<_>>()?;
 
-    if packs.is_empty() {
-        println!("No battery packs installed.");
-        return Ok(());
-    }
-
     // Build a map of the user's actual dependency versions so we can compare.
+    // (Cheap to compute even when packs is empty; keeps the structure simple.)
     let user_versions = collect_user_dep_versions(&user_manifest_path, &user_manifest_content)?;
 
-    let mut any_warnings = false;
+    // --- Map each installed pack into its `InstalledPackStatus`.
+    let pack_statuses: Vec<cargo_bp_script::InstalledPackStatus> = packs
+        .iter()
+        .map(|pack| {
+            // Resolve which crates are expected for this pack's active features.
+            let expected = pack.spec.resolve_for_features(&pack.active_features);
 
-    for pack in &packs {
-        // [impl cli.status.list]
-        println!(
-            "{} ({})",
-            style(&pack.short_name).bold(),
-            style(&pack.version).dim(),
-        );
-
-        // Resolve which crates are expected for this pack's active features.
-        let expected = pack.spec.resolve_for_features(&pack.active_features);
-
-        let mut pack_warnings = Vec::new();
-        for (dep_name, dep_spec) in &expected {
-            if dep_spec.version.is_empty() {
-                continue;
-            }
-            if let Some(user_version) = user_versions.get(dep_name.as_str()) {
-                // [impl cli.status.version-warn]
-                if should_upgrade_version(user_version, &dep_spec.version) {
-                    pack_warnings.push((
-                        dep_name.as_str(),
-                        user_version.as_str(),
-                        dep_spec.version.as_str(),
-                    ));
+            // [impl cli.status.version-warn]
+            let warnings = expected.iter().filter_map(|(dep_name, dep_spec)| {
+                if dep_spec.version.is_empty() {
+                    return None;
                 }
-            }
-        }
+                let user_version = user_versions.get(dep_name.as_str())?;
+                if !should_upgrade_version(user_version, &dep_spec.version) {
+                    return None;
+                }
+                Some(cargo_bp_script::DependencyWarning::new(
+                    dep_name.clone(),
+                    user_version.clone(),
+                    dep_spec.version.clone(),
+                ))
+            });
 
-        if pack_warnings.is_empty() {
-            println!("  {} all dependencies up to date", style("✓").green());
-        } else {
-            any_warnings = true;
-            for (dep, current, recommended) in &pack_warnings {
-                println!(
-                    "  {} {}: {} → {} recommended",
-                    style("⚠").yellow(),
-                    dep,
-                    style(current).red(),
-                    style(recommended).green(),
-                );
-            }
-        }
-    }
+            cargo_bp_script::InstalledPackStatus::new(
+                &pack.short_name,
+                &pack.spec.name,
+                &pack.version,
+            )
+            .with_active_features(pack.active_features.iter().cloned())
+            .with_warnings(warnings)
+        })
+        .collect();
 
-    if any_warnings {
-        println!();
-        println!("Run {} to update.", style("cargo bp sync").bold());
-    }
-
-    Ok(())
+    Ok(
+        cargo_bp_script::StatusReport::new(cargo_bp_script::ProjectInfo::new(user_manifest_path))
+            .with_packs(pack_statuses),
+    )
 }
 
 fn check_battery_packs(

--- a/src/cargo-bp-script/Cargo.toml
+++ b/src/cargo-bp-script/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "cargo-bp-script"
+version = "0.1.0"
+edition = "2024"
+description = "Schema and process runner for scripting `cargo bp` commands (e.g. `cargo bp status --json`)"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/battery-pack-rs/battery-pack"
+keywords = ["battery-pack", "cargo", "scripting"]
+readme = "README.md"
+
+[dependencies]
+serde = { workspace = true }
+serde_json.workspace = true
+thiserror.workspace = true

--- a/src/cargo-bp-script/README.md
+++ b/src/cargo-bp-script/README.md
@@ -1,0 +1,61 @@
+# cargo-bp-script
+
+Schema and process runner for scripting `cargo bp` commands.
+
+This crate provides:
+
+- **Strongly-typed schema** for the JSON output of `cargo bp` subcommands
+  that support `--json`. This lets agents and tools consume `cargo bp`
+  output without parsing free-form text.
+- **A small "commons" runner** that spawns `cargo bp` as a subprocess,
+  captures its stdout, and parses the JSON into the schema types.
+
+Currently supports:
+
+- `cargo bp status --json` → [`StatusReport`]
+
+## Consuming output
+
+```rust,no_run
+use cargo_bp_script::StatusCommand;
+
+let report = StatusCommand::new()
+    .cwd("/path/to/my/project")
+    .run()?;
+
+for pack in &report.packs {
+    println!("{} {}", pack.short_name, pack.version);
+    for warning in &pack.warnings {
+        println!(
+            "  {}: {} → {} recommended",
+            warning.crate_name, warning.current_version, warning.recommended_version,
+        );
+    }
+}
+# Ok::<(), cargo_bp_script::Error>(())
+```
+
+## Producing output
+
+The schema types use a `new(required)` + chainable `with_*` builder
+pattern, so additional fields can be added in future schema versions
+without breaking producers:
+
+```rust
+use cargo_bp_script::{
+    DependencyWarning, InstalledPackStatus, ProjectInfo, StatusReport,
+};
+
+let report = StatusReport::new(ProjectInfo::new("Cargo.toml"))
+    .with_pack(
+        InstalledPackStatus::new("cli", "cli-battery-pack", "0.3.0")
+            .with_active_feature("default")
+            .with_warning(DependencyWarning::new("clap", "4.4.0", "4.5.0")),
+    );
+```
+
+## Schema versioning
+
+The top-level [`StatusReport::schema_version`] field is bumped on
+breaking changes to the JSON layout. The current value is exposed
+as the [`SCHEMA_VERSION`] constant.

--- a/src/cargo-bp-script/src/lib.rs
+++ b/src/cargo-bp-script/src/lib.rs
@@ -1,0 +1,118 @@
+//! Schema and process runner for scripting `cargo bp` commands.
+//!
+//! See the [crate README](https://crates.io/crates/cargo-bp-script)
+//! for a high-level overview.
+//!
+//! # Quick start
+//!
+//! Spawn `cargo bp status --json` and parse the result:
+//!
+//! ```no_run
+//! use cargo_bp_script::StatusCommand;
+//!
+//! let report = StatusCommand::new().run()?;
+//! for pack in &report.packs {
+//!     println!("{} {}", pack.short_name, pack.version);
+//! }
+//! # Ok::<(), cargo_bp_script::Error>(())
+//! ```
+//!
+//! # Construction
+//!
+//! All schema types use a `new(required)` + chainable `with_*` setters
+//! pattern, which lets the schema grow without breaking producers:
+//!
+//! ```
+//! use cargo_bp_script::{
+//!     DependencyWarning, InstalledPackStatus, ProjectInfo, StatusReport,
+//! };
+//!
+//! let report = StatusReport::new(ProjectInfo::new("Cargo.toml"))
+//!     .with_pack(
+//!         InstalledPackStatus::new("cli", "cli-battery-pack", "0.3.0")
+//!             .with_active_feature("default")
+//!             .with_warning(DependencyWarning::new("clap", "4.4.0", "4.5.0")),
+//!     );
+//! assert_eq!(report.packs.len(), 1);
+//! ```
+
+#![deny(missing_docs)]
+
+pub mod runner;
+pub mod status;
+
+// Re-export the most commonly used items at the crate root for
+// ergonomic access. The full API stays addressable via the modules.
+pub use runner::{Error, StatusCommand, parse_status};
+pub use status::{
+    DependencyWarning, InstalledPackStatus, ProjectInfo, SCHEMA_VERSION, StatusReport,
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// JSON serialisation round-trips through `parse_status` when reports
+    /// are built via the chained-builder API.
+    #[test]
+    fn round_trip_status_report_via_builders() {
+        let report = StatusReport::new(ProjectInfo::new("/tmp/proj/Cargo.toml"))
+            .with_pack(
+                InstalledPackStatus::new("cli", "cli-battery-pack", "0.3.0")
+                    .with_active_feature("default")
+                    .with_warning(DependencyWarning::new("clap", "4.4.0", "4.5.0")),
+            )
+            .with_pack(InstalledPackStatus::new(
+                "error",
+                "error-battery-pack",
+                "0.2.0",
+            ));
+
+        let bytes = serde_json::to_vec(&report).expect("serialize");
+        let parsed = parse_status(&bytes).expect("parse_status");
+        assert_eq!(parsed, report);
+    }
+
+    /// `with_packs` extends — it does not replace.
+    #[test]
+    fn with_packs_extends() {
+        let pack_a = InstalledPackStatus::new("a", "a-battery-pack", "0.1.0");
+        let pack_b = InstalledPackStatus::new("b", "b-battery-pack", "0.1.0");
+        let pack_c = InstalledPackStatus::new("c", "c-battery-pack", "0.1.0");
+
+        let report = StatusReport::new(ProjectInfo::new("Cargo.toml"))
+            .with_pack(pack_a.clone())
+            .with_packs([pack_b.clone(), pack_c.clone()]);
+
+        assert_eq!(report.packs, vec![pack_a, pack_b, pack_c]);
+    }
+
+    /// `with_active_features` accepts any string-likes (and extends).
+    #[test]
+    fn with_active_features_accepts_string_likes() {
+        let pack = InstalledPackStatus::new("cli", "cli-battery-pack", "0.3.0")
+            .with_active_feature("default")
+            .with_active_features(["fancy", "indicators"])
+            .with_active_features(vec!["color".to_string()]);
+
+        assert_eq!(
+            pack.active_features,
+            vec!["default", "fancy", "indicators", "color"],
+        );
+    }
+
+    /// Fresh reports advertise the current `SCHEMA_VERSION`.
+    #[test]
+    fn schema_version_is_set() {
+        let report = StatusReport::new(ProjectInfo::new("Cargo.toml"));
+        assert_eq!(report.schema_version, SCHEMA_VERSION);
+        assert!(report.packs.is_empty());
+    }
+
+    /// `parse_status` surfaces malformed input as `Error::Parse`.
+    #[test]
+    fn parse_status_rejects_garbage() {
+        let err = parse_status(b"not json").unwrap_err();
+        assert!(matches!(err, Error::Parse { .. }), "got {err:?}");
+    }
+}

--- a/src/cargo-bp-script/src/runner.rs
+++ b/src/cargo-bp-script/src/runner.rs
@@ -1,0 +1,171 @@
+//! Process runner for `cargo bp` JSON commands.
+//!
+//! Spawns `cargo bp` as a subprocess, captures stdout, and parses
+//! the JSON payload into the [schema](crate::status) types.
+
+use std::ffi::{OsStr, OsString};
+use std::path::PathBuf;
+use std::process::{Command, ExitStatus};
+
+use crate::status::StatusReport;
+
+/// Error returned by the runner.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum Error {
+    /// The subprocess could not be spawned at all (e.g. binary not on `$PATH`).
+    #[error("failed to spawn `{program}`: {source}")]
+    Spawn {
+        /// The program that failed to spawn (typically `"cargo"`).
+        program: String,
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// The subprocess ran but exited with a non-zero status.
+    #[error("`cargo bp status --json` exited with {status}: {stderr}")]
+    ExitStatus {
+        /// Exit status of the subprocess.
+        status: ExitStatus,
+        /// Captured stderr (UTF-8 lossy).
+        stderr: String,
+    },
+
+    /// The subprocess emitted output that could not be parsed as the
+    /// expected JSON schema.
+    #[error("failed to parse `cargo bp status --json` output as JSON: {source}")]
+    Parse {
+        /// Underlying parse error from `serde_json`.
+        #[source]
+        source: serde_json::Error,
+    },
+}
+
+/// Builder for invoking `cargo bp status --json` and parsing its output.
+///
+/// # Example
+///
+/// ```no_run
+/// use cargo_bp_script::StatusCommand;
+///
+/// let report = StatusCommand::new().run()?;
+/// for pack in &report.packs {
+///     println!("{} {}", pack.short_name, pack.version);
+/// }
+/// # Ok::<(), cargo_bp_script::Error>(())
+/// ```
+#[derive(Debug, Clone)]
+pub struct StatusCommand {
+    program: OsString,
+    cwd: Option<PathBuf>,
+    crate_source: Option<PathBuf>,
+    path: Option<PathBuf>,
+}
+
+impl Default for StatusCommand {
+    fn default() -> Self {
+        Self {
+            program: OsString::from("cargo"),
+            cwd: None,
+            crate_source: None,
+            path: None,
+        }
+    }
+}
+
+impl StatusCommand {
+    /// Create a new builder. By default the runner invokes the `cargo`
+    /// binary on `$PATH` so that `cargo bp` is dispatched to the
+    /// installed `cargo-bp` subcommand.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Override the program used to invoke `cargo bp`.
+    ///
+    /// The default is `"cargo"`, which means the runner spawns
+    /// `cargo bp status --json`. You may instead point at a directly
+    /// built `cargo-bp` binary (typically used in tests):
+    ///
+    /// ```no_run
+    /// # use cargo_bp_script::StatusCommand;
+    /// let report = StatusCommand::new()
+    ///     .program("/path/to/target/debug/cargo-bp")
+    ///     .run()?;
+    /// # Ok::<(), cargo_bp_script::Error>(())
+    /// ```
+    ///
+    /// In either case the runner appends `bp status --json`, which
+    /// works because `cargo-bp`'s top-level command is `bp`.
+    pub fn program(mut self, program: impl Into<OsString>) -> Self {
+        self.program = program.into();
+        self
+    }
+
+    /// Run the command in a different working directory. Defaults to
+    /// the current process's working directory.
+    pub fn cwd(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.cwd = Some(dir.into());
+        self
+    }
+
+    /// Forward `--crate-source <path>` to `cargo bp`.
+    pub fn crate_source(mut self, path: impl Into<PathBuf>) -> Self {
+        self.crate_source = Some(path.into());
+        self
+    }
+
+    /// Forward `--path <path>` to `cargo bp status`.
+    pub fn path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.path = Some(path.into());
+        self
+    }
+
+    /// Spawn `cargo bp status --json`, capture stdout, and parse it
+    /// into a [`StatusReport`].
+    pub fn run(&self) -> Result<StatusReport, Error> {
+        // --- Build the command line.
+        // Layout: <program> bp [--crate-source <p>] status --json [--path <p>]
+        let mut cmd = Command::new(&self.program);
+        cmd.arg("bp");
+        if let Some(cs) = &self.crate_source {
+            cmd.arg("--crate-source").arg(cs);
+        }
+        cmd.arg("status").arg("--json");
+        if let Some(p) = &self.path {
+            cmd.arg("--path").arg(p);
+        }
+        if let Some(d) = &self.cwd {
+            cmd.current_dir(d);
+        }
+
+        // --- Spawn and capture output.
+        let output = cmd.output().map_err(|source| Error::Spawn {
+            program: program_display(&self.program),
+            source,
+        })?;
+        if !output.status.success() {
+            return Err(Error::ExitStatus {
+                status: output.status,
+                stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            });
+        }
+
+        // --- Parse JSON payload.
+        parse_status(&output.stdout)
+    }
+}
+
+/// Parse a `cargo bp status --json` payload into a [`StatusReport`].
+///
+/// Useful when the caller already has the bytes in hand (for example,
+/// from their own subprocess wrapper) and just wants the typed report.
+pub fn parse_status(bytes: &[u8]) -> Result<StatusReport, Error> {
+    serde_json::from_slice(bytes).map_err(|source| Error::Parse { source })
+}
+
+/// Best-effort display string for an `OsStr`, used only for error messages.
+fn program_display(program: &OsStr) -> String {
+    program.to_string_lossy().into_owned()
+}

--- a/src/cargo-bp-script/src/status.rs
+++ b/src/cargo-bp-script/src/status.rs
@@ -1,0 +1,208 @@
+//! Schema for `cargo bp status --json` output.
+//!
+//! These types are the stable, machine-consumable representation of
+//! `cargo bp status`. They are emitted by the CLI when invoked with
+//! `--json` and parsed by the [`runner`](crate::runner) module.
+//!
+//! # Construction
+//!
+//! Each type follows the same `new(required)` + chainable `with_*`
+//! setters pattern. Required fields are positional arguments to
+//! `new`; optional / collection-shaped fields are populated via
+//! `with_*` methods. New fields added in future schema versions get
+//! a new `with_*` setter rather than changing `new()`'s signature,
+//! so producers don't break.
+//!
+//! ```
+//! use cargo_bp_script::{
+//!     DependencyWarning, InstalledPackStatus, ProjectInfo, StatusReport,
+//! };
+//!
+//! let report = StatusReport::new(ProjectInfo::new("/path/to/Cargo.toml"))
+//!     .with_pack(
+//!         InstalledPackStatus::new("cli", "cli-battery-pack", "0.3.0")
+//!             .with_active_feature("default")
+//!             .with_warning(DependencyWarning::new("clap", "4.4.0", "4.5.0")),
+//!     );
+//! assert_eq!(report.packs.len(), 1);
+//! ```
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// Current JSON schema version emitted by `cargo bp status --json`.
+///
+/// Bumped on any breaking change to the schema. Consumers may use
+/// [`StatusReport::schema_version`] to detect the version they
+/// received and adapt accordingly.
+pub const SCHEMA_VERSION: &str = "1";
+
+/// Top-level report emitted by `cargo bp status --json`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct StatusReport {
+    /// Schema version. Currently always `"1"`.
+    pub schema_version: String,
+
+    /// Information about the project that was inspected.
+    pub project: ProjectInfo,
+
+    /// All installed battery packs, in stable order (sorted by short name).
+    pub packs: Vec<InstalledPackStatus>,
+}
+
+/// Information about the project whose status was inspected.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ProjectInfo {
+    /// Path to the `Cargo.toml` that was inspected.
+    pub manifest_path: PathBuf,
+}
+
+/// Status of a single installed battery pack.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct InstalledPackStatus {
+    /// Short name without the `-battery-pack` suffix, e.g. `"cli"`.
+    pub short_name: String,
+
+    /// Full crate name, e.g. `"cli-battery-pack"`.
+    pub name: String,
+
+    /// Registered version of the battery pack as recorded in the
+    /// project's metadata.
+    pub version: String,
+
+    /// Active features for this pack in the user's project.
+    ///
+    /// Sorted alphabetically.
+    pub active_features: Vec<String>,
+
+    /// Per-dependency warnings for this pack — each entry indicates
+    /// a dependency whose user-side version is older than what the
+    /// battery pack recommends.
+    ///
+    /// An empty vector means all dependencies are up to date.
+    pub warnings: Vec<DependencyWarning>,
+}
+
+/// A single version-drift warning for a battery pack dependency.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct DependencyWarning {
+    /// Crate name (e.g. `"clap"`).
+    pub crate_name: String,
+    /// Current version pinned in the user's `Cargo.toml` (or workspace).
+    pub current_version: String,
+    /// Version recommended by the battery pack.
+    pub recommended_version: String,
+}
+
+// ============================================================================
+// Builders
+// ============================================================================
+//
+// All schema types follow the same shape:
+//   - `new(required_fields...)` for the smallest valid value.
+//   - `with_<field>` for adding a single item to a collection-shaped field.
+//   - `with_<plural>` for extending a collection with an iterator.
+// New fields added in future schema versions gain a new `with_*` method
+// instead of changing `new()`'s signature, so producers stay forward-compatible.
+
+impl StatusReport {
+    /// Start building a report with the current [`SCHEMA_VERSION`] and
+    /// no packs. Add packs with [`with_pack`](Self::with_pack) /
+    /// [`with_packs`](Self::with_packs).
+    pub fn new(project: ProjectInfo) -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION.to_string(),
+            project,
+            packs: Vec::new(),
+        }
+    }
+
+    /// Append a single installed-pack status.
+    pub fn with_pack(mut self, pack: InstalledPackStatus) -> Self {
+        self.packs.push(pack);
+        self
+    }
+
+    /// Extend the report with multiple installed-pack statuses.
+    pub fn with_packs(mut self, packs: impl IntoIterator<Item = InstalledPackStatus>) -> Self {
+        self.packs.extend(packs);
+        self
+    }
+}
+
+impl ProjectInfo {
+    /// Build a [`ProjectInfo`] from the inspected manifest path.
+    pub fn new(manifest_path: impl Into<PathBuf>) -> Self {
+        Self {
+            manifest_path: manifest_path.into(),
+        }
+    }
+}
+
+impl InstalledPackStatus {
+    /// Start building an installed-pack status with no active features
+    /// or warnings. Use [`with_active_feature`](Self::with_active_feature) /
+    /// [`with_warning`](Self::with_warning) (and their plural variants)
+    /// to populate the rest.
+    pub fn new(
+        short_name: impl Into<String>,
+        name: impl Into<String>,
+        version: impl Into<String>,
+    ) -> Self {
+        Self {
+            short_name: short_name.into(),
+            name: name.into(),
+            version: version.into(),
+            active_features: Vec::new(),
+            warnings: Vec::new(),
+        }
+    }
+
+    /// Append a single active feature.
+    pub fn with_active_feature(mut self, feature: impl Into<String>) -> Self {
+        self.active_features.push(feature.into());
+        self
+    }
+
+    /// Extend the active features list from any iterable of string-likes.
+    pub fn with_active_features<I, S>(mut self, features: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.active_features
+            .extend(features.into_iter().map(Into::into));
+        self
+    }
+
+    /// Append a single dependency warning.
+    pub fn with_warning(mut self, warning: DependencyWarning) -> Self {
+        self.warnings.push(warning);
+        self
+    }
+
+    /// Extend the warnings list with multiple dependency warnings.
+    pub fn with_warnings(mut self, warnings: impl IntoIterator<Item = DependencyWarning>) -> Self {
+        self.warnings.extend(warnings);
+        self
+    }
+}
+
+impl DependencyWarning {
+    /// Build a [`DependencyWarning`] from its current required fields.
+    pub fn new(
+        crate_name: impl Into<String>,
+        current_version: impl Into<String>,
+        recommended_version: impl Into<String>,
+    ) -> Self {
+        Self {
+            crate_name: crate_name.into(),
+            current_version: current_version.into(),
+            recommended_version: recommended_version.into(),
+        }
+    }
+}

--- a/src/cargo-bp/Cargo.toml
+++ b/src/cargo-bp/Cargo.toml
@@ -28,6 +28,8 @@ anyhow.workspace = true
 
 [dev-dependencies]
 assert_cmd = "2"
+cargo-bp-script.workspace = true
+serde_json.workspace = true
 snapbox.workspace = true
 tempfile.workspace = true
 toml.workspace = true

--- a/src/cargo-bp/tests/status_json.rs
+++ b/src/cargo-bp/tests/status_json.rs
@@ -1,0 +1,201 @@
+//! Integration tests for `cargo bp status --json`.
+//!
+//! Exercises both the binary directly (via `assert_cmd`) and the
+//! `cargo-bp-script` runner that wraps it.
+
+use assert_cmd::Command;
+use cargo_bp_script::{SCHEMA_VERSION, StatusCommand, parse_status};
+use std::path::{Path, PathBuf};
+
+fn cargo_bp() -> Command {
+    Command::new(assert_cmd::cargo::cargo_bin!("cargo-bp"))
+}
+
+fn fixtures_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("battery-pack")
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("tests/fixtures")
+}
+
+/// Build a temp project that has `fancy-battery-pack` registered as a
+/// build-dep and an outdated `clap` regular dep that should produce a
+/// version warning relative to the fixture's recommendation.
+fn make_project_with_outdated_clap() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("Cargo.toml"),
+        r#"
+[package]
+name = "test-consumer"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = "3.0"
+
+[build-dependencies]
+fancy-battery-pack = "0.2.0"
+"#,
+    )
+    .unwrap();
+    // Stub src/lib.rs so the manifest is plausibly a real crate.
+    std::fs::create_dir_all(tmp.path().join("src")).unwrap();
+    std::fs::write(tmp.path().join("src/lib.rs"), "").unwrap();
+    tmp
+}
+
+#[test]
+fn status_json_emits_valid_schema() {
+    let tmp = make_project_with_outdated_clap();
+    let fixture = fixtures_dir().join("fancy-battery-pack");
+
+    let output = cargo_bp()
+        .args([
+            "bp",
+            "status",
+            "--json",
+            "--path",
+            &fixture.to_string_lossy(),
+        ])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run cargo-bp");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // --- Parse via the script crate so we exercise `parse_status`.
+    let report = parse_status(&output.stdout).unwrap_or_else(|err| {
+        panic!(
+            "parse_status failed: {err}\nraw stdout: {:?}",
+            output.stdout
+        )
+    });
+
+    assert_eq!(report.schema_version, SCHEMA_VERSION);
+    // Compare via canonicalisation to avoid macOS `/var` vs `/private/var`
+    // surprises when comparing tempdir paths.
+    let expected_manifest = tmp.path().join("Cargo.toml").canonicalize().unwrap();
+    let got_manifest = report.project.manifest_path.canonicalize().unwrap();
+    assert_eq!(
+        got_manifest, expected_manifest,
+        "manifest_path should point at the project's Cargo.toml",
+    );
+
+    // We registered exactly one battery pack (fancy).
+    assert_eq!(report.packs.len(), 1, "expected one installed pack");
+    let pack = &report.packs[0];
+    assert_eq!(pack.short_name, "fancy");
+    assert_eq!(pack.name, "fancy-battery-pack");
+    assert_eq!(pack.version, "0.2.0");
+
+    // The fixture recommends clap 4 → user has 3.0 → expect a warning.
+    let clap_warning = pack
+        .warnings
+        .iter()
+        .find(|w| w.crate_name == "clap")
+        .expect("expected a clap version warning");
+    assert_eq!(clap_warning.current_version, "3.0");
+    assert!(
+        clap_warning.recommended_version.starts_with('4'),
+        "fancy-battery-pack recommends a 4.x clap, got: {}",
+        clap_warning.recommended_version,
+    );
+}
+
+#[test]
+fn status_command_runner_returns_typed_report() {
+    let tmp = make_project_with_outdated_clap();
+    let fixture = fixtures_dir().join("fancy-battery-pack");
+
+    // Use the locally-built `cargo-bp` binary directly so we don't need
+    // it on PATH for this test to work.
+    let report = StatusCommand::new()
+        .program(assert_cmd::cargo::cargo_bin!("cargo-bp"))
+        .cwd(tmp.path())
+        .path(&fixture)
+        .run()
+        .expect("StatusCommand::run failed");
+
+    assert_eq!(report.schema_version, SCHEMA_VERSION);
+    assert_eq!(report.packs.len(), 1);
+    assert_eq!(report.packs[0].name, "fancy-battery-pack");
+    assert!(
+        report.packs[0]
+            .warnings
+            .iter()
+            .any(|w| w.crate_name == "clap"),
+        "expected a clap version warning",
+    );
+}
+
+#[test]
+fn status_json_outside_project_fails_cleanly() {
+    let tmp = tempfile::tempdir().unwrap();
+
+    let output = cargo_bp()
+        .args(["bp", "status", "--json"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run cargo-bp");
+
+    // No Cargo.toml → should error, and the error should travel to stderr,
+    // leaving stdout empty so the script runner's `parse_status` doesn't
+    // get a misleading half-payload.
+    assert!(!output.status.success());
+    assert!(
+        output.stdout.is_empty(),
+        "stdout should be empty on error, got: {:?}",
+        String::from_utf8_lossy(&output.stdout),
+    );
+}
+
+#[test]
+fn status_json_no_packs_emits_empty_packs_array() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("Cargo.toml"),
+        r#"
+[package]
+name = "no-packs"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = "1"
+"#,
+    )
+    .unwrap();
+    std::fs::create_dir_all(tmp.path().join("src")).unwrap();
+    std::fs::write(tmp.path().join("src/lib.rs"), "").unwrap();
+
+    let output = cargo_bp()
+        .args(["bp", "status", "--json"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run cargo-bp");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let report =
+        parse_status(&output.stdout).expect("parse_status should succeed for empty packs case");
+    assert!(
+        report.packs.is_empty(),
+        "expected no packs, got {} packs",
+        report.packs.len(),
+    );
+    assert_eq!(report.schema_version, SCHEMA_VERSION);
+}


### PR DESCRIPTION
Introduces a new top-level `cargo-bp-script` crate providing:

- JSON schema types for `cargo bp status` output (StatusReport, ProjectInfo, InstalledPackStatus, DependencyWarning), all `#[non_exhaustive]` with chainable `new(required)` + `with_*` builders so future schema fields are non-breaking on both producer and consumer sides.
- A small process runner (`StatusCommand`) and `parse_status` helper for spawning `cargo bp` and parsing its JSON output, intended for agent-scriptable consumers.

`cargo bp status` gains a `--json` flag that emits the schema-conformant payload on stdout; the human-readable text output is unchanged.

Adds spec rule cli.status.json and updates the user-facing mdbook docs.