### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,7 +301,7 @@ dependencies = [
 
 [[package]]
 name = "backend-service-battery-pack"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -353,7 +353,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "battery-pack"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "anyhow",
  "battery-pack",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "bphelper-build"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "bphelper-manifest",
  "cargo_metadata",
@@ -463,7 +463,7 @@ dependencies = [
 
 [[package]]
 name = "bphelper-cli"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "bphelper-manifest",
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "bphelper-manifest"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "serde",
  "tempfile",
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-bp"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -563,7 +563,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-bp-script"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -635,7 +635,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "ci-battery-pack"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "arbitrary",
  "battery-pack",
@@ -727,7 +727,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-battery-pack"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1360,7 +1360,7 @@ dependencies = [
 
 [[package]]
 name = "error-battery-pack"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "battery-pack",
@@ -2406,7 +2406,7 @@ checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "logging-battery-pack"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "battery-pack",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ resolver = "2"
 
 [workspace.dependencies]
 battery-pack = { path = "src/battery-pack", version = "0.5" }
-cargo-bp-script = { path = "src/cargo-bp-script", version = "0.1" }
+cargo-bp-script = { path = "src/cargo-bp-script", version = "0.2" }
 anyhow = "1"
 minijinja = { version = "2", features = ["loader"] }
 cargo_metadata = "0.23"

--- a/battery-packs/ci-battery-pack/CHANGELOG.md
+++ b/battery-packs/ci-battery-pack/CHANGELOG.md
@@ -11,17 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- *(ci-battery-pack)* add optional cross-platform testing job
+- *(ci-battery-pack)* add optional cross-platform testing job ([#128](https://github.com/battery-pack-rs/battery-pack/pull/128))
 
 ### Fixed
 
-- *(ci-battery-pack)* make snapshot tests cross-platform for .exe
+- *(ci-battery-pack)* make snapshot tests cross-platform for `.exe` ([#128](https://github.com/battery-pack-rs/battery-pack/pull/128))
 
 ### Other
 
-- *(battery-pack)* migrate templates to battery-pack.toml, drop unused dep
-- *(templates)* trim .rs whitespace more aggressively, rustfmt after render, rustfmt on validate
-- Merge pull request #128 from jlizen/feat/ci-bp-skill
+- *(battery-pack)* migrate templates to `battery-pack.toml`, drop unused dep ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
 
 ## [0.1.4](https://github.com/battery-pack-rs/battery-pack/compare/ci-battery-pack-v0.1.3...ci-battery-pack-v0.1.4) - 2026-04-30
 

--- a/battery-packs/ci-battery-pack/CHANGELOG.md
+++ b/battery-packs/ci-battery-pack/CHANGELOG.md
@@ -11,11 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- *(ci-battery-pack)* add optional cross-platform testing job ([#128](https://github.com/battery-pack-rs/battery-pack/pull/128))
+- *(ci-battery-pack)* add optional cross-platform testing job ([#136](https://github.com/battery-pack-rs/battery-pack/pull/136))
 
 ### Fixed
 
-- *(ci-battery-pack)* make snapshot tests cross-platform for `.exe` ([#128](https://github.com/battery-pack-rs/battery-pack/pull/128))
+- *(test)* make snapshot tests cross-platform for `.exe` ([#138](https://github.com/battery-pack-rs/battery-pack/pull/138))
 
 ### Other
 

--- a/battery-packs/ci-battery-pack/CHANGELOG.md
+++ b/battery-packs/ci-battery-pack/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/battery-pack-rs/battery-pack/compare/ci-battery-pack-v0.1.4...ci-battery-pack-v0.1.5) - 2026-06-03
+
+### Added
+
+- *(ci-battery-pack)* add optional cross-platform testing job
+
+### Fixed
+
+- *(ci-battery-pack)* make snapshot tests cross-platform for .exe
+
+### Other
+
+- *(battery-pack)* migrate templates to battery-pack.toml, drop unused dep
+- *(templates)* trim .rs whitespace more aggressively, rustfmt after render, rustfmt on validate
+- Merge pull request #128 from jlizen/feat/ci-bp-skill
+
 ## [0.1.4](https://github.com/battery-pack-rs/battery-pack/compare/ci-battery-pack-v0.1.3...ci-battery-pack-v0.1.4) - 2026-04-30
 
 ### Added

--- a/battery-packs/ci-battery-pack/Cargo.toml
+++ b/battery-packs/ci-battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ci-battery-pack"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 description = "Battery pack for CI/CD workflows in Rust projects"
 license = "MIT OR Apache-2.0"

--- a/battery-packs/cli-battery-pack/CHANGELOG.md
+++ b/battery-packs/cli-battery-pack/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- *(cli-battery-pack)* add `[EXE]` to help snapshots for Windows compat
+- *(test)* add `[EXE]` to help snapshots for Windows compat ([#138](https://github.com/battery-pack-rs/battery-pack/pull/138))
 
 ### Other
 

--- a/battery-packs/cli-battery-pack/CHANGELOG.md
+++ b/battery-packs/cli-battery-pack/CHANGELOG.md
@@ -11,11 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- *(cli-battery-pack)* add [EXE] to help snapshots for Windows compat
+- *(cli-battery-pack)* add `[EXE]` to help snapshots for Windows compat
 
 ### Other
 
-- *(battery-pack)* migrate templates to battery-pack.toml, drop unused dep
+- *(battery-pack)* migrate templates to `battery-pack.toml`, drop unused dep ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
 
 ## [0.6.1](https://github.com/battery-pack-rs/battery-pack/compare/cli-battery-pack-v0.6.0...cli-battery-pack-v0.6.1) - 2026-04-30
 

--- a/battery-packs/cli-battery-pack/CHANGELOG.md
+++ b/battery-packs/cli-battery-pack/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2](https://github.com/battery-pack-rs/battery-pack/compare/cli-battery-pack-v0.6.1...cli-battery-pack-v0.6.2) - 2026-06-03
+
+### Fixed
+
+- *(cli-battery-pack)* add [EXE] to help snapshots for Windows compat
+
+### Other
+
+- *(battery-pack)* migrate templates to battery-pack.toml, drop unused dep
+
 ## [0.6.1](https://github.com/battery-pack-rs/battery-pack/compare/cli-battery-pack-v0.6.0...cli-battery-pack-v0.6.1) - 2026-04-30
 
 ### Added

--- a/battery-packs/cli-battery-pack/Cargo.toml
+++ b/battery-packs/cli-battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli-battery-pack"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 description = "Battery pack for building CLI applications in Rust"
 license = "MIT OR Apache-2.0"

--- a/battery-packs/error-battery-pack/CHANGELOG.md
+++ b/battery-packs/error-battery-pack/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
-- *(battery-pack)* migrate templates to battery-pack.toml, drop unused dep
+- *(battery-pack)* migrate templates to `battery-pack.toml`, drop unused dep ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
 
 ## [0.6.3](https://github.com/battery-pack-rs/battery-pack/compare/error-battery-pack-v0.6.2...error-battery-pack-v0.6.3) - 2026-05-17
 

--- a/battery-packs/error-battery-pack/CHANGELOG.md
+++ b/battery-packs/error-battery-pack/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.4](https://github.com/battery-pack-rs/battery-pack/compare/error-battery-pack-v0.6.3...error-battery-pack-v0.6.4) - 2026-06-03
+
+### Other
+
+- *(battery-pack)* migrate templates to battery-pack.toml, drop unused dep
+
 ## [0.6.3](https://github.com/battery-pack-rs/battery-pack/compare/error-battery-pack-v0.6.2...error-battery-pack-v0.6.3) - 2026-05-17
 
 ### Other

--- a/battery-packs/error-battery-pack/Cargo.toml
+++ b/battery-packs/error-battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "error-battery-pack"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2024"
 description = "Error handling done well — anyhow for apps, thiserror for libraries"
 license = "MIT OR Apache-2.0"

--- a/battery-packs/logging-battery-pack/CHANGELOG.md
+++ b/battery-packs/logging-battery-pack/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2](https://github.com/battery-pack-rs/battery-pack/compare/logging-battery-pack-v0.5.1...logging-battery-pack-v0.5.2) - 2026-06-03
+
+### Other
+
+- *(battery-pack)* migrate templates to battery-pack.toml, drop unused dep
+
 ## [0.5.1](https://github.com/battery-pack-rs/battery-pack/compare/logging-battery-pack-v0.5.0...logging-battery-pack-v0.5.1) - 2026-04-30
 
 ### Added

--- a/battery-packs/logging-battery-pack/CHANGELOG.md
+++ b/battery-packs/logging-battery-pack/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
-- *(battery-pack)* migrate templates to battery-pack.toml, drop unused dep
+- *(battery-pack)* migrate templates to `battery-pack.toml`, drop unused dep ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
 
 ## [0.5.1](https://github.com/battery-pack-rs/battery-pack/compare/logging-battery-pack-v0.5.0...logging-battery-pack-v0.5.1) - 2026-04-30
 

--- a/battery-packs/logging-battery-pack/Cargo.toml
+++ b/battery-packs/logging-battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logging-battery-pack"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 description = "Battery pack for logging and tracing in Rust"
 license = "MIT OR Apache-2.0"

--- a/opinionated-battery-packs/backend-service-battery-pack/CHANGELOG.md
+++ b/opinionated-battery-packs/backend-service-battery-pack/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/battery-pack-rs/battery-pack/compare/backend-service-battery-pack-v0.1.0...backend-service-battery-pack-v0.1.1) - 2026-06-03
+
+### Other
+
+- rename network-service-battery-pack to backend-service-battery-pack

--- a/opinionated-battery-packs/backend-service-battery-pack/CHANGELOG.md
+++ b/opinionated-battery-packs/backend-service-battery-pack/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.1](https://github.com/battery-pack-rs/battery-pack/compare/backend-service-battery-pack-v0.1.0...backend-service-battery-pack-v0.1.1) - 2026-06-03
 
+### Added
+
+- *(backend-service-battery-pack)* opinionated battery pack that scaffolds an async backend service (axum) with metrique wide-event metrics, structured tracing, optional dial9 flight-recorder integration, jemalloc/mimalloc allocator selection, graceful shutdown with drain metrics, an in-memory or HTTP-forwarding downstream, and a Tower middleware stack, plus telemetry, memory-allocator, and service-architecture skills ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
+
 ### Other
 
-- rename network-service-battery-pack to backend-service-battery-pack
+- *(backend-service-battery-pack)* rename from network-service-battery-pack ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))

--- a/opinionated-battery-packs/backend-service-battery-pack/Cargo.toml
+++ b/opinionated-battery-packs/backend-service-battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "backend-service-battery-pack"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Opinionated battery pack for resilient async backend services in Rust"
 license = "MIT OR Apache-2.0"

--- a/src/battery-pack/CHANGELOG.md
+++ b/src/battery-pack/CHANGELOG.md
@@ -13,20 +13,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - *(backend-service-battery-pack)* new opinionated async backend service pack ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
 - *(bphelper-cli)* resolve bp-managed active packs from `battery-pack.toml` ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
-- *(validate)* add `validate_template_with` for exercising placeholder combinations ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
-- *(cargo-bp-script)* add JSON output for `list` and `show` commands
-- *(ci-battery-pack)* add optional cross-platform testing job ([#128](https://github.com/battery-pack-rs/battery-pack/pull/128))
+- *(test)* add `validate_template_with` for exercising placeholder combinations ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
+- *(cargo-bp-script)* add JSON output for `list` and `show` commands ([#140](https://github.com/battery-pack-rs/battery-pack/pull/140))
+- *(ci-battery-pack)* add optional cross-platform testing job ([#136](https://github.com/battery-pack-rs/battery-pack/pull/136))
 
 ### Fixed
 
-- *(with_template)* migrate default_template snapshot to `battery-pack.toml` ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
-- *(template)* render template paths and tests OS-agnostically on Windows ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
+- *(test)* migrate default_template snapshot to `battery-pack.toml` ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
+- *(template)* render template paths and tests OS-agnostically on Windows ([#134](https://github.com/battery-pack-rs/battery-pack/pull/134))
 - *(validate)* merge patches into a template's `.cargo/config.toml` instead of overwriting ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
-- *(template)* use a trailing slash in `starts_with` to prevent false prefix matches ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
+- *(template)* use a trailing slash in `starts_with` to prevent false prefix matches ([#134](https://github.com/battery-pack-rs/battery-pack/pull/134))
 - *(manifest)* include non-optional base deps when features are active ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
-- *(cargo-bp)* address PR review: conflict guard and snapbox tests ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
-- *(ci-battery-pack)* make snapshot tests cross-platform for `.exe` ([#128](https://github.com/battery-pack-rs/battery-pack/pull/128))
-- *(cli-battery-pack)* add `[EXE]` to help snapshots for Windows compat
+- *(cargo-bp)* address PR review: conflict guard and snapbox tests ([#140](https://github.com/battery-pack-rs/battery-pack/pull/140))
+- *(test)* make snapshot tests cross-platform for `.exe` ([#138](https://github.com/battery-pack-rs/battery-pack/pull/138))
+- *(test)* add `[EXE]` to help snapshots for Windows compat ([#138](https://github.com/battery-pack-rs/battery-pack/pull/138))
 
 ### Other
 

--- a/src/battery-pack/CHANGELOG.md
+++ b/src/battery-pack/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.5](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.5.4...battery-pack-v0.5.5) - 2026-06-03
+
+### Added
+
+- *(bphelper-cli)* resolve bp-managed active packs from battery-pack.toml
+- *(validate)* add validate_template_with for exercising placeholder combinations
+- *(cargo-bp-script)* add JSON output for `list` and `show` commands
+- *(ci-battery-pack)* add optional cross-platform testing job
+
+### Fixed
+
+- *(with_template)* migrate default_template snapshot to battery-pack.toml
+- *(network-service)* correct clonable typo and apply rustfmt
+- render template paths and tests OS-agnostically on Windows
+- *(validate)* merge patches into a template's .cargo/config.toml instead of overwriting
+- *(template)* use trailing slash in starts_with to prevent false prefix matches
+- *(manifest)* include non-optional base deps when features are active
+- *(cargo-bp)* address PR review — conflict guard and snapbox tests
+- *(ci-battery-pack)* make snapshot tests cross-platform for .exe
+- *(cli-battery-pack)* add [EXE] to help snapshots for Windows compat
+
+### Other
+
+- Merge pull request #142 from jlizen/feat/network-service-battery-pack
+- *(battery-pack)* migrate templates to battery-pack.toml, drop unused dep
+- *(templates)* trim .rs whitespace more aggressively, rustfmt after render, rustfmt on validate
+- rename network-service-battery-pack to backend-service-battery-pack
+- *(template)* add path normalization and _Cargo.toml rename coverage
+- tidy whitespace + .gitignore EOF newline
+- *(template)* Windows path bugs in template validation
+- *(manifest)* capture non-optional deps dropped when features active
+- *(cargo-bp)* unify data-gathering and rendering for list/show
+- Merge pull request #128 from jlizen/feat/ci-bp-skill
+
 ## [0.5.4](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.5.3...battery-pack-v0.5.4) - 2026-05-17
 
 ### Added

--- a/src/battery-pack/CHANGELOG.md
+++ b/src/battery-pack/CHANGELOG.md
@@ -11,35 +11,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- *(bphelper-cli)* resolve bp-managed active packs from battery-pack.toml
-- *(validate)* add validate_template_with for exercising placeholder combinations
+- *(backend-service-battery-pack)* new opinionated async backend service pack ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
+- *(bphelper-cli)* resolve bp-managed active packs from `battery-pack.toml` ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
+- *(validate)* add `validate_template_with` for exercising placeholder combinations ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
 - *(cargo-bp-script)* add JSON output for `list` and `show` commands
-- *(ci-battery-pack)* add optional cross-platform testing job
+- *(ci-battery-pack)* add optional cross-platform testing job ([#128](https://github.com/battery-pack-rs/battery-pack/pull/128))
 
 ### Fixed
 
-- *(with_template)* migrate default_template snapshot to battery-pack.toml
-- *(network-service)* correct clonable typo and apply rustfmt
-- render template paths and tests OS-agnostically on Windows
-- *(validate)* merge patches into a template's .cargo/config.toml instead of overwriting
-- *(template)* use trailing slash in starts_with to prevent false prefix matches
-- *(manifest)* include non-optional base deps when features are active
-- *(cargo-bp)* address PR review — conflict guard and snapbox tests
-- *(ci-battery-pack)* make snapshot tests cross-platform for .exe
-- *(cli-battery-pack)* add [EXE] to help snapshots for Windows compat
+- *(with_template)* migrate default_template snapshot to `battery-pack.toml` ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
+- *(template)* render template paths and tests OS-agnostically on Windows ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
+- *(validate)* merge patches into a template's `.cargo/config.toml` instead of overwriting ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
+- *(template)* use a trailing slash in `starts_with` to prevent false prefix matches ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
+- *(manifest)* include non-optional base deps when features are active ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
+- *(cargo-bp)* address PR review: conflict guard and snapbox tests ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
+- *(ci-battery-pack)* make snapshot tests cross-platform for `.exe` ([#128](https://github.com/battery-pack-rs/battery-pack/pull/128))
+- *(cli-battery-pack)* add `[EXE]` to help snapshots for Windows compat
 
 ### Other
 
-- Merge pull request #142 from jlizen/feat/network-service-battery-pack
-- *(battery-pack)* migrate templates to battery-pack.toml, drop unused dep
-- *(templates)* trim .rs whitespace more aggressively, rustfmt after render, rustfmt on validate
-- rename network-service-battery-pack to backend-service-battery-pack
-- *(template)* add path normalization and _Cargo.toml rename coverage
-- tidy whitespace + .gitignore EOF newline
-- *(template)* Windows path bugs in template validation
-- *(manifest)* capture non-optional deps dropped when features active
-- *(cargo-bp)* unify data-gathering and rendering for list/show
-- Merge pull request #128 from jlizen/feat/ci-bp-skill
+- *(battery-pack)* migrate templates to `battery-pack.toml`, drop unused dep ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
+- *(templates)* trim `.rs` whitespace, run rustfmt after render, and assert `cargo fmt --check` on validate ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
+- *(backend-service-battery-pack)* rename from network-service-battery-pack ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
 
 ## [0.5.4](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.5.3...battery-pack-v0.5.4) - 2026-05-17
 

--- a/src/battery-pack/Cargo.toml
+++ b/src/battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "battery-pack"
-version = "0.5.4"
+version = "0.5.5"
 edition = "2024"
 description = "Curated crate bundles with docs, templates, and agentic skills"
 license = "MIT OR Apache-2.0"
@@ -21,9 +21,9 @@ build = ["bphelper-build"]
 cli = ["bphelper-cli"]
 
 [dependencies]
-bphelper-build = { path = "bphelper-build", version = "0.4.7", optional = true }
-bphelper-cli = { path = "bphelper-cli", version = "0.8.2", optional = true }
-bphelper-manifest = { path = "bphelper-manifest", version = "0.5.5" }
+bphelper-build = { path = "bphelper-build", version = "0.4.8", optional = true }
+bphelper-cli = { path = "bphelper-cli", version = "0.9.0", optional = true }
+bphelper-manifest = { path = "bphelper-manifest", version = "0.5.6" }
 anyhow.workspace = true
 
 [dev-dependencies]

--- a/src/battery-pack/bphelper-build/CHANGELOG.md
+++ b/src/battery-pack/bphelper-build/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.8](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-build-v0.4.7...bphelper-build-v0.4.8) - 2026-06-03
+
+### Fixed
+
+- render template paths and tests OS-agnostically on Windows
+
 ## [0.4.7](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-build-v0.4.6...bphelper-build-v0.4.7) - 2026-04-30
 
 ### Added

--- a/src/battery-pack/bphelper-build/CHANGELOG.md
+++ b/src/battery-pack/bphelper-build/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- *(template)* render template paths and tests OS-agnostically on Windows ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
+- *(template)* render template paths and tests OS-agnostically on Windows ([#134](https://github.com/battery-pack-rs/battery-pack/pull/134))
 
 ## [0.4.7](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-build-v0.4.6...bphelper-build-v0.4.7) - 2026-04-30
 

--- a/src/battery-pack/bphelper-build/CHANGELOG.md
+++ b/src/battery-pack/bphelper-build/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- render template paths and tests OS-agnostically on Windows
+- *(template)* render template paths and tests OS-agnostically on Windows ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
 
 ## [0.4.7](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-build-v0.4.6...bphelper-build-v0.4.7) - 2026-04-30
 

--- a/src/battery-pack/bphelper-build/Cargo.toml
+++ b/src/battery-pack/bphelper-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bphelper-build"
-version = "0.4.7"
+version = "0.4.8"
 edition = "2024"
 description = "Build-time documentation generation for battery packs"
 license = "MIT OR Apache-2.0"
@@ -8,7 +8,7 @@ repository = "https://github.com/battery-pack-rs/battery-pack"
 keywords = ["battery-pack"]
 
 [dependencies]
-bphelper-manifest = { path = "../bphelper-manifest", version = "0.5.5" }
+bphelper-manifest = { path = "../bphelper-manifest", version = "0.5.6" }
 handlebars.workspace = true
 cargo_metadata.workspace = true
 serde.workspace = true

--- a/src/battery-pack/bphelper-cli/CHANGELOG.md
+++ b/src/battery-pack/bphelper-cli/CHANGELOG.md
@@ -12,13 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - *(bphelper-cli)* resolve bp-managed active packs from `battery-pack.toml` ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
-- *(validate)* add `validate_template_with` for exercising placeholder combinations ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
+- *(test)* add `validate_template_with` for exercising placeholder combinations ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
 
 ### Fixed
 
 - *(validate)* merge patches into a template's `.cargo/config.toml` instead of overwriting ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
-- *(template)* use a trailing slash in `starts_with` to prevent false prefix matches ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
-- *(template)* render template paths and tests OS-agnostically on Windows ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
+- *(template)* use a trailing slash in `starts_with` to prevent false prefix matches ([#134](https://github.com/battery-pack-rs/battery-pack/pull/134))
+- *(template)* render template paths and tests OS-agnostically on Windows ([#134](https://github.com/battery-pack-rs/battery-pack/pull/134))
 
 ### Other
 

--- a/src/battery-pack/bphelper-cli/CHANGELOG.md
+++ b/src/battery-pack/bphelper-cli/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.8.2...bphelper-cli-v0.9.0) - 2026-06-03
+
+### Added
+
+- *(bphelper-cli)* resolve bp-managed active packs from battery-pack.toml
+- *(validate)* add validate_template_with for exercising placeholder combinations
+
+### Fixed
+
+- *(network-service)* correct clonable typo and apply rustfmt
+- *(validate)* merge patches into a template's .cargo/config.toml instead of overwriting
+- *(template)* use trailing slash in starts_with to prevent false prefix matches
+- render template paths and tests OS-agnostically on Windows
+
+### Other
+
+- Merge pull request #142 from jlizen/feat/network-service-battery-pack
+- *(battery-pack)* migrate templates to battery-pack.toml, drop unused dep
+- *(templates)* trim .rs whitespace more aggressively, rustfmt after render, rustfmt on validate
+- *(template)* add path normalization and _Cargo.toml rename coverage
+- tidy whitespace + .gitignore EOF newline
+- *(template)* Windows path bugs in template validation
+
 ## [0.8.2](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.8.1...bphelper-cli-v0.8.2) - 2026-05-17
 
 ### Added

--- a/src/battery-pack/bphelper-cli/CHANGELOG.md
+++ b/src/battery-pack/bphelper-cli/CHANGELOG.md
@@ -11,24 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- *(bphelper-cli)* resolve bp-managed active packs from battery-pack.toml
-- *(validate)* add validate_template_with for exercising placeholder combinations
+- *(bphelper-cli)* resolve bp-managed active packs from `battery-pack.toml` ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
+- *(validate)* add `validate_template_with` for exercising placeholder combinations ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
 
 ### Fixed
 
-- *(network-service)* correct clonable typo and apply rustfmt
-- *(validate)* merge patches into a template's .cargo/config.toml instead of overwriting
-- *(template)* use trailing slash in starts_with to prevent false prefix matches
-- render template paths and tests OS-agnostically on Windows
+- *(validate)* merge patches into a template's `.cargo/config.toml` instead of overwriting ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
+- *(template)* use a trailing slash in `starts_with` to prevent false prefix matches ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
+- *(template)* render template paths and tests OS-agnostically on Windows ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
 
 ### Other
 
-- Merge pull request #142 from jlizen/feat/network-service-battery-pack
-- *(battery-pack)* migrate templates to battery-pack.toml, drop unused dep
-- *(templates)* trim .rs whitespace more aggressively, rustfmt after render, rustfmt on validate
-- *(template)* add path normalization and _Cargo.toml rename coverage
-- tidy whitespace + .gitignore EOF newline
-- *(template)* Windows path bugs in template validation
+- *(battery-pack)* migrate templates to `battery-pack.toml`, drop unused dep ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
+- *(templates)* trim `.rs` whitespace, run rustfmt after render, and assert `cargo fmt --check` on validate ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
 
 ## [0.8.2](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.8.1...bphelper-cli-v0.8.2) - 2026-05-17
 

--- a/src/battery-pack/bphelper-cli/Cargo.toml
+++ b/src/battery-pack/bphelper-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bphelper-cli"
-version = "0.8.2"
+version = "0.9.0"
 edition = "2024"
 description = "CLI for creating and managing battery packs"
 license = "MIT OR Apache-2.0"
@@ -8,7 +8,7 @@ repository = "https://github.com/battery-pack-rs/battery-pack"
 keywords = ["battery-pack", "cli", "cargo"]
 
 [dependencies]
-bphelper-manifest = { path = "../bphelper-manifest", version = "0.5.5" }
+bphelper-manifest = { path = "../bphelper-manifest", version = "0.5.6" }
 cargo-bp-script.workspace = true
 clap.workspace = true
 clap_complete = { workspace = true, features = ["unstable-dynamic"] }

--- a/src/battery-pack/bphelper-manifest/CHANGELOG.md
+++ b/src/battery-pack/bphelper-manifest/CHANGELOG.md
@@ -11,12 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- *(manifest)* include non-optional base deps when features are active
+- *(manifest)* include non-optional base deps when features are active ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
 
 ### Other
 
-- *(templates)* trim .rs whitespace more aggressively, rustfmt after render, rustfmt on validate
-- *(manifest)* capture non-optional deps dropped when features active
+- *(templates)* trim `.rs` whitespace, run rustfmt after render, and assert `cargo fmt --check` on validate ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
 
 ## [0.5.5](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-manifest-v0.5.4...bphelper-manifest-v0.5.5) - 2026-04-30
 

--- a/src/battery-pack/bphelper-manifest/CHANGELOG.md
+++ b/src/battery-pack/bphelper-manifest/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.6](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-manifest-v0.5.5...bphelper-manifest-v0.5.6) - 2026-06-03
+
+### Fixed
+
+- *(manifest)* include non-optional base deps when features are active
+
+### Other
+
+- *(templates)* trim .rs whitespace more aggressively, rustfmt after render, rustfmt on validate
+- *(manifest)* capture non-optional deps dropped when features active
+
 ## [0.5.5](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-manifest-v0.5.4...bphelper-manifest-v0.5.5) - 2026-04-30
 
 ### Added

--- a/src/battery-pack/bphelper-manifest/Cargo.toml
+++ b/src/battery-pack/bphelper-manifest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bphelper-manifest"
-version = "0.5.5"
+version = "0.5.6"
 edition = "2024"
 description = "Shared battery pack manifest parsing"
 license = "MIT OR Apache-2.0"

--- a/src/cargo-bp-script/CHANGELOG.md
+++ b/src/cargo-bp-script/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-script-v0.1.0...cargo-bp-script-v0.2.0) - 2026-06-03
+
+### Added
+
+- *(cargo-bp-script)* add JSON output for `list` and `show` commands
+
+### Other
+
+- *(cargo-bp)* unify data-gathering and rendering for list/show

--- a/src/cargo-bp-script/CHANGELOG.md
+++ b/src/cargo-bp-script/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- *(cargo-bp-script)* add JSON output for `list` and `show` commands
+- *(cargo-bp-script)* add JSON output for `list` and `show` commands ([#140](https://github.com/battery-pack-rs/battery-pack/pull/140))
 
 ### Other
 
-- *(cargo-bp)* unify data-gathering and rendering for list/show
+- *(cargo-bp)* unify data-gathering and rendering for `list`/`show` ([#140](https://github.com/battery-pack-rs/battery-pack/pull/140))

--- a/src/cargo-bp-script/Cargo.toml
+++ b/src/cargo-bp-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-bp-script"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 description = "Schema and process runner for scripting `cargo bp` commands (e.g. `cargo bp status --json`)"
 license = "MIT OR Apache-2.0"

--- a/src/cargo-bp/CHANGELOG.md
+++ b/src/cargo-bp/CHANGELOG.md
@@ -12,25 +12,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - *(cargo-bp-script)* add JSON output for `list` and `show` commands
-- *(bphelper-cli)* resolve bp-managed active packs from battery-pack.toml
-- *(validate)* add validate_template_with for exercising placeholder combinations
+- *(bphelper-cli)* resolve bp-managed active packs from `battery-pack.toml` ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
+- *(validate)* add `validate_template_with` for exercising placeholder combinations ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
 
 ### Fixed
 
-- *(cargo-bp)* address PR review — conflict guard and snapbox tests
-- render template paths and tests OS-agnostically on Windows
-- *(network-service)* correct clonable typo and apply rustfmt
-- *(validate)* merge patches into a template's .cargo/config.toml instead of overwriting
-- *(template)* use trailing slash in starts_with to prevent false prefix matches
+- *(cargo-bp)* address PR review: conflict guard and snapbox tests ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
+- *(template)* render template paths and tests OS-agnostically on Windows ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
+- *(validate)* merge patches into a template's `.cargo/config.toml` instead of overwriting ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
+- *(template)* use a trailing slash in `starts_with` to prevent false prefix matches ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
 
 ### Other
 
-- Merge pull request #142 from jlizen/feat/network-service-battery-pack
-- *(battery-pack)* migrate templates to battery-pack.toml, drop unused dep
-- *(templates)* trim .rs whitespace more aggressively, rustfmt after render, rustfmt on validate
-- *(template)* add path normalization and _Cargo.toml rename coverage
-- tidy whitespace + .gitignore EOF newline
-- *(template)* Windows path bugs in template validation
+- *(battery-pack)* migrate templates to `battery-pack.toml`, drop unused dep ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
+- *(templates)* trim `.rs` whitespace, run rustfmt after render, and assert `cargo fmt --check` on validate ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
 
 ## [0.5.5](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-v0.5.4...cargo-bp-v0.5.5) - 2026-05-17
 

--- a/src/cargo-bp/CHANGELOG.md
+++ b/src/cargo-bp/CHANGELOG.md
@@ -11,16 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- *(cargo-bp-script)* add JSON output for `list` and `show` commands
+- *(cargo-bp-script)* add JSON output for `list` and `show` commands ([#140](https://github.com/battery-pack-rs/battery-pack/pull/140))
 - *(bphelper-cli)* resolve bp-managed active packs from `battery-pack.toml` ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
-- *(validate)* add `validate_template_with` for exercising placeholder combinations ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
+- *(test)* add `validate_template_with` for exercising placeholder combinations ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
 
 ### Fixed
 
-- *(cargo-bp)* address PR review: conflict guard and snapbox tests ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
-- *(template)* render template paths and tests OS-agnostically on Windows ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
+- *(cargo-bp)* address PR review: conflict guard and snapbox tests ([#140](https://github.com/battery-pack-rs/battery-pack/pull/140))
+- *(template)* render template paths and tests OS-agnostically on Windows ([#134](https://github.com/battery-pack-rs/battery-pack/pull/134))
 - *(validate)* merge patches into a template's `.cargo/config.toml` instead of overwriting ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
-- *(template)* use a trailing slash in `starts_with` to prevent false prefix matches ([#142](https://github.com/battery-pack-rs/battery-pack/pull/142))
+- *(template)* use a trailing slash in `starts_with` to prevent false prefix matches ([#134](https://github.com/battery-pack-rs/battery-pack/pull/134))
 
 ### Other
 

--- a/src/cargo-bp/CHANGELOG.md
+++ b/src/cargo-bp/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.6](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-v0.5.5...cargo-bp-v0.5.6) - 2026-06-03
+
+### Added
+
+- *(cargo-bp-script)* add JSON output for `list` and `show` commands
+- *(bphelper-cli)* resolve bp-managed active packs from battery-pack.toml
+- *(validate)* add validate_template_with for exercising placeholder combinations
+
+### Fixed
+
+- *(cargo-bp)* address PR review — conflict guard and snapbox tests
+- render template paths and tests OS-agnostically on Windows
+- *(network-service)* correct clonable typo and apply rustfmt
+- *(validate)* merge patches into a template's .cargo/config.toml instead of overwriting
+- *(template)* use trailing slash in starts_with to prevent false prefix matches
+
+### Other
+
+- Merge pull request #142 from jlizen/feat/network-service-battery-pack
+- *(battery-pack)* migrate templates to battery-pack.toml, drop unused dep
+- *(templates)* trim .rs whitespace more aggressively, rustfmt after render, rustfmt on validate
+- *(template)* add path normalization and _Cargo.toml rename coverage
+- tidy whitespace + .gitignore EOF newline
+- *(template)* Windows path bugs in template validation
+
 ## [0.5.5](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-v0.5.4...cargo-bp-v0.5.5) - 2026-05-17
 
 ### Added

--- a/src/cargo-bp/Cargo.toml
+++ b/src/cargo-bp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-bp"
-version = "0.5.5"
+version = "0.5.6"
 edition = "2024"
 description = "CLI for creating and managing battery packs (cargo bp)"
 license = "MIT OR Apache-2.0"
@@ -23,7 +23,7 @@ name = "cargo-bp"
 path = "src/main.rs"
 
 [dependencies]
-bphelper-cli = { path = "../battery-pack/bphelper-cli", version = "0.8" }
+bphelper-cli = { path = "../battery-pack/bphelper-cli", version = "0.9" }
 anyhow.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION



## 🤖 New release

* `bphelper-manifest`: 0.5.5 -> 0.5.6 (✓ API compatible changes)
* `bphelper-build`: 0.4.7 -> 0.4.8 (✓ API compatible changes)
* `cargo-bp-script`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)
* `bphelper-cli`: 0.8.2 -> 0.9.0 (⚠ API breaking changes)
* `battery-pack`: 0.5.4 -> 0.5.5 (✓ API compatible changes)
* `cargo-bp`: 0.5.5 -> 0.5.6
* `cli-battery-pack`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `ci-battery-pack`: 0.1.4 -> 0.1.5 (✓ API compatible changes)
* `error-battery-pack`: 0.6.3 -> 0.6.4 (✓ API compatible changes)
* `logging-battery-pack`: 0.5.1 -> 0.5.2 (✓ API compatible changes)
* `backend-service-battery-pack`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

### ⚠ `cargo-bp-script` breaking changes

```text
--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field command of variant Error::ExitStatus in /tmp/.tmpujSEck/battery-pack/src/cargo-bp-script/src/runner.rs:32
  field command of variant Error::Parse in /tmp/.tmpujSEck/battery-pack/src/cargo-bp-script/src/runner.rs:44
  field command of variant Error::ExitStatus in /tmp/.tmpujSEck/battery-pack/src/cargo-bp-script/src/runner.rs:32
  field command of variant Error::Parse in /tmp/.tmpujSEck/battery-pack/src/cargo-bp-script/src/runner.rs:44
```

### ⚠ `bphelper-cli` breaking changes

```text
--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/function_parameter_count_changed.ron

Failed in:
  bphelper_cli::resolve_bp_managed_content now takes 3 parameters instead of 2, in /tmp/.tmpujSEck/battery-pack/src/battery-pack/bphelper-cli/src/registry/mod.rs:301
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `bphelper-manifest`

<blockquote>

## [0.5.6](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-manifest-v0.5.5...bphelper-manifest-v0.5.6) - 2026-06-03

### Fixed

- *(manifest)* include non-optional base deps when features are active

### Other

- *(templates)* trim .rs whitespace more aggressively, rustfmt after render, rustfmt on validate
- *(manifest)* capture non-optional deps dropped when features active
</blockquote>

## `bphelper-build`

<blockquote>

## [0.4.8](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-build-v0.4.7...bphelper-build-v0.4.8) - 2026-06-03

### Fixed

- render template paths and tests OS-agnostically on Windows
</blockquote>

## `cargo-bp-script`

<blockquote>

## [0.2.0](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-script-v0.1.0...cargo-bp-script-v0.2.0) - 2026-06-03

### Added

- *(cargo-bp-script)* add JSON output for `list` and `show` commands

### Other

- *(cargo-bp)* unify data-gathering and rendering for list/show
</blockquote>

## `bphelper-cli`

<blockquote>

## [0.9.0](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.8.2...bphelper-cli-v0.9.0) - 2026-06-03

### Added

- *(bphelper-cli)* resolve bp-managed active packs from battery-pack.toml
- *(validate)* add validate_template_with for exercising placeholder combinations

### Fixed

- *(network-service)* correct clonable typo and apply rustfmt
- *(validate)* merge patches into a template's .cargo/config.toml instead of overwriting
- *(template)* use trailing slash in starts_with to prevent false prefix matches
- render template paths and tests OS-agnostically on Windows

### Other

- Merge pull request #142 from jlizen/feat/network-service-battery-pack
- *(battery-pack)* migrate templates to battery-pack.toml, drop unused dep
- *(templates)* trim .rs whitespace more aggressively, rustfmt after render, rustfmt on validate
- *(template)* add path normalization and _Cargo.toml rename coverage
- tidy whitespace + .gitignore EOF newline
- *(template)* Windows path bugs in template validation
</blockquote>

## `battery-pack`

<blockquote>

## [0.5.5](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.5.4...battery-pack-v0.5.5) - 2026-06-03

### Added

- *(bphelper-cli)* resolve bp-managed active packs from battery-pack.toml
- *(validate)* add validate_template_with for exercising placeholder combinations
- *(cargo-bp-script)* add JSON output for `list` and `show` commands
- *(ci-battery-pack)* add optional cross-platform testing job

### Fixed

- *(with_template)* migrate default_template snapshot to battery-pack.toml
- *(network-service)* correct clonable typo and apply rustfmt
- render template paths and tests OS-agnostically on Windows
- *(validate)* merge patches into a template's .cargo/config.toml instead of overwriting
- *(template)* use trailing slash in starts_with to prevent false prefix matches
- *(manifest)* include non-optional base deps when features are active
- *(cargo-bp)* address PR review — conflict guard and snapbox tests
- *(ci-battery-pack)* make snapshot tests cross-platform for .exe
- *(cli-battery-pack)* add [EXE] to help snapshots for Windows compat

### Other

- Merge pull request #142 from jlizen/feat/network-service-battery-pack
- *(battery-pack)* migrate templates to battery-pack.toml, drop unused dep
- *(templates)* trim .rs whitespace more aggressively, rustfmt after render, rustfmt on validate
- rename network-service-battery-pack to backend-service-battery-pack
- *(template)* add path normalization and _Cargo.toml rename coverage
- tidy whitespace + .gitignore EOF newline
- *(template)* Windows path bugs in template validation
- *(manifest)* capture non-optional deps dropped when features active
- *(cargo-bp)* unify data-gathering and rendering for list/show
- Merge pull request #128 from jlizen/feat/ci-bp-skill
</blockquote>

## `cargo-bp`

<blockquote>

## [0.5.6](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-v0.5.5...cargo-bp-v0.5.6) - 2026-06-03

### Added

- *(cargo-bp-script)* add JSON output for `list` and `show` commands
- *(bphelper-cli)* resolve bp-managed active packs from battery-pack.toml
- *(validate)* add validate_template_with for exercising placeholder combinations

### Fixed

- *(cargo-bp)* address PR review — conflict guard and snapbox tests
- render template paths and tests OS-agnostically on Windows
- *(network-service)* correct clonable typo and apply rustfmt
- *(validate)* merge patches into a template's .cargo/config.toml instead of overwriting
- *(template)* use trailing slash in starts_with to prevent false prefix matches

### Other

- Merge pull request #142 from jlizen/feat/network-service-battery-pack
- *(battery-pack)* migrate templates to battery-pack.toml, drop unused dep
- *(templates)* trim .rs whitespace more aggressively, rustfmt after render, rustfmt on validate
- *(template)* add path normalization and _Cargo.toml rename coverage
- tidy whitespace + .gitignore EOF newline
- *(template)* Windows path bugs in template validation
</blockquote>

## `cli-battery-pack`

<blockquote>

## [0.6.2](https://github.com/battery-pack-rs/battery-pack/compare/cli-battery-pack-v0.6.1...cli-battery-pack-v0.6.2) - 2026-06-03

### Fixed

- *(cli-battery-pack)* add [EXE] to help snapshots for Windows compat

### Other

- *(battery-pack)* migrate templates to battery-pack.toml, drop unused dep
</blockquote>

## `ci-battery-pack`

<blockquote>

## [0.1.5](https://github.com/battery-pack-rs/battery-pack/compare/ci-battery-pack-v0.1.4...ci-battery-pack-v0.1.5) - 2026-06-03

### Added

- *(ci-battery-pack)* add optional cross-platform testing job

### Fixed

- *(ci-battery-pack)* make snapshot tests cross-platform for .exe

### Other

- *(battery-pack)* migrate templates to battery-pack.toml, drop unused dep
- *(templates)* trim .rs whitespace more aggressively, rustfmt after render, rustfmt on validate
- Merge pull request #128 from jlizen/feat/ci-bp-skill
</blockquote>

## `error-battery-pack`

<blockquote>

## [0.6.4](https://github.com/battery-pack-rs/battery-pack/compare/error-battery-pack-v0.6.3...error-battery-pack-v0.6.4) - 2026-06-03

### Other

- *(battery-pack)* migrate templates to battery-pack.toml, drop unused dep
</blockquote>

## `logging-battery-pack`

<blockquote>

## [0.5.2](https://github.com/battery-pack-rs/battery-pack/compare/logging-battery-pack-v0.5.1...logging-battery-pack-v0.5.2) - 2026-06-03

### Other

- *(battery-pack)* migrate templates to battery-pack.toml, drop unused dep
</blockquote>

## `backend-service-battery-pack`

<blockquote>

## [0.1.1](https://github.com/battery-pack-rs/battery-pack/compare/backend-service-battery-pack-v0.1.0...backend-service-battery-pack-v0.1.1) - 2026-06-03

### Other

- rename network-service-battery-pack to backend-service-battery-pack
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).