### PR TITLE
fix(ci-battery-pack): make snapshot tests cross-platform for .exe

### DIFF
--- a/battery-packs/ci-battery-pack/src/lib.rs
+++ b/battery-packs/ci-battery-pack/src/lib.rs
@@ -3,7 +3,19 @@
 #[cfg(test)]
 mod tests {
     use ::battery_pack::testing::PreviewBuilder;
-    use snapbox::{assert_data_eq, file};
+    use snapbox::{Assert, Redactions, file};
+
+    /// Custom assert that unconditionally maps `[EXE]` to `.exe` so snapshots
+    /// containing literal `.exe` (e.g. in GitHub Actions workflow templates)
+    /// pass on all platforms.
+    fn assert_snapshot(actual: impl snapbox::IntoData, expected: impl snapbox::IntoData) {
+        let mut redactions = Redactions::new();
+        redactions.insert("[EXE]", ".exe").unwrap();
+        Assert::new()
+            .action_env("SNAPSHOTS")
+            .redact_with(redactions)
+            .eq(actual, expected);
+    }
 
     #[test]
     fn validate() {
@@ -56,94 +68,94 @@ mod tests {
 
     #[test]
     fn snapshot_minimalist() {
-        assert_data_eq!(snapshot("full", &[]), file!["snapshots/minimalist.txt"]);
+        assert_snapshot(snapshot("full", &[]), file!["snapshots/minimalist.txt"]);
     }
 
     #[test]
     fn snapshot_maximalist() {
-        assert_data_eq!(
+        assert_snapshot(
             snapshot("full", &[("all", "true")]),
-            file!["snapshots/maximalist.txt"]
+            file!["snapshots/maximalist.txt"],
         );
     }
 
     #[test]
     fn snapshot_standalone_benchmarks() {
-        assert_data_eq!(
+        assert_snapshot(
             snapshot("benchmarks", &[]),
-            file!["snapshots/standalone_benchmarks.txt"]
+            file!["snapshots/standalone_benchmarks.txt"],
         );
     }
 
     #[test]
     fn snapshot_standalone_fuzzing() {
-        assert_data_eq!(
+        assert_snapshot(
             snapshot("fuzzing", &[]),
-            file!["snapshots/standalone_fuzzing.txt"]
+            file!["snapshots/standalone_fuzzing.txt"],
         );
     }
 
     #[test]
     fn snapshot_standalone_stress_test() {
-        assert_data_eq!(
+        assert_snapshot(
             snapshot("stress-test", &[]),
-            file!["snapshots/standalone_stress_test.txt"]
+            file!["snapshots/standalone_stress_test.txt"],
         );
     }
 
     #[test]
     fn snapshot_standalone_mdbook() {
-        assert_data_eq!(
+        assert_snapshot(
             snapshot("mdbook", &[]),
-            file!["snapshots/standalone_mdbook.txt"]
+            file!["snapshots/standalone_mdbook.txt"],
         );
     }
 
     #[test]
     fn snapshot_standalone_spellcheck() {
-        assert_data_eq!(
+        assert_snapshot(
             snapshot("spellcheck", &[]),
-            file!["snapshots/standalone_spellcheck.txt"]
+            file!["snapshots/standalone_spellcheck.txt"],
         );
     }
 
     #[test]
     fn snapshot_standalone_xtask() {
-        assert_data_eq!(
+        assert_snapshot(
             snapshot("xtask", &[]),
-            file!["snapshots/standalone_xtask.txt"]
+            file!["snapshots/standalone_xtask.txt"],
         );
     }
 
     #[test]
     fn snapshot_standalone_binary_release() {
-        assert_data_eq!(
+        assert_snapshot(
             snapshot("binary-release", &[]),
-            file!["snapshots/standalone_binary_release.txt"]
+            file!["snapshots/standalone_binary_release.txt"],
         );
     }
 
     #[test]
     fn snapshot_standalone_trusted_publishing() {
-        assert_data_eq!(
+        assert_snapshot(
             snapshot("trusted-publishing", &[]),
-            file!["snapshots/standalone_trusted_publishing.txt"]
+            file!["snapshots/standalone_trusted_publishing.txt"],
         );
     }
 
     #[test]
     fn snapshot_standalone_mutation_testing() {
-        assert_data_eq!(
+        assert_snapshot(
             snapshot("mutation-testing", &[]),
-            file!["snapshots/standalone_mutation_testing.txt"]
+            file!["snapshots/standalone_mutation_testing.txt"],
         );
     }
 
     #[test]
     fn snapshot_standalone_clippy_sarif() {
-        assert_data_eq!(
+        assert_snapshot(
             snapshot("clippy-sarif", &[]),
-            file!["snapshots/standalone_clippy_sarif.txt"]
+            file!["snapshots/standalone_clippy_sarif.txt"],
         );
     }
 }

--- a/battery-packs/ci-battery-pack/src/snapshots/maximalist.txt
+++ b/battery-packs/ci-battery-pack/src/snapshots/maximalist.txt
@@ -165,7 +165,7 @@ jobs:
         shell: pwsh
         run: |
           cd target/${{ matrix.target }}/release
-          Compress-Archive -Path test-project.exe -DestinationPath ../../../test-project-${{ matrix.target }}-${{ steps.version.outputs.version }}.zip
+          Compress-Archive -Path test-project[EXE] -DestinationPath ../../../test-project-${{ matrix.target }}-${{ steps.version.outputs.version }}.zip
 
       - name: Upload release asset
         uses: softprops/action-gh-release@[..] # v[..]

--- a/battery-packs/ci-battery-pack/src/snapshots/standalone_binary_release.txt
+++ b/battery-packs/ci-battery-pack/src/snapshots/standalone_binary_release.txt
@@ -70,7 +70,7 @@ jobs:
         shell: pwsh
         run: |
           cd target/${{ matrix.target }}/release
-          Compress-Archive -Path test-project.exe -DestinationPath ../../../test-project-${{ matrix.target }}-${{ steps.version.outputs.version }}.zip
+          Compress-Archive -Path test-project[EXE] -DestinationPath ../../../test-project-${{ matrix.target }}-${{ steps.version.outputs.version }}.zip
 
       - name: Upload release asset
         uses: softprops/action-gh-release@[..] # v[..]

--- a/battery-packs/cli-battery-pack/templates/simple/tests/snapshots/cli__help.txt
+++ b/battery-packs/cli-battery-pack/templates/simple/tests/snapshots/cli__help.txt
@@ -1,6 +1,6 @@
 A CLI application
 
-[1m[4mUsage:[0m [1m{{ project_name }}[0m [OPTIONS]
+[1m[4mUsage:[0m [1m{{ project_name }}[EXE][0m [OPTIONS]
 
 [1m[4mOptions:[0m
   [1m-n[0m, [1m--name[0m <NAME>   Name to greet [default: World]

--- a/battery-packs/cli-battery-pack/templates/subcmds/tests/snapshots/cli__help.txt
+++ b/battery-packs/cli-battery-pack/templates/subcmds/tests/snapshots/cli__help.txt
@@ -1,6 +1,6 @@
 A CLI application with subcommands
 
-[1m[4mUsage:[0m [1m{{ project_name }}[0m [OPTIONS] <COMMAND>
+[1m[4mUsage:[0m [1m{{ project_name }}[EXE][0m [OPTIONS] <COMMAND>
 
 [1m[4mCommands:[0m
   [1mhello[0m    Say hello


### PR DESCRIPTION
Quickie - #134 added proper CI tests for windows. But, snapbox has an inbuilt behavior to redact `.exe` suffixes on windows, that doesn't apply on other platforms (weird choice).

Changing it to unconditionally apply the redaction to avoid mismatch between linux vs windows snaps.

The actual user-facing functionality was fine all along.