### PR TITLE
refactor(status): split text/JSON output into render_status_* fns

### DIFF
--- a/src/battery-pack/bphelper-cli/src/commands/mod.rs
+++ b/src/battery-pack/bphelper-cli/src/commands/mod.rs
@@ -1872,6 +1872,13 @@ fn print_template_preview(opts: &crate::template_engine::PreviewOpts<'_>) -> Res
 // ============================================================================
 // Status command
 // ============================================================================
+//
+// Status is split into three pieces so that the text and JSON outputs are
+// guaranteed to read from the same data:
+//   1. `build_status_report` — pure data, returns a `StatusReport`.
+//   2. `render_status_json`  — serializes the report to a writer.
+//   3. `render_status_text`  — pretty-prints the report to a writer.
+// `status_battery_packs` is a thin dispatcher that picks one renderer.
 
 // [impl cli.status.list]
 // [impl cli.status.version-warn]
@@ -1885,57 +1892,79 @@ fn status_battery_packs(
     source: &CrateSource,
     json: bool,
 ) -> Result<()> {
+    let report = build_status_report(project_dir, path, source)?;
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    if json {
+        render_status_json(&report, &mut out).context("Failed to write status JSON")?;
+    } else {
+        render_status_text(&report, &mut out).context("Failed to render status")?;
+    }
+    Ok(())
+}
+
+/// Serialize a [`StatusReport`] as JSON to `w`, with a trailing newline.
+///
+/// Used for `cargo bp status --json`. Stable, machine-consumable output;
+/// the schema lives in `cargo-bp-script`.
+// [impl cli.status.json]
+fn render_status_json(
+    report: &cargo_bp_script::StatusReport,
+    w: &mut impl std::io::Write,
+) -> std::io::Result<()> {
+    serde_json::to_writer(&mut *w, report)?;
+    writeln!(w)?;
+    Ok(())
+}
+
+/// Pretty-print a [`StatusReport`] for human consumption to `w`.
+///
+/// Reads the same data the JSON renderer reads, so JSON and text output
+/// are guaranteed to be consistent at the data layer.
+// [impl cli.status.list]
+// [impl cli.status.version-warn]
+fn render_status_text(
+    report: &cargo_bp_script::StatusReport,
+    w: &mut impl std::io::Write,
+) -> std::io::Result<()> {
     use console::style;
 
-    // --- Build the structured report once; both renderers consume it.
-    let report = build_status_report(project_dir, path, source)?;
-
-    // --- JSON path: emit only the schema payload on stdout.
-    if json {
-        let stdout = std::io::stdout();
-        let mut handle = stdout.lock();
-        serde_json::to_writer(&mut handle, &report).context("Failed to serialize status JSON")?;
-        // Trailing newline so consumers can `read_to_string()` and tools play nice.
-        use std::io::Write as _;
-        writeln!(handle).context("Failed to write status JSON")?;
-        return Ok(());
-    }
-
-    // --- Text path: preserve the existing human-readable rendering.
     if report.packs.is_empty() {
-        println!("No battery packs installed.");
+        writeln!(w, "No battery packs installed.")?;
         return Ok(());
     }
 
     let mut any_warnings = false;
     for pack in &report.packs {
         // [impl cli.status.list]
-        println!(
+        writeln!(
+            w,
             "{} ({})",
             style(&pack.short_name).bold(),
             style(&pack.version).dim(),
-        );
+        )?;
 
         if pack.warnings.is_empty() {
-            println!("  {} all dependencies up to date", style("✓").green());
+            writeln!(w, "  {} all dependencies up to date", style("✓").green())?;
         } else {
             any_warnings = true;
             for warning in &pack.warnings {
                 // [impl cli.status.version-warn]
-                println!(
+                writeln!(
+                    w,
                     "  {} {}: {} → {} recommended",
                     style("⚠").yellow(),
                     warning.crate_name,
                     style(&warning.current_version).red(),
                     style(&warning.recommended_version).green(),
-                );
+                )?;
             }
         }
     }
 
     if any_warnings {
-        println!();
-        println!("Run {} to update.", style("cargo bp sync").bold());
+        writeln!(w)?;
+        writeln!(w, "Run {} to update.", style("cargo bp sync").bold())?;
     }
 
     Ok(())

--- a/src/battery-pack/bphelper-cli/src/commands/tests.rs
+++ b/src/battery-pack/bphelper-cli/src/commands/tests.rs
@@ -1971,3 +1971,113 @@ fn load_template_hints_returns_hints() {
     assert_eq!(hints[0], "Add mod errors;");
     assert_eq!(hints[1], "Run cargo install cargo-fuzz");
 }
+
+// ============================================================================
+// render_status_json / render_status_text
+// ============================================================================
+//
+// Both renderers share `cargo_bp_script::StatusReport` as their input,
+// so these tests pin the contract between the schema struct and each
+// output mode. Any future schema change forces both renderers to be
+// updated coherently.
+
+/// Build a small report with one pack, one feature, and one warning.
+fn sample_report() -> cargo_bp_script::StatusReport {
+    cargo_bp_script::StatusReport::new(cargo_bp_script::ProjectInfo::new("/proj/Cargo.toml"))
+        .with_pack(
+            cargo_bp_script::InstalledPackStatus::new("cli", "cli-battery-pack", "0.3.0")
+                .with_active_feature("default")
+                .with_warning(cargo_bp_script::DependencyWarning::new(
+                    "clap", "4.4.0", "4.5.0",
+                )),
+        )
+}
+
+#[test]
+fn render_status_json_round_trips_through_parse_status() {
+    let report = sample_report();
+
+    let mut buf = Vec::new();
+    super::render_status_json(&report, &mut buf).unwrap();
+
+    // Last byte should be a newline so consumers can read until EOF safely.
+    assert_eq!(
+        buf.last(),
+        Some(&b'\n'),
+        "JSON output must end with newline"
+    );
+
+    let parsed = cargo_bp_script::parse_status(&buf).expect("parse_status round-trip");
+    assert_eq!(parsed, report);
+}
+
+#[test]
+// [verify cli.status.list]
+// [verify cli.status.version-warn]
+fn render_status_text_includes_pack_and_warning() {
+    // Strip ANSI styling so the assertions don't depend on TTY detection.
+    console::set_colors_enabled(false);
+
+    let report = sample_report();
+
+    let mut buf = Vec::new();
+    super::render_status_text(&report, &mut buf).unwrap();
+    let text = String::from_utf8(buf).expect("renderer emits UTF-8");
+
+    // Pack header + version
+    assert!(text.contains("cli"), "missing pack short_name in:\n{text}");
+    assert!(text.contains("0.3.0"), "missing pack version in:\n{text}");
+
+    // Warning row
+    assert!(text.contains("clap"), "missing crate name in:\n{text}");
+    assert!(
+        text.contains("4.4.0"),
+        "missing current version in:\n{text}"
+    );
+    assert!(
+        text.contains("4.5.0"),
+        "missing recommended version in:\n{text}"
+    );
+
+    // Trailing hint when warnings are present
+    assert!(
+        text.contains("cargo bp sync"),
+        "missing sync hint in:\n{text}"
+    );
+}
+
+#[test]
+fn render_status_text_no_packs_emits_friendly_message() {
+    console::set_colors_enabled(false);
+
+    let report =
+        cargo_bp_script::StatusReport::new(cargo_bp_script::ProjectInfo::new("/proj/Cargo.toml"));
+
+    let mut buf = Vec::new();
+    super::render_status_text(&report, &mut buf).unwrap();
+    let text = String::from_utf8(buf).unwrap();
+
+    assert!(text.starts_with("No battery packs installed."));
+    // No sync hint when there's nothing to sync.
+    assert!(!text.contains("cargo bp sync"));
+}
+
+#[test]
+fn render_status_text_no_warnings_omits_sync_hint() {
+    console::set_colors_enabled(false);
+
+    let report =
+        cargo_bp_script::StatusReport::new(cargo_bp_script::ProjectInfo::new("/proj/Cargo.toml"))
+            .with_pack(cargo_bp_script::InstalledPackStatus::new(
+                "cli",
+                "cli-battery-pack",
+                "0.3.0",
+            ));
+
+    let mut buf = Vec::new();
+    super::render_status_text(&report, &mut buf).unwrap();
+    let text = String::from_utf8(buf).unwrap();
+
+    assert!(text.contains("all dependencies up to date"));
+    assert!(!text.contains("cargo bp sync"));
+}


### PR DESCRIPTION
Both `cargo bp status` and `cargo bp status --json` already shared a single source of truth via `build_status_report`, but the text path's formatting logic was inlined inside `status_battery_packs` while the JSON path was a one-liner via `serde_json`. That asymmetry made it easy to accidentally let the two paths drift.

Extract two symmetric, writer-generic functions:

- `render_status_json(&report, w)` — schema-conformant JSON output.
- `render_status_text(&report, w)` — human-readable pretty-print.

`status_battery_packs` becomes a thin dispatcher that picks one and locks stdout. Adds unit tests against in-memory buffers covering JSON round-trip via `parse_status`, the warning row, the empty-packs path, and the no-warnings path. No user-visible behavior change.