### PR TITLE
Add optional cross-platform testing job

### DIFF
--- a/battery-packs/ci-battery-pack/README.md
+++ b/battery-packs/ci-battery-pack/README.md
@@ -63,6 +63,7 @@ Use `-d all` to enable everything. Otherwise, each defaults to off (except `trus
 | `spellcheck` | false | [typos](https://github.com/crate-ci/typos) config + workflow | |
 | `xtask` | false | [cargo-xtask](https://github.com/matklad/cargo-xtask) scaffold with codegen `--check` | `xshell`, `xflags` |
 | `mutation_testing` | false | [cargo-mutants](https://mutants.rs/) mutation testing | |
+| `cross_platform` | false | Test suite on macOS and Windows | |
 | `clippy_sarif` | false | Clippy with GitHub PR annotations via [SARIF](https://github.com/psastras/sarif-rs) | |
 
 ### SHA pinning

--- a/battery-packs/ci-battery-pack/snippets/github/ci-pass.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/ci-pass.yml
@@ -1,5 +1,5 @@
   ci-pass:
-    needs: [fmt, {% if all or clippy_sarif %}clippy-sarif{% else %}clippy{% endif %}, warnings, docsrs, build, features, msrv, lockfile, minimal-versions, semver{% if all or benchmarks %}, bench, bench-pr{% endif %}{% if all or fuzzing %}, fuzz-smoke{% endif %}{% if all or stress_tests %}, stress-test{% endif %}{% if all or spellcheck %}, spellcheck{% endif %}{% if all or xtask %}, xtask{% endif %}{% if all or mutation_testing %}, mutants{% endif %}]
+    needs: [fmt, {% if all or clippy_sarif %}clippy-sarif{% else %}clippy{% endif %}, warnings, docsrs, build, features, msrv, lockfile, minimal-versions, semver{% if all or cross_platform %}, cross-platform{% endif %}{% if all or benchmarks %}, bench, bench-pr{% endif %}{% if all or fuzzing %}, fuzz-smoke{% endif %}{% if all or stress_tests %}, stress-test{% endif %}{% if all or spellcheck %}, spellcheck{% endif %}{% if all or xtask %}, xtask{% endif %}{% if all or mutation_testing %}, mutants{% endif %}]
     if: {% raw %}${{ !cancelled() }}{% endraw %}
     runs-on: ubuntu-latest
     steps:

--- a/battery-packs/ci-battery-pack/snippets/github/jobs/cross-platform.yml
+++ b/battery-packs/ci-battery-pack/snippets/github/jobs/cross-platform.yml
@@ -1,0 +1,15 @@
+  # Test on macOS and Windows to catch platform-specific issues.
+  cross-platform:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: {% raw %}${{ matrix.os }}{% endraw %}
+    steps:
+      - uses: {{ pin_github_action("actions/checkout", "v6") }}
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/rust-build
+        with:
+          toolchain: stable
+          flags: --all-features

--- a/battery-packs/ci-battery-pack/src/snapshots/maximalist.txt
+++ b/battery-packs/ci-battery-pack/src/snapshots/maximalist.txt
@@ -303,6 +303,21 @@ jobs:
         with:
           persist-credentials: false
       - uses: obi1kenobi/cargo-semver-checks-action@[..] # v2
+  # Test on macOS and Windows to catch platform-specific issues.
+  cross-platform:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@[..] # v[..]
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/rust-build
+        with:
+          toolchain: stable
+          flags: --all-features
   # Bencher regression detection. Requires:
   # - BENCHER_API_TOKEN repo secret (https://bencher.dev/docs)
   # - BENCHER_PROJECT repo variable (your Bencher project slug)
@@ -455,7 +470,7 @@ jobs:
           sarif_file: clippy-results.sarif
           wait-for-processing: true
   ci-pass:
-    needs: [fmt, clippy-sarif, warnings, docsrs, build, features, msrv, lockfile, minimal-versions, semver, bench, bench-pr, fuzz-smoke, stress-test, spellcheck, xtask, mutants]
+    needs: [fmt, clippy-sarif, warnings, docsrs, build, features, msrv, lockfile, minimal-versions, semver, cross-platform, bench, bench-pr, fuzz-smoke, stress-test, spellcheck, xtask, mutants]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:

--- a/battery-packs/ci-battery-pack/templates/full/.github/workflows/ci.yml
+++ b/battery-packs/ci-battery-pack/templates/full/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
 {% include "snippets/github/jobs/lockfile.yml" %}
 {% include "snippets/github/jobs/minimal-versions.yml" %}
 {% include "snippets/github/jobs/semver.yml" %}
+{%- if all or cross_platform %}
+{% include "snippets/github/jobs/cross-platform.yml" %}
+{%- endif -%}
 {%- if all or benchmarks %}
 {% include "snippets/github/jobs/bench.yml" %}
 {%- endif -%}

--- a/battery-packs/ci-battery-pack/templates/full/bp-template.toml
+++ b/battery-packs/ci-battery-pack/templates/full/bp-template.toml
@@ -59,6 +59,11 @@ type = "bool"
 prompt = "Include cross-platform binary builds (GitHub Releases + cargo-binstall)?"
 default = "false"
 
+[placeholders.cross_platform]
+type = "bool"
+prompt = "Include cross-platform testing (macOS + Windows)?"
+default = "false"
+
 [placeholders.mutation_testing]
 type = "bool"
 prompt = "Include mutation testing (cargo-mutants)?"


### PR DESCRIPTION
### Summary

Adds a `cross_platform` opt-in feature that runs the test suite on macOS and Windows via a matrix job. Useful for crates that deal with filesystem paths, platform-specific FFI, or conditional compilation.

The job reuses the existing `rust-build` composite action (stable toolchain, `--all-features`) rather than duplicating the full toolchain/feature matrix from the `build` job. Cross-platform bugs are almost always platform-specific (path separators, line endings, FFI), not toolchain-version-specific, so this keeps CI minutes reasonable.

Inspired by the `test-os` job in [tower-rs/tower-http#683](https://github.com/tower-rs/tower-http/pull/683).

### Testing

The maximalist snapshot includes the new `cross-platform` job and its entry in the `ci-pass` needs list. The minimalist snapshot correctly omits it (opt-in only). `validate` test confirms template rendering is well-formed.
