### PR TITLE
feat(cargo-bp-script): add JSON output for `list` and `show` commands

### DIFF
--- a/src/battery-pack/bphelper-cli/src/commands/mod.rs
+++ b/src/battery-pack/bphelper-cli/src/commands/mod.rs
@@ -181,7 +181,7 @@ pub(crate) enum BpCommands {
         define: Vec<(String, String)>,
 
         /// Emit machine-readable JSON instead of the default text output
-        #[arg(long)]
+        #[arg(long, conflicts_with_all = ["template", "define"])]
         json: bool,
     },
 

--- a/src/battery-pack/bphelper-cli/src/commands/mod.rs
+++ b/src/battery-pack/bphelper-cli/src/commands/mod.rs
@@ -6,7 +6,7 @@
 use anyhow::{Context, Result, bail};
 use clap::{CommandFactory, Parser, Subcommand};
 use std::collections::{BTreeMap, BTreeSet};
-use std::io::{IsTerminal, Write};
+use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 
 use crate::manifest::{
@@ -312,14 +312,10 @@ pub fn main() -> Result<()> {
                     // [impl cli.list.interactive]
                     // [impl cli.list.non-interactive]
                     // [impl cli.list.json]
-                    if json {
-                        list_battery_packs_json(&source, filter.as_deref())
-                    } else if interactive {
-                        crate::tui::run_list(source, filter)
+                    if json || !interactive {
+                        list_battery_packs(&source, filter.as_deref(), json)
                     } else {
-                        // [impl cli.list.query]
-                        // [impl cli.list.filter]
-                        print_battery_pack_list(&source, filter.as_deref())
+                        crate::tui::run_list(source, filter)
                     }
                 }
                 BpCommands::Show {
@@ -330,8 +326,15 @@ pub fn main() -> Result<()> {
                     json,
                 } => {
                     // [impl cli.show.json]
-                    if json {
-                        show_battery_pack_json(&battery_pack, path.as_deref(), &source)
+                    // [impl cli.show.non-interactive]
+                    if json || (!interactive && template.is_none()) {
+                        show_battery_pack(
+                            &battery_pack,
+                            path.as_deref(),
+                            &source,
+                            &project_dir,
+                            json,
+                        )
                     } else {
                         let show_opts = crate::tui::ShowOpts {
                             battery_pack: &battery_pack,
@@ -344,23 +347,15 @@ pub fn main() -> Result<()> {
                             // [impl cli.show.interactive]
                             // [impl cli.show.template-preview]
                             crate::tui::run_show(show_opts)
-                        } else if let Some(tmpl) = show_opts.template {
+                        } else {
                             // [impl cli.show.template-preview]
                             print_template_preview(&crate::template_engine::PreviewOpts {
                                 battery_pack: show_opts.battery_pack,
-                                template: tmpl,
+                                template: show_opts.template.unwrap(),
                                 path: show_opts.path,
                                 source: &show_opts.source,
                                 defines: show_opts.defines,
                             })
-                        } else {
-                            // [impl cli.show.non-interactive]
-                            print_battery_pack_detail(
-                                show_opts.battery_pack,
-                                show_opts.path,
-                                &show_opts.source,
-                                &project_dir,
-                            )
                         }
                     }
                 }
@@ -1667,69 +1662,27 @@ fn prompt_for_template(
     Ok(config.path.clone())
 }
 
-fn print_battery_pack_list(source: &CrateSource, filter: Option<&str>) -> Result<()> {
-    use console::style;
-
-    let battery_packs = fetch_battery_pack_list(source, filter)?;
-
-    if battery_packs.is_empty() {
-        match filter {
-            Some(q) => println!("No battery packs found matching '{}'", q),
-            None => println!("No battery packs found"),
-        }
-        return Ok(());
-    }
-
-    // Find the longest name for alignment
-    let max_name_len = battery_packs
-        .iter()
-        .map(|c| c.short_name.len())
-        .max()
-        .unwrap_or(0);
-
-    let max_version_len = battery_packs
-        .iter()
-        .map(|c| c.version.len())
-        .max()
-        .unwrap_or(0);
-
-    println!();
-    for bp in &battery_packs {
-        let desc = bp.description.lines().next().unwrap_or("");
-
-        // Pad strings manually, then apply colors (ANSI codes break width formatting)
-        let name_padded = format!("{:<width$}", bp.short_name, width = max_name_len);
-        let ver_padded = format!("{:<width$}", bp.version, width = max_version_len);
-
-        println!(
-            "  {}  {}  {}",
-            style(name_padded).green().bold(),
-            style(ver_padded).dim(),
-            desc,
-        );
-    }
-    println!();
-
-    println!(
-        "{}",
-        style(format!("Found {} battery pack(s)", battery_packs.len())).dim()
-    );
-
-    Ok(())
-}
-
 // ============================================================================
-// List --json
+// List command
 // ============================================================================
+//
+// Like `status`, the list command is split into:
+//   1. `build_list_report`  — pure data, returns a `ListReport`.
+//   2. `render_list_json`   — serializes the report.
+//   3. `render_list_text`   — pretty-prints the report.
+// `list_battery_packs` is a thin dispatcher that picks one renderer.
 
-/// Build a [`cargo_bp_script::ListReport`] and emit it as JSON.
 // [impl cli.list.json]
-fn list_battery_packs_json(source: &CrateSource, filter: Option<&str>) -> Result<()> {
+// [impl cli.list.non-interactive]
+fn list_battery_packs(source: &CrateSource, filter: Option<&str>, json: bool) -> Result<()> {
     let report = build_list_report(source, filter)?;
     let stdout = std::io::stdout();
     let mut out = stdout.lock();
-    serde_json::to_writer(&mut out, &report).context("Failed to write list JSON")?;
-    writeln!(out)?;
+    if json {
+        render_list_json(&report, &mut out).context("Failed to write list JSON")?;
+    } else {
+        render_list_text(&report, &mut out).context("Failed to render list")?;
+    }
     Ok(())
 }
 
@@ -1751,18 +1704,100 @@ fn build_list_report(
     Ok(report)
 }
 
-// ============================================================================
-// Show --json
-// ============================================================================
+/// Serialize a [`ListReport`] as JSON to `w`, with a trailing newline.
+fn render_list_json(
+    report: &cargo_bp_script::ListReport,
+    w: &mut impl std::io::Write,
+) -> std::io::Result<()> {
+    serde_json::to_writer(&mut *w, report)?;
+    writeln!(w)?;
+    Ok(())
+}
 
-/// Build a [`cargo_bp_script::ShowReport`] and emit it as JSON.
+/// Pretty-print a [`ListReport`] for human consumption to `w`.
+fn render_list_text(
+    report: &cargo_bp_script::ListReport,
+    w: &mut impl std::io::Write,
+) -> std::io::Result<()> {
+    use console::style;
+
+    if report.packs.is_empty() {
+        match &report.filter {
+            Some(q) => writeln!(w, "No battery packs found matching '{}'", q)?,
+            None => writeln!(w, "No battery packs found")?,
+        }
+        return Ok(());
+    }
+
+    // Find the longest name for alignment
+    let max_name_len = report
+        .packs
+        .iter()
+        .map(|p| p.short_name.len())
+        .max()
+        .unwrap_or(0);
+
+    let max_version_len = report
+        .packs
+        .iter()
+        .map(|p| p.version.len())
+        .max()
+        .unwrap_or(0);
+
+    writeln!(w)?;
+    for pack in &report.packs {
+        let desc = pack.description.lines().next().unwrap_or("");
+
+        // Pad strings manually, then apply colors (ANSI codes break width formatting)
+        let name_padded = format!("{:<width$}", pack.short_name, width = max_name_len);
+        let ver_padded = format!("{:<width$}", pack.version, width = max_version_len);
+
+        writeln!(
+            w,
+            "  {}  {}  {}",
+            style(name_padded).green().bold(),
+            style(ver_padded).dim(),
+            desc,
+        )?;
+    }
+    writeln!(w)?;
+
+    writeln!(
+        w,
+        "{}",
+        style(format!("Found {} battery pack(s)", report.packs.len())).dim()
+    )?;
+
+    Ok(())
+}
+
+// ============================================================================
+// Show command
+// ============================================================================
+//
+// Like `status`, the show command is split into:
+//   1. `build_show_report`  — pure data, returns a `ShowReport`.
+//   2. `render_show_json`   — serializes the report.
+//   3. `render_show_text`   — pretty-prints the report.
+// `show_battery_pack` is a thin dispatcher that picks one renderer.
+
 // [impl cli.show.json]
-fn show_battery_pack_json(name: &str, path: Option<&str>, source: &CrateSource) -> Result<()> {
-    let report = build_show_report(name, path, source)?;
+// [impl cli.show.non-interactive]
+fn show_battery_pack(
+    name: &str,
+    path: Option<&str>,
+    source: &CrateSource,
+    project_dir: &Path,
+    json: bool,
+) -> Result<()> {
+    let report = build_show_report(name, path, source, project_dir)?;
     let stdout = std::io::stdout();
     let mut out = stdout.lock();
-    serde_json::to_writer(&mut out, &report).context("Failed to write show JSON")?;
-    writeln!(out)?;
+    if json {
+        render_show_json(&report, &mut out).context("Failed to write show JSON")?;
+    } else {
+        render_show_text(&report, &mut out).context("Failed to render show")?;
+    }
     Ok(())
 }
 
@@ -1771,6 +1806,7 @@ fn build_show_report(
     name: &str,
     path: Option<&str>,
     source: &CrateSource,
+    project_dir: &Path,
 ) -> Result<cargo_bp_script::ShowReport> {
     // --path takes precedence over --crate-source
     let detail = if path.is_some() {
@@ -1827,6 +1863,16 @@ fn build_show_report(
         info
     }));
 
+    // Installed state from the current project (if available)
+    let crate_name = resolve_crate_name(name);
+    let (managed_deps, active_features) = read_installed_state(project_dir, &crate_name);
+    if !managed_deps.is_empty() {
+        report = report.with_installed_crates(managed_deps);
+    }
+    if !active_features.is_empty() {
+        report = report.with_active_features(active_features);
+    }
+
     Ok(report)
 }
 
@@ -1849,138 +1895,138 @@ fn read_installed_state(
     (managed, features)
 }
 
-fn print_battery_pack_detail(
-    name: &str,
-    path: Option<&str>,
-    source: &CrateSource,
-    project_dir: &Path,
-) -> Result<()> {
+/// Serialize a [`ShowReport`] as JSON to `w`, with a trailing newline.
+fn render_show_json(
+    report: &cargo_bp_script::ShowReport,
+    w: &mut impl std::io::Write,
+) -> std::io::Result<()> {
+    serde_json::to_writer(&mut *w, report)?;
+    writeln!(w)?;
+    Ok(())
+}
+
+/// Pretty-print a [`ShowReport`] for human consumption to `w`.
+fn render_show_text(
+    report: &cargo_bp_script::ShowReport,
+    w: &mut impl std::io::Write,
+) -> std::io::Result<()> {
     use console::style;
 
-    // --path takes precedence over --crate-source
-    let detail = if path.is_some() {
-        fetch_battery_pack_detail(name, path)?
-    } else {
-        fetch_battery_pack_detail_from_source(source, name)?
-    };
-
-    // Read installed state from the project (if available)
-    let crate_name = resolve_crate_name(name);
-    let (managed_deps, active_features) = read_installed_state(project_dir, &crate_name);
-
     // Header
-    println!();
-    println!(
+    writeln!(w)?;
+    writeln!(
+        w,
         "{} {}",
-        style(&detail.name).green().bold(),
-        style(&detail.version).dim()
-    );
-    if !detail.description.is_empty() {
-        println!("{}", detail.description);
+        style(&report.name).green().bold(),
+        style(&report.version).dim()
+    )?;
+    if !report.description.is_empty() {
+        writeln!(w, "{}", report.description)?;
     }
 
     // Authors
-    if !detail.owners.is_empty() {
-        println!();
-        println!("{}", style("Authors:").bold());
-        for owner in &detail.owners {
+    if !report.owners.is_empty() {
+        writeln!(w)?;
+        writeln!(w, "{}", style("Authors:").bold())?;
+        for owner in &report.owners {
             if let Some(name) = &owner.name {
-                println!("  {} ({})", name, owner.login);
+                writeln!(w, "  {} ({})", name, owner.login)?;
             } else {
-                println!("  {}", owner.login);
+                writeln!(w, "  {}", owner.login)?;
             }
         }
     }
 
     // Crates
-    if !detail.crates.is_empty() {
-        println!();
-        println!("{}", style("Crates:").bold());
-        for dep in &detail.crates {
-            let marker = if managed_deps.contains(dep) {
+    if !report.crates.is_empty() {
+        writeln!(w)?;
+        writeln!(w, "{}", style("Crates:").bold())?;
+        for dep in &report.crates {
+            let marker = if report.installed_crates.contains(dep) {
                 format!(" {}", style("✓").green())
             } else {
                 String::new()
             };
-            println!("  {}{}", dep, marker);
+            writeln!(w, "  {}{}", dep, marker)?;
         }
     }
 
     // Features
-    if !detail.features.is_empty() {
-        println!();
-        println!("{}", style("Features:").bold());
-        for (feat_name, members) in &detail.features {
-            let marker = if active_features.contains(feat_name) {
+    if !report.features.is_empty() {
+        writeln!(w)?;
+        writeln!(w, "{}", style("Features:").bold())?;
+        for feat in &report.features {
+            let marker = if report.active_features.contains(&feat.name) {
                 format!(" {}", style("✓").green())
             } else {
                 String::new()
             };
-            println!(
+            writeln!(
+                w,
                 "  {} → {}{}",
-                style(feat_name).cyan(),
-                members.join(", "),
+                style(&feat.name).cyan(),
+                feat.crates.join(", "),
                 marker
-            );
+            )?;
         }
     }
 
     // Extends
-    if !detail.extends.is_empty() {
-        println!();
-        println!("{}", style("Extends:").bold());
-        for dep in &detail.extends {
-            println!("  {}", dep);
+    if !report.extends.is_empty() {
+        writeln!(w)?;
+        writeln!(w, "{}", style("Extends:").bold())?;
+        for dep in &report.extends {
+            writeln!(w, "  {}", dep)?;
         }
     }
 
     // Templates
-    if !detail.templates.is_empty() {
-        println!();
-        println!("{}", style("Templates:").bold());
-        let max_name_len = detail
+    if !report.templates.is_empty() {
+        writeln!(w)?;
+        writeln!(w, "{}", style("Templates:").bold())?;
+        let max_name_len = report
             .templates
             .iter()
             .map(|t| t.name.len())
             .max()
             .unwrap_or(0);
-        for tmpl in &detail.templates {
+        for tmpl in &report.templates {
             let name_padded = format!("{:<width$}", tmpl.name, width = max_name_len);
             if let Some(desc) = &tmpl.description {
-                println!("  {}  {}", style(name_padded).cyan(), desc);
+                writeln!(w, "  {}  {}", style(name_padded).cyan(), desc)?;
             } else {
-                println!("  {}", style(name_padded).cyan());
+                writeln!(w, "  {}", style(name_padded).cyan())?;
             }
         }
     }
 
     // [impl format.examples.browsable]
     // Examples
-    if !detail.examples.is_empty() {
-        println!();
-        println!("{}", style("Examples:").bold());
-        let max_name_len = detail
+    if !report.examples.is_empty() {
+        writeln!(w)?;
+        writeln!(w, "{}", style("Examples:").bold())?;
+        let max_name_len = report
             .examples
             .iter()
             .map(|e| e.name.len())
             .max()
             .unwrap_or(0);
-        for example in &detail.examples {
+        for example in &report.examples {
             let name_padded = format!("{:<width$}", example.name, width = max_name_len);
             if let Some(desc) = &example.description {
-                println!("  {}  {}", style(name_padded).magenta(), desc);
+                writeln!(w, "  {}  {}", style(name_padded).magenta(), desc)?;
             } else {
-                println!("  {}", style(name_padded).magenta());
+                writeln!(w, "  {}", style(name_padded).magenta())?;
             }
         }
     }
 
     // Install hints
-    println!();
-    println!("{}", style("Install:").bold());
-    println!("  cargo bp add {}", detail.short_name);
-    println!("  cargo bp new {}", detail.short_name);
-    println!();
+    writeln!(w)?;
+    writeln!(w, "{}", style("Install:").bold())?;
+    writeln!(w, "  cargo bp add {}", report.short_name)?;
+    writeln!(w, "  cargo bp new {}", report.short_name)?;
+    writeln!(w)?;
 
     Ok(())
 }

--- a/src/battery-pack/bphelper-cli/src/commands/mod.rs
+++ b/src/battery-pack/bphelper-cli/src/commands/mod.rs
@@ -6,7 +6,7 @@
 use anyhow::{Context, Result, bail};
 use clap::{CommandFactory, Parser, Subcommand};
 use std::collections::{BTreeMap, BTreeSet};
-use std::io::IsTerminal;
+use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
 
 use crate::manifest::{
@@ -154,6 +154,10 @@ pub(crate) enum BpCommands {
     List {
         /// Filter by name (omit to list all battery packs)
         filter: Option<String>,
+
+        /// Emit machine-readable JSON instead of the default text output
+        #[arg(long)]
+        json: bool,
     },
 
     /// Show detailed information about a battery pack
@@ -175,6 +179,10 @@ pub(crate) enum BpCommands {
         /// Set a template placeholder value (e.g., -d description="My project")
         #[arg(long = "define", short = 'd', value_parser = parse_define)]
         define: Vec<(String, String)>,
+
+        /// Emit machine-readable JSON instead of the default text output
+        #[arg(long)]
+        json: bool,
     },
 
     /// Show status of installed battery packs and version warnings
@@ -300,10 +308,13 @@ pub fn main() -> Result<()> {
                     interactive,
                     &project_dir,
                 ),
-                BpCommands::List { filter } => {
+                BpCommands::List { filter, json } => {
                     // [impl cli.list.interactive]
                     // [impl cli.list.non-interactive]
-                    if interactive {
+                    // [impl cli.list.json]
+                    if json {
+                        list_battery_packs_json(&source, filter.as_deref())
+                    } else if interactive {
                         crate::tui::run_list(source, filter)
                     } else {
                         // [impl cli.list.query]
@@ -316,35 +327,41 @@ pub fn main() -> Result<()> {
                     template,
                     path,
                     define,
+                    json,
                 } => {
-                    let show_opts = crate::tui::ShowOpts {
-                        battery_pack: &battery_pack,
-                        template: template.as_deref(),
-                        path: path.as_deref(),
-                        source,
-                        defines: define.into_iter().collect(),
-                    };
-                    if interactive {
-                        // [impl cli.show.interactive]
-                        // [impl cli.show.template-preview]
-                        crate::tui::run_show(show_opts)
-                    } else if let Some(tmpl) = show_opts.template {
-                        // [impl cli.show.template-preview]
-                        print_template_preview(&crate::template_engine::PreviewOpts {
-                            battery_pack: show_opts.battery_pack,
-                            template: tmpl,
-                            path: show_opts.path,
-                            source: &show_opts.source,
-                            defines: show_opts.defines,
-                        })
+                    // [impl cli.show.json]
+                    if json {
+                        show_battery_pack_json(&battery_pack, path.as_deref(), &source)
                     } else {
-                        // [impl cli.show.non-interactive]
-                        print_battery_pack_detail(
-                            show_opts.battery_pack,
-                            show_opts.path,
-                            &show_opts.source,
-                            &project_dir,
-                        )
+                        let show_opts = crate::tui::ShowOpts {
+                            battery_pack: &battery_pack,
+                            template: template.as_deref(),
+                            path: path.as_deref(),
+                            source,
+                            defines: define.into_iter().collect(),
+                        };
+                        if interactive {
+                            // [impl cli.show.interactive]
+                            // [impl cli.show.template-preview]
+                            crate::tui::run_show(show_opts)
+                        } else if let Some(tmpl) = show_opts.template {
+                            // [impl cli.show.template-preview]
+                            print_template_preview(&crate::template_engine::PreviewOpts {
+                                battery_pack: show_opts.battery_pack,
+                                template: tmpl,
+                                path: show_opts.path,
+                                source: &show_opts.source,
+                                defines: show_opts.defines,
+                            })
+                        } else {
+                            // [impl cli.show.non-interactive]
+                            print_battery_pack_detail(
+                                show_opts.battery_pack,
+                                show_opts.path,
+                                &show_opts.source,
+                                &project_dir,
+                            )
+                        }
                     }
                 }
                 BpCommands::Status { path, json } => {
@@ -1699,6 +1716,118 @@ fn print_battery_pack_list(source: &CrateSource, filter: Option<&str>) -> Result
     );
 
     Ok(())
+}
+
+// ============================================================================
+// List --json
+// ============================================================================
+
+/// Build a [`cargo_bp_script::ListReport`] and emit it as JSON.
+// [impl cli.list.json]
+fn list_battery_packs_json(source: &CrateSource, filter: Option<&str>) -> Result<()> {
+    let report = build_list_report(source, filter)?;
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    serde_json::to_writer(&mut out, &report).context("Failed to write list JSON")?;
+    writeln!(out)?;
+    Ok(())
+}
+
+/// Build a [`cargo_bp_script::ListReport`] from the registry. Pure data.
+fn build_list_report(
+    source: &CrateSource,
+    filter: Option<&str>,
+) -> Result<cargo_bp_script::ListReport> {
+    let battery_packs = fetch_battery_pack_list(source, filter)?;
+
+    let mut report = cargo_bp_script::ListReport::new();
+    if let Some(f) = filter {
+        report = report.with_filter(f);
+    }
+    report = report.with_packs(battery_packs.iter().map(|bp| {
+        cargo_bp_script::PackSummary::new(&bp.short_name, &bp.name, &bp.version)
+            .with_description(&bp.description)
+    }));
+    Ok(report)
+}
+
+// ============================================================================
+// Show --json
+// ============================================================================
+
+/// Build a [`cargo_bp_script::ShowReport`] and emit it as JSON.
+// [impl cli.show.json]
+fn show_battery_pack_json(name: &str, path: Option<&str>, source: &CrateSource) -> Result<()> {
+    let report = build_show_report(name, path, source)?;
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    serde_json::to_writer(&mut out, &report).context("Failed to write show JSON")?;
+    writeln!(out)?;
+    Ok(())
+}
+
+/// Build a [`cargo_bp_script::ShowReport`] from the registry. Pure data.
+fn build_show_report(
+    name: &str,
+    path: Option<&str>,
+    source: &CrateSource,
+) -> Result<cargo_bp_script::ShowReport> {
+    // --path takes precedence over --crate-source
+    let detail = if path.is_some() {
+        fetch_battery_pack_detail(name, path)?
+    } else {
+        fetch_battery_pack_detail_from_source(source, name)?
+    };
+
+    let mut report =
+        cargo_bp_script::ShowReport::new(&detail.short_name, &detail.name, &detail.version)
+            .with_description(&detail.description);
+
+    if let Some(repo) = &detail.repository {
+        report = report.with_repository(repo);
+    }
+
+    // Owners
+    report = report.with_owners(detail.owners.iter().map(|o| {
+        let mut info = cargo_bp_script::OwnerInfo::new(&o.login);
+        if let Some(n) = &o.name {
+            info = info.with_name(n);
+        }
+        info
+    }));
+
+    // Crates
+    report = report.with_crates(detail.crates.iter().map(|s| s.as_str()));
+
+    // Extends
+    for ext in &detail.extends {
+        report = report.with_extends(ext);
+    }
+
+    // Features
+    report = report.with_features(detail.features.iter().map(|(feat_name, members)| {
+        cargo_bp_script::FeatureInfo::new(feat_name).with_crates(members.iter().map(|s| s.as_str()))
+    }));
+
+    // Templates
+    report = report.with_templates(detail.templates.iter().map(|t| {
+        let mut info = cargo_bp_script::TemplateInfo::new(&t.name);
+        if let Some(d) = &t.description {
+            info = info.with_description(d);
+        }
+        info
+    }));
+
+    // Examples
+    report = report.with_examples(detail.examples.iter().map(|e| {
+        let mut info = cargo_bp_script::ExampleInfo::new(&e.name);
+        if let Some(d) = &e.description {
+            info = info.with_description(d);
+        }
+        info
+    }));
+
+    Ok(report)
 }
 
 /// Read installed state (managed-deps and active features) for a battery pack.

--- a/src/cargo-bp-script/src/lib.rs
+++ b/src/cargo-bp-script/src/lib.rs
@@ -38,12 +38,18 @@
 
 #![deny(missing_docs)]
 
+pub mod list;
 pub mod runner;
+pub mod show;
 pub mod status;
 
 // Re-export the most commonly used items at the crate root for
 // ergonomic access. The full API stays addressable via the modules.
-pub use runner::{Error, StatusCommand, parse_status};
+pub use list::{ListReport, PackSummary};
+pub use runner::{
+    Error, ListCommand, ShowCommand, StatusCommand, parse_list, parse_show, parse_status,
+};
+pub use show::{ExampleInfo, FeatureInfo, OwnerInfo, ShowReport, TemplateInfo};
 pub use status::{
     DependencyWarning, InstalledPackStatus, ProjectInfo, SCHEMA_VERSION, StatusReport,
 };
@@ -114,5 +120,68 @@ mod tests {
     fn parse_status_rejects_garbage() {
         let err = parse_status(b"not json").unwrap_err();
         assert!(matches!(err, Error::Parse { .. }), "got {err:?}");
+    }
+
+    /// JSON serialization round-trips through `parse_list`.
+    #[test]
+    fn round_trip_list_report() {
+        let report = ListReport::new()
+            .with_filter("cli")
+            .with_pack(
+                PackSummary::new("cli", "cli-battery-pack", "0.3.0")
+                    .with_description("Opinionated CLI starter kit"),
+            )
+            .with_packs([PackSummary::new("error", "error-battery-pack", "0.2.0")
+                .with_description("Error handling")]);
+
+        let bytes = serde_json::to_vec(&report).expect("serialize");
+        let parsed = parse_list(&bytes).expect("parse_list");
+        assert_eq!(parsed, report);
+    }
+
+    /// JSON serialization round-trips through `parse_show`.
+    #[test]
+    fn round_trip_show_report() {
+        let report = ShowReport::new("cli", "cli-battery-pack", "0.3.0")
+            .with_description("Opinionated CLI starter kit")
+            .with_repository("https://github.com/battery-pack-rs/battery-pack")
+            .with_owner(OwnerInfo::new("ferris").with_name("Ferris the Crab"))
+            .with_crate("clap")
+            .with_crates(["indicatif", "console"])
+            .with_extends("error")
+            .with_feature(
+                FeatureInfo::new("fancy")
+                    .with_crate("dialoguer")
+                    .with_crates(["ratatui"]),
+            )
+            .with_template(TemplateInfo::new("default").with_description("Minimal CLI app"))
+            .with_example(ExampleInfo::new("mini-grep").with_description("A grep clone"));
+
+        let bytes = serde_json::to_vec(&report).expect("serialize");
+        let parsed = parse_show(&bytes).expect("parse_show");
+        assert_eq!(parsed, report);
+    }
+
+    /// `parse_list` surfaces malformed input as `Error::Parse`.
+    #[test]
+    fn parse_list_rejects_garbage() {
+        let err = parse_list(b"not json").unwrap_err();
+        assert!(matches!(err, Error::Parse { .. }), "got {err:?}");
+    }
+
+    /// `parse_show` surfaces malformed input as `Error::Parse`.
+    #[test]
+    fn parse_show_rejects_garbage() {
+        let err = parse_show(b"not json").unwrap_err();
+        assert!(matches!(err, Error::Parse { .. }), "got {err:?}");
+    }
+
+    /// `ListReport::default()` creates an empty report.
+    #[test]
+    fn list_report_default() {
+        let report = ListReport::default();
+        assert_eq!(report.schema_version, SCHEMA_VERSION);
+        assert!(report.packs.is_empty());
+        assert!(report.filter.is_none());
     }
 }

--- a/src/cargo-bp-script/src/list.rs
+++ b/src/cargo-bp-script/src/list.rs
@@ -1,0 +1,113 @@
+//! Schema for `cargo bp list --json` output.
+//!
+//! These types are the stable, machine-consumable representation of
+//! `cargo bp list`. They are emitted by the CLI when invoked with
+//! `--json` and parsed by the [`runner`](crate::runner) module.
+//!
+//! # Construction
+//!
+//! ```
+//! use cargo_bp_script::{ListReport, PackSummary};
+//!
+//! let report = ListReport::new()
+//!     .with_pack(PackSummary::new("cli", "cli-battery-pack", "0.3.0")
+//!         .with_description("Opinionated CLI starter kit"));
+//! assert_eq!(report.packs.len(), 1);
+//! ```
+
+use serde::{Deserialize, Serialize};
+
+use crate::SCHEMA_VERSION;
+
+/// Top-level report emitted by `cargo bp list --json`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ListReport {
+    /// Schema version. Currently always `"1"`.
+    pub schema_version: String,
+
+    /// Optional filter that was applied (if any).
+    pub filter: Option<String>,
+
+    /// Available battery packs matching the filter.
+    pub packs: Vec<PackSummary>,
+}
+
+/// Summary of a single available battery pack.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct PackSummary {
+    /// Short name without the `-battery-pack` suffix, e.g. `"cli"`.
+    pub short_name: String,
+
+    /// Full crate name, e.g. `"cli-battery-pack"`.
+    pub name: String,
+
+    /// Latest version on the registry.
+    pub version: String,
+
+    /// One-line description of the battery pack.
+    pub description: String,
+}
+
+// ============================================================================
+// Builders
+// ============================================================================
+
+impl ListReport {
+    /// Start building a report with the current [`SCHEMA_VERSION`] and
+    /// no packs.
+    pub fn new() -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION.to_string(),
+            filter: None,
+            packs: Vec::new(),
+        }
+    }
+
+    /// Set the filter that was applied.
+    pub fn with_filter(mut self, filter: impl Into<String>) -> Self {
+        self.filter = Some(filter.into());
+        self
+    }
+
+    /// Append a single pack summary.
+    pub fn with_pack(mut self, pack: PackSummary) -> Self {
+        self.packs.push(pack);
+        self
+    }
+
+    /// Extend the report with multiple pack summaries.
+    pub fn with_packs(mut self, packs: impl IntoIterator<Item = PackSummary>) -> Self {
+        self.packs.extend(packs);
+        self
+    }
+}
+
+impl Default for ListReport {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PackSummary {
+    /// Build a [`PackSummary`] from its required fields.
+    pub fn new(
+        short_name: impl Into<String>,
+        name: impl Into<String>,
+        version: impl Into<String>,
+    ) -> Self {
+        Self {
+            short_name: short_name.into(),
+            name: name.into(),
+            version: version.into(),
+            description: String::new(),
+        }
+    }
+
+    /// Set the description.
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.description = description.into();
+        self
+    }
+}

--- a/src/cargo-bp-script/src/runner.rs
+++ b/src/cargo-bp-script/src/runner.rs
@@ -7,6 +7,8 @@ use std::ffi::{OsStr, OsString};
 use std::path::PathBuf;
 use std::process::{Command, ExitStatus};
 
+use crate::list::ListReport;
+use crate::show::ShowReport;
 use crate::status::StatusReport;
 
 /// Error returned by the runner.
@@ -24,8 +26,10 @@ pub enum Error {
     },
 
     /// The subprocess ran but exited with a non-zero status.
-    #[error("`cargo bp status --json` exited with {status}: {stderr}")]
+    #[error("`{command}` exited with {status}: {stderr}")]
     ExitStatus {
+        /// The command string that failed (e.g. `"cargo bp status --json"`).
+        command: String,
         /// Exit status of the subprocess.
         status: ExitStatus,
         /// Captured stderr (UTF-8 lossy).
@@ -34,8 +38,10 @@ pub enum Error {
 
     /// The subprocess emitted output that could not be parsed as the
     /// expected JSON schema.
-    #[error("failed to parse `cargo bp status --json` output as JSON: {source}")]
+    #[error("failed to parse `{command}` output as JSON: {source}")]
     Parse {
+        /// The command whose output failed to parse.
+        command: String,
         /// Underlying parse error from `serde_json`.
         #[source]
         source: serde_json::Error,
@@ -125,7 +131,6 @@ impl StatusCommand {
     /// Spawn `cargo bp status --json`, capture stdout, and parse it
     /// into a [`StatusReport`].
     pub fn run(&self) -> Result<StatusReport, Error> {
-        // --- Build the command line.
         // Layout: <program> bp [--crate-source <p>] status --json [--path <p>]
         let mut cmd = Command::new(&self.program);
         cmd.arg("bp");
@@ -140,32 +145,248 @@ impl StatusCommand {
             cmd.current_dir(d);
         }
 
-        // --- Spawn and capture output.
-        let output = cmd.output().map_err(|source| Error::Spawn {
-            program: program_display(&self.program),
-            source,
-        })?;
-        if !output.status.success() {
-            return Err(Error::ExitStatus {
-                status: output.status,
-                stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
-            });
-        }
-
-        // --- Parse JSON payload.
-        parse_status(&output.stdout)
+        let output = spawn(&self.program, &mut cmd)?;
+        parse_status(&output)
     }
 }
+
+// ============================================================================
+// ListCommand
+// ============================================================================
+
+/// Builder for invoking `cargo bp list --json` and parsing its output.
+///
+/// # Example
+///
+/// ```no_run
+/// use cargo_bp_script::ListCommand;
+///
+/// let report = ListCommand::new().run()?;
+/// for pack in &report.packs {
+///     println!("{} — {}", pack.short_name, pack.description);
+/// }
+/// # Ok::<(), cargo_bp_script::Error>(())
+/// ```
+#[derive(Debug, Clone)]
+pub struct ListCommand {
+    program: OsString,
+    cwd: Option<PathBuf>,
+    crate_source: Option<PathBuf>,
+    filter: Option<String>,
+}
+
+impl Default for ListCommand {
+    fn default() -> Self {
+        Self {
+            program: OsString::from("cargo"),
+            cwd: None,
+            crate_source: None,
+            filter: None,
+        }
+    }
+}
+
+impl ListCommand {
+    /// Create a new builder with default settings.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Override the program used to invoke `cargo bp`.
+    pub fn program(mut self, program: impl Into<OsString>) -> Self {
+        self.program = program.into();
+        self
+    }
+
+    /// Run the command in a different working directory.
+    pub fn cwd(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.cwd = Some(dir.into());
+        self
+    }
+
+    /// Forward `--crate-source <path>` to `cargo bp`.
+    pub fn crate_source(mut self, path: impl Into<PathBuf>) -> Self {
+        self.crate_source = Some(path.into());
+        self
+    }
+
+    /// Set an optional filter string to narrow results.
+    pub fn filter(mut self, filter: impl Into<String>) -> Self {
+        self.filter = Some(filter.into());
+        self
+    }
+
+    /// Spawn `cargo bp list --json`, capture stdout, and parse it
+    /// into a [`ListReport`].
+    pub fn run(&self) -> Result<ListReport, Error> {
+        // Layout: <program> bp [--crate-source <p>] list --json [<filter>]
+        let mut cmd = Command::new(&self.program);
+        cmd.arg("bp");
+        if let Some(cs) = &self.crate_source {
+            cmd.arg("--crate-source").arg(cs);
+        }
+        cmd.arg("list").arg("--json");
+        if let Some(f) = &self.filter {
+            cmd.arg(f);
+        }
+        if let Some(d) = &self.cwd {
+            cmd.current_dir(d);
+        }
+
+        let output = spawn(&self.program, &mut cmd)?;
+        parse_list(&output)
+    }
+}
+
+// ============================================================================
+// ShowCommand
+// ============================================================================
+
+/// Builder for invoking `cargo bp show --json <pack>` and parsing its output.
+///
+/// # Example
+///
+/// ```no_run
+/// use cargo_bp_script::ShowCommand;
+///
+/// let report = ShowCommand::new("cli").run()?;
+/// println!("{} v{}", report.name, report.version);
+/// for c in &report.crates {
+///     println!("  - {c}");
+/// }
+/// # Ok::<(), cargo_bp_script::Error>(())
+/// ```
+#[derive(Debug, Clone)]
+pub struct ShowCommand {
+    program: OsString,
+    cwd: Option<PathBuf>,
+    crate_source: Option<PathBuf>,
+    path: Option<PathBuf>,
+    battery_pack: String,
+}
+
+impl ShowCommand {
+    /// Create a new builder for the given battery pack name.
+    pub fn new(battery_pack: impl Into<String>) -> Self {
+        Self {
+            program: OsString::from("cargo"),
+            cwd: None,
+            crate_source: None,
+            path: None,
+            battery_pack: battery_pack.into(),
+        }
+    }
+
+    /// Override the program used to invoke `cargo bp`.
+    pub fn program(mut self, program: impl Into<OsString>) -> Self {
+        self.program = program.into();
+        self
+    }
+
+    /// Run the command in a different working directory.
+    pub fn cwd(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.cwd = Some(dir.into());
+        self
+    }
+
+    /// Forward `--crate-source <path>` to `cargo bp`.
+    pub fn crate_source(mut self, path: impl Into<PathBuf>) -> Self {
+        self.crate_source = Some(path.into());
+        self
+    }
+
+    /// Forward `--path <path>` to `cargo bp show`.
+    pub fn path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.path = Some(path.into());
+        self
+    }
+
+    /// Spawn `cargo bp show --json <pack>`, capture stdout, and parse it
+    /// into a [`ShowReport`].
+    pub fn run(&self) -> Result<ShowReport, Error> {
+        // Layout: <program> bp [--crate-source <p>] show --json [--path <p>] <pack>
+        let mut cmd = Command::new(&self.program);
+        cmd.arg("bp");
+        if let Some(cs) = &self.crate_source {
+            cmd.arg("--crate-source").arg(cs);
+        }
+        cmd.arg("show").arg("--json");
+        if let Some(p) = &self.path {
+            cmd.arg("--path").arg(p);
+        }
+        cmd.arg(&self.battery_pack);
+        if let Some(d) = &self.cwd {
+            cmd.current_dir(d);
+        }
+
+        let output = spawn(&self.program, &mut cmd)?;
+        parse_show(&output)
+    }
+}
+
+// ============================================================================
+// Parsing helpers
+// ============================================================================
 
 /// Parse a `cargo bp status --json` payload into a [`StatusReport`].
 ///
 /// Useful when the caller already has the bytes in hand (for example,
 /// from their own subprocess wrapper) and just wants the typed report.
 pub fn parse_status(bytes: &[u8]) -> Result<StatusReport, Error> {
-    serde_json::from_slice(bytes).map_err(|source| Error::Parse { source })
+    serde_json::from_slice(bytes).map_err(|source| Error::Parse {
+        command: "cargo bp status --json".into(),
+        source,
+    })
+}
+
+/// Parse a `cargo bp list --json` payload into a [`ListReport`].
+pub fn parse_list(bytes: &[u8]) -> Result<ListReport, Error> {
+    serde_json::from_slice(bytes).map_err(|source| Error::Parse {
+        command: "cargo bp list --json".into(),
+        source,
+    })
+}
+
+/// Parse a `cargo bp show --json` payload into a [`ShowReport`].
+pub fn parse_show(bytes: &[u8]) -> Result<ShowReport, Error> {
+    serde_json::from_slice(bytes).map_err(|source| Error::Parse {
+        command: "cargo bp show --json".into(),
+        source,
+    })
+}
+
+// ============================================================================
+// Internal helpers
+// ============================================================================
+
+/// Spawn a command and return its stdout on success, or an appropriate error.
+fn spawn(program: &OsStr, cmd: &mut Command) -> Result<Vec<u8>, Error> {
+    let output = cmd.output().map_err(|source| Error::Spawn {
+        program: program_display(program),
+        source,
+    })?;
+    if !output.status.success() {
+        return Err(Error::ExitStatus {
+            command: format_command(cmd),
+            status: output.status,
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        });
+    }
+    Ok(output.stdout)
 }
 
 /// Best-effort display string for an `OsStr`, used only for error messages.
 fn program_display(program: &OsStr) -> String {
     program.to_string_lossy().into_owned()
+}
+
+/// Best-effort reconstruction of the command line for error messages.
+fn format_command(cmd: &Command) -> String {
+    let prog = cmd.get_program().to_string_lossy();
+    let args: Vec<_> = cmd.get_args().map(|a| a.to_string_lossy()).collect();
+    if args.is_empty() {
+        prog.into_owned()
+    } else {
+        format!("{} {}", prog, args.join(" "))
+    }
 }

--- a/src/cargo-bp-script/src/show.rs
+++ b/src/cargo-bp-script/src/show.rs
@@ -63,6 +63,18 @@ pub struct ShowReport {
 
     /// Available examples.
     pub examples: Vec<ExampleInfo>,
+
+    /// Crates from this pack that are currently installed in the user's
+    /// project. Empty when not run inside a project or when the pack
+    /// isn't installed.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub installed_crates: Vec<String>,
+
+    /// Features from this pack that are currently active in the user's
+    /// project. Empty when not run inside a project or when the pack
+    /// isn't installed.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub active_features: Vec<String>,
 }
 
 /// Information about a battery pack owner/author.
@@ -133,6 +145,8 @@ impl ShowReport {
             features: Vec::new(),
             templates: Vec::new(),
             examples: Vec::new(),
+            installed_crates: Vec::new(),
+            active_features: Vec::new(),
         }
     }
 
@@ -215,6 +229,28 @@ impl ShowReport {
     /// Extend with multiple examples.
     pub fn with_examples(mut self, examples: impl IntoIterator<Item = ExampleInfo>) -> Self {
         self.examples.extend(examples);
+        self
+    }
+
+    /// Set the crates from this pack that are currently installed.
+    pub fn with_installed_crates<I, S>(mut self, crates: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.installed_crates
+            .extend(crates.into_iter().map(Into::into));
+        self
+    }
+
+    /// Set the features from this pack that are currently active.
+    pub fn with_active_features<I, S>(mut self, features: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.active_features
+            .extend(features.into_iter().map(Into::into));
         self
     }
 }

--- a/src/cargo-bp-script/src/show.rs
+++ b/src/cargo-bp-script/src/show.rs
@@ -1,0 +1,294 @@
+//! Schema for `cargo bp show --json` output.
+//!
+//! These types are the stable, machine-consumable representation of
+//! `cargo bp show <pack>`. They are emitted by the CLI when invoked
+//! with `--json` and parsed by the [`runner`](crate::runner) module.
+//!
+//! # Construction
+//!
+//! ```
+//! use cargo_bp_script::{ShowReport, OwnerInfo, TemplateInfo, ExampleInfo, FeatureInfo};
+//!
+//! let report = ShowReport::new("cli", "cli-battery-pack", "0.3.0")
+//!     .with_description("Opinionated CLI starter kit")
+//!     .with_crate("clap")
+//!     .with_crate("indicatif")
+//!     .with_owner(OwnerInfo::new("rustacean").with_name("Ferris"))
+//!     .with_feature(FeatureInfo::new("fancy").with_crate("dialoguer"))
+//!     .with_template(TemplateInfo::new("default").with_description("Minimal CLI app"))
+//!     .with_example(ExampleInfo::new("mini-grep").with_description("Grep clone"));
+//! assert_eq!(report.crates.len(), 2);
+//! ```
+
+use serde::{Deserialize, Serialize};
+
+use crate::SCHEMA_VERSION;
+
+/// Top-level report emitted by `cargo bp show --json`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ShowReport {
+    /// Schema version. Currently always `"1"`.
+    pub schema_version: String,
+
+    /// Short name without the `-battery-pack` suffix, e.g. `"cli"`.
+    pub short_name: String,
+
+    /// Full crate name, e.g. `"cli-battery-pack"`.
+    pub name: String,
+
+    /// Version of the battery pack.
+    pub version: String,
+
+    /// Description of the battery pack.
+    pub description: String,
+
+    /// Repository URL (if known).
+    pub repository: Option<String>,
+
+    /// Pack authors/owners.
+    pub owners: Vec<OwnerInfo>,
+
+    /// Default crates provided by this battery pack.
+    pub crates: Vec<String>,
+
+    /// Battery packs this one extends.
+    pub extends: Vec<String>,
+
+    /// Named features and the crates they include.
+    pub features: Vec<FeatureInfo>,
+
+    /// Available templates.
+    pub templates: Vec<TemplateInfo>,
+
+    /// Available examples.
+    pub examples: Vec<ExampleInfo>,
+}
+
+/// Information about a battery pack owner/author.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct OwnerInfo {
+    /// Login/username.
+    pub login: String,
+
+    /// Display name (if known).
+    pub name: Option<String>,
+}
+
+/// A named feature and the crates it provides.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct FeatureInfo {
+    /// Feature name (e.g. `"fancy"`).
+    pub name: String,
+
+    /// Crates activated by this feature.
+    pub crates: Vec<String>,
+}
+
+/// Information about an available template.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct TemplateInfo {
+    /// Template name.
+    pub name: String,
+
+    /// Short description (if available).
+    pub description: Option<String>,
+}
+
+/// Information about an available example.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ExampleInfo {
+    /// Example name.
+    pub name: String,
+
+    /// Short description (if available).
+    pub description: Option<String>,
+}
+
+// ============================================================================
+// Builders
+// ============================================================================
+
+impl ShowReport {
+    /// Start building a report with the current [`SCHEMA_VERSION`].
+    pub fn new(
+        short_name: impl Into<String>,
+        name: impl Into<String>,
+        version: impl Into<String>,
+    ) -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION.to_string(),
+            short_name: short_name.into(),
+            name: name.into(),
+            version: version.into(),
+            description: String::new(),
+            repository: None,
+            owners: Vec::new(),
+            crates: Vec::new(),
+            extends: Vec::new(),
+            features: Vec::new(),
+            templates: Vec::new(),
+            examples: Vec::new(),
+        }
+    }
+
+    /// Set the description.
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.description = description.into();
+        self
+    }
+
+    /// Set the repository URL.
+    pub fn with_repository(mut self, repository: impl Into<String>) -> Self {
+        self.repository = Some(repository.into());
+        self
+    }
+
+    /// Append a single owner.
+    pub fn with_owner(mut self, owner: OwnerInfo) -> Self {
+        self.owners.push(owner);
+        self
+    }
+
+    /// Extend with multiple owners.
+    pub fn with_owners(mut self, owners: impl IntoIterator<Item = OwnerInfo>) -> Self {
+        self.owners.extend(owners);
+        self
+    }
+
+    /// Append a single crate name.
+    pub fn with_crate(mut self, crate_name: impl Into<String>) -> Self {
+        self.crates.push(crate_name.into());
+        self
+    }
+
+    /// Extend with multiple crate names.
+    pub fn with_crates<I, S>(mut self, crates: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.crates.extend(crates.into_iter().map(Into::into));
+        self
+    }
+
+    /// Append a single extends entry.
+    pub fn with_extends(mut self, extends: impl Into<String>) -> Self {
+        self.extends.push(extends.into());
+        self
+    }
+
+    /// Append a single feature.
+    pub fn with_feature(mut self, feature: FeatureInfo) -> Self {
+        self.features.push(feature);
+        self
+    }
+
+    /// Extend with multiple features.
+    pub fn with_features(mut self, features: impl IntoIterator<Item = FeatureInfo>) -> Self {
+        self.features.extend(features);
+        self
+    }
+
+    /// Append a single template.
+    pub fn with_template(mut self, template: TemplateInfo) -> Self {
+        self.templates.push(template);
+        self
+    }
+
+    /// Extend with multiple templates.
+    pub fn with_templates(mut self, templates: impl IntoIterator<Item = TemplateInfo>) -> Self {
+        self.templates.extend(templates);
+        self
+    }
+
+    /// Append a single example.
+    pub fn with_example(mut self, example: ExampleInfo) -> Self {
+        self.examples.push(example);
+        self
+    }
+
+    /// Extend with multiple examples.
+    pub fn with_examples(mut self, examples: impl IntoIterator<Item = ExampleInfo>) -> Self {
+        self.examples.extend(examples);
+        self
+    }
+}
+
+impl OwnerInfo {
+    /// Build an [`OwnerInfo`] from a login.
+    pub fn new(login: impl Into<String>) -> Self {
+        Self {
+            login: login.into(),
+            name: None,
+        }
+    }
+
+    /// Set the display name.
+    pub fn with_name(mut self, name: impl Into<String>) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+}
+
+impl FeatureInfo {
+    /// Build a [`FeatureInfo`] from its name with no crates.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            crates: Vec::new(),
+        }
+    }
+
+    /// Append a single crate to this feature.
+    pub fn with_crate(mut self, crate_name: impl Into<String>) -> Self {
+        self.crates.push(crate_name.into());
+        self
+    }
+
+    /// Extend with multiple crates.
+    pub fn with_crates<I, S>(mut self, crates: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.crates.extend(crates.into_iter().map(Into::into));
+        self
+    }
+}
+
+impl TemplateInfo {
+    /// Build a [`TemplateInfo`] from its name.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            description: None,
+        }
+    }
+
+    /// Set the description.
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+}
+
+impl ExampleInfo {
+    /// Build an [`ExampleInfo`] from its name.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            description: None,
+        }
+    }
+
+    /// Set the description.
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+}

--- a/src/cargo-bp/tests/list_json.rs
+++ b/src/cargo-bp/tests/list_json.rs
@@ -1,0 +1,132 @@
+//! Integration tests for `cargo bp list --json`.
+
+use assert_cmd::Command;
+use cargo_bp_script::{ListCommand, SCHEMA_VERSION, parse_list};
+use std::path::{Path, PathBuf};
+
+fn cargo_bp() -> Command {
+    Command::new(assert_cmd::cargo::cargo_bin!("cargo-bp"))
+}
+
+fn fixtures_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("battery-pack")
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("tests/fixtures")
+}
+
+#[test]
+fn list_json_emits_valid_schema() {
+    let output = cargo_bp()
+        .args([
+            "bp",
+            "--crate-source",
+            &fixtures_dir().to_string_lossy(),
+            "list",
+            "--json",
+        ])
+        .output()
+        .expect("failed to run cargo-bp");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let report = parse_list(&output.stdout).unwrap_or_else(|err| {
+        panic!(
+            "parse_list failed: {err}\nraw stdout: {:?}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    });
+
+    assert_eq!(report.schema_version, SCHEMA_VERSION);
+    assert!(report.filter.is_none());
+
+    // The fixtures workspace has at least basic, fancy, and managed battery packs.
+    assert!(
+        report.packs.len() >= 3,
+        "expected at least 3 packs, got {}",
+        report.packs.len()
+    );
+
+    // Verify structure of a known pack.
+    let fancy = report
+        .packs
+        .iter()
+        .find(|p| p.short_name == "fancy")
+        .expect("expected fancy-battery-pack in list");
+    assert_eq!(fancy.name, "fancy-battery-pack");
+    assert_eq!(fancy.version, "0.2.0");
+    assert!(!fancy.description.is_empty());
+}
+
+#[test]
+fn list_json_with_filter() {
+    let output = cargo_bp()
+        .args([
+            "bp",
+            "--crate-source",
+            &fixtures_dir().to_string_lossy(),
+            "list",
+            "--json",
+            "fancy",
+        ])
+        .output()
+        .expect("failed to run cargo-bp");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let report = parse_list(&output.stdout).unwrap();
+    assert_eq!(report.filter.as_deref(), Some("fancy"));
+    assert_eq!(report.packs.len(), 1);
+    assert_eq!(report.packs[0].short_name, "fancy");
+}
+
+#[test]
+fn list_json_no_match_returns_empty_array() {
+    let output = cargo_bp()
+        .args([
+            "bp",
+            "--crate-source",
+            &fixtures_dir().to_string_lossy(),
+            "list",
+            "--json",
+            "nonexistent-xyz",
+        ])
+        .output()
+        .expect("failed to run cargo-bp");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let report = parse_list(&output.stdout).unwrap();
+    assert!(report.packs.is_empty());
+    assert_eq!(report.filter.as_deref(), Some("nonexistent-xyz"));
+}
+
+#[test]
+fn list_command_runner_returns_typed_report() {
+    let report = ListCommand::new()
+        .program(assert_cmd::cargo::cargo_bin!("cargo-bp"))
+        .crate_source(fixtures_dir())
+        .run()
+        .expect("ListCommand::run failed");
+
+    assert_eq!(report.schema_version, SCHEMA_VERSION);
+    assert!(report.packs.len() >= 3);
+    assert!(report.packs.iter().any(|p| p.short_name == "fancy"));
+}

--- a/src/cargo-bp/tests/list_json.rs
+++ b/src/cargo-bp/tests/list_json.rs
@@ -2,6 +2,7 @@
 
 use assert_cmd::Command;
 use cargo_bp_script::{ListCommand, SCHEMA_VERSION, parse_list};
+use snapbox::{assert_data_eq, str};
 use std::path::{Path, PathBuf};
 
 fn cargo_bp() -> Command {
@@ -87,10 +88,14 @@ fn list_json_with_filter() {
         String::from_utf8_lossy(&output.stderr)
     );
 
-    let report = parse_list(&output.stdout).unwrap();
-    assert_eq!(report.filter.as_deref(), Some("fancy"));
-    assert_eq!(report.packs.len(), 1);
-    assert_eq!(report.packs[0].short_name, "fancy");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_data_eq!(
+        stdout.as_ref(),
+        str![[r#"
+{"schema_version":"1","filter":"fancy","packs":[{"short_name":"fancy","name":"fancy-battery-pack","version":"0.2.0","description":"A feature-rich test battery pack"}]}
+
+"#]]
+    );
 }
 
 #[test]
@@ -113,9 +118,14 @@ fn list_json_no_match_returns_empty_array() {
         String::from_utf8_lossy(&output.stderr)
     );
 
-    let report = parse_list(&output.stdout).unwrap();
-    assert!(report.packs.is_empty());
-    assert_eq!(report.filter.as_deref(), Some("nonexistent-xyz"));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_data_eq!(
+        stdout.as_ref(),
+        str![[r#"
+{"schema_version":"1","filter":"nonexistent-xyz","packs":[]}
+
+"#]]
+    );
 }
 
 #[test]

--- a/src/cargo-bp/tests/show_json.rs
+++ b/src/cargo-bp/tests/show_json.rs
@@ -2,6 +2,7 @@
 
 use assert_cmd::Command;
 use cargo_bp_script::{SCHEMA_VERSION, ShowCommand, parse_show};
+use snapbox::{assert_data_eq, str};
 use std::path::{Path, PathBuf};
 
 fn cargo_bp() -> Command {
@@ -115,14 +116,14 @@ fn show_json_via_crate_source() {
         String::from_utf8_lossy(&output.stderr)
     );
 
-    let report = parse_show(&output.stdout).unwrap();
-    assert_eq!(report.short_name, "basic");
-    assert_eq!(report.name, "basic-battery-pack");
-    assert_eq!(report.version, "0.1.0");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_data_eq!(
+        stdout.as_ref(),
+        str![[r#"
+{"schema_version":"1","short_name":"basic","name":"basic-battery-pack","version":"0.1.0","description":"A simple test battery pack","repository":null,"owners":[],"crates":["anyhow","eyre","thiserror"],"extends":[],"features":[{"name":"all-errors","crates":["anyhow","eyre","thiserror"]},{"name":"default","crates":["anyhow","thiserror"]}],"templates":[],"examples":[],"active_features":["default"]}
 
-    // basic-battery-pack has anyhow and thiserror as default crates.
-    assert!(report.crates.contains(&"anyhow".to_string()));
-    assert!(report.crates.contains(&"thiserror".to_string()));
+"#]]
+    );
 }
 
 #[test]
@@ -144,6 +145,35 @@ fn show_json_unknown_pack_fails() {
         output.stdout.is_empty(),
         "stdout should be empty on error, got: {:?}",
         String::from_utf8_lossy(&output.stdout),
+    );
+}
+
+#[test]
+fn show_json_conflicts_with_template() {
+    let fixture = fixtures_dir().join("fancy-battery-pack");
+
+    let output = cargo_bp()
+        .args([
+            "bp",
+            "show",
+            "--json",
+            "--template",
+            "default",
+            "--path",
+            &fixture.to_string_lossy(),
+            "fancy",
+        ])
+        .output()
+        .expect("failed to run cargo-bp");
+
+    assert!(
+        !output.status.success(),
+        "should fail when --json and --template are combined"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("cannot be used with"),
+        "expected conflict error, got: {stderr}"
     );
 }
 

--- a/src/cargo-bp/tests/show_json.rs
+++ b/src/cargo-bp/tests/show_json.rs
@@ -1,0 +1,164 @@
+//! Integration tests for `cargo bp show --json`.
+
+use assert_cmd::Command;
+use cargo_bp_script::{SCHEMA_VERSION, ShowCommand, parse_show};
+use std::path::{Path, PathBuf};
+
+fn cargo_bp() -> Command {
+    Command::new(assert_cmd::cargo::cargo_bin!("cargo-bp"))
+}
+
+fn fixtures_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("battery-pack")
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("tests/fixtures")
+}
+
+#[test]
+fn show_json_emits_valid_schema() {
+    let fixture = fixtures_dir().join("fancy-battery-pack");
+
+    let output = cargo_bp()
+        .args([
+            "bp",
+            "show",
+            "--json",
+            "--path",
+            &fixture.to_string_lossy(),
+            "fancy",
+        ])
+        .output()
+        .expect("failed to run cargo-bp");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let report = parse_show(&output.stdout).unwrap_or_else(|err| {
+        panic!(
+            "parse_show failed: {err}\nraw stdout: {:?}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    });
+
+    assert_eq!(report.schema_version, SCHEMA_VERSION);
+    assert_eq!(report.short_name, "fancy");
+    assert_eq!(report.name, "fancy-battery-pack");
+    assert_eq!(report.version, "0.2.0");
+    assert_eq!(report.description, "A feature-rich test battery pack");
+    assert_eq!(
+        report.repository.as_deref(),
+        Some("https://github.com/example/fancy")
+    );
+
+    // Crates: hidden deps (serde*, cc) should be excluded.
+    assert!(
+        report.crates.contains(&"clap".to_string()),
+        "expected clap in crates, got {:?}",
+        report.crates
+    );
+    assert!(
+        !report.crates.contains(&"serde".to_string()),
+        "serde should be hidden"
+    );
+    assert!(
+        !report.crates.contains(&"cc".to_string()),
+        "cc should be hidden"
+    );
+
+    // Features
+    assert!(
+        report.features.iter().any(|f| f.name == "indicators"),
+        "expected indicators feature, got {:?}",
+        report.features
+    );
+
+    // Templates
+    assert!(
+        report.templates.len() >= 2,
+        "expected at least 2 templates, got {}",
+        report.templates.len()
+    );
+    let default_tmpl = report
+        .templates
+        .iter()
+        .find(|t| t.name == "default")
+        .expect("expected 'default' template");
+    assert_eq!(default_tmpl.description.as_deref(), Some("Basic CLI app"));
+}
+
+#[test]
+fn show_json_via_crate_source() {
+    let output = cargo_bp()
+        .args([
+            "bp",
+            "--crate-source",
+            &fixtures_dir().to_string_lossy(),
+            "show",
+            "--json",
+            "basic",
+        ])
+        .output()
+        .expect("failed to run cargo-bp");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let report = parse_show(&output.stdout).unwrap();
+    assert_eq!(report.short_name, "basic");
+    assert_eq!(report.name, "basic-battery-pack");
+    assert_eq!(report.version, "0.1.0");
+
+    // basic-battery-pack has anyhow and thiserror as default crates.
+    assert!(report.crates.contains(&"anyhow".to_string()));
+    assert!(report.crates.contains(&"thiserror".to_string()));
+}
+
+#[test]
+fn show_json_unknown_pack_fails() {
+    let output = cargo_bp()
+        .args([
+            "bp",
+            "--crate-source",
+            &fixtures_dir().to_string_lossy(),
+            "show",
+            "--json",
+            "nonexistent-xyz",
+        ])
+        .output()
+        .expect("failed to run cargo-bp");
+
+    assert!(!output.status.success());
+    assert!(
+        output.stdout.is_empty(),
+        "stdout should be empty on error, got: {:?}",
+        String::from_utf8_lossy(&output.stdout),
+    );
+}
+
+#[test]
+fn show_command_runner_returns_typed_report() {
+    let fixture = fixtures_dir().join("fancy-battery-pack");
+
+    let report = ShowCommand::new("fancy")
+        .program(assert_cmd::cargo::cargo_bin!("cargo-bp"))
+        .path(&fixture)
+        .run()
+        .expect("ShowCommand::run failed");
+
+    assert_eq!(report.schema_version, SCHEMA_VERSION);
+    assert_eq!(report.name, "fancy-battery-pack");
+    assert!(!report.crates.is_empty());
+    assert!(!report.templates.is_empty());
+}


### PR DESCRIPTION
Extend cargo-bp-script with schema types and runners for `cargo bp list --json` and `cargo bp show --json`, following the same pattern as the existing `status --json` support. Add --json flags to both CLI subcommands and integration tests exercising the binary and the typed runner API.