### PR TITLE
Preserve existing features on re-add

### DIFF
--- a/src/battery-pack/bphelper-cli/src/commands/mod.rs
+++ b/src/battery-pack/bphelper-cli/src/commands/mod.rs
@@ -11,9 +11,10 @@ use std::path::{Path, PathBuf};
 
 use crate::manifest::{
     add_dep_to_table, dep_kind_section, find_installed_bp_names, find_user_manifest,
-    find_workspace_manifest, read_active_features_for_project, read_managed_deps_for_project,
-    remove_battery_pack_state_entry, remove_deps_by_kind, should_upgrade_version,
-    sync_dep_in_table, write_battery_pack_state, write_deps_by_kind, write_workspace_refs_by_kind,
+    find_workspace_manifest, read_active_features_for_project, read_active_features_from_state,
+    read_managed_deps_for_project, remove_battery_pack_state_entry, remove_deps_by_kind,
+    should_upgrade_version, sync_dep_in_table, write_battery_pack_state, write_deps_by_kind,
+    write_workspace_refs_by_kind,
 };
 use crate::registry::{
     CrateSource, InstalledPack, TemplateConfig, fetch_battery_pack_detail,
@@ -771,10 +772,35 @@ pub(crate) fn add_battery_pack(
 
     // Step 2: Determine which crates to install — interactive picker, explicit flags, or defaults.
     // No manifest changes have been made yet, so cancellation is free.
+    //
+    // Merge previously stored features so that re-adding with `-F bar` is
+    // additive rather than replacing the existing feature set.
+    // Skip merging when the user explicitly narrows (--no-default-features,
+    // --all-features, or specific crates) since those signal a fresh selection.
+    let user_manifest_path = find_user_manifest(project_dir)?;
+    let merged_features: Vec<String> = if !no_default_features
+        && !all_features
+        && specific_crates.is_empty()
+    {
+        if let Some(existing) = read_active_features_from_state(&user_manifest_path, &crate_name) {
+            let mut merged: Vec<String> = existing.into_iter().collect();
+            for f in with_features {
+                if !merged.contains(f) {
+                    merged.push(f.clone());
+                }
+            }
+            merged
+        } else {
+            with_features.to_vec()
+        }
+    } else {
+        with_features.to_vec()
+    };
+
     let resolved = resolve_add_crates(
         &bp_spec,
         &crate_name,
-        with_features,
+        &merged_features,
         no_default_features,
         all_features,
         specific_crates,
@@ -808,7 +834,6 @@ pub(crate) fn add_battery_pack(
     }
 
     // Step 3: Now write everything — build-dep, workspace deps, crate deps, metadata.
-    let user_manifest_path = find_user_manifest(project_dir)?;
     let user_manifest_content =
         std::fs::read_to_string(&user_manifest_path).context("Failed to read Cargo.toml")?;
     // [impl manifest.toml.preserve]

--- a/src/battery-pack/bphelper-cli/src/commands/tests.rs
+++ b/src/battery-pack/bphelper-cli/src/commands/tests.rs
@@ -2137,10 +2137,55 @@ fn add_preserves_existing_features_on_re_add() {
         .map(|v| v.as_str().unwrap())
         .collect();
 
-    // INVERTED: This asserts the BUGGY behavior. Once fixed, flip to assert
-    // that indicators IS present.
+    // After fix: indicators should be preserved from the first add.
     assert!(
-        !features.contains(&"indicators"),
-        "BUG: indicators should be preserved but is currently wiped"
+        features.contains(&"indicators"),
+        "existing features should be preserved on re-add"
+    );
+}
+
+/// `--no-default-features` signals a fresh selection, so existing features
+/// should NOT be merged in.
+#[test]
+fn add_no_default_features_does_not_merge_existing() {
+    let tmp = make_temp_project();
+
+    // First add: install with indicators (gives default + indicators)
+    add(
+        "fancy",
+        "fancy-battery-pack",
+        &["indicators"],
+        FeatureMode::Default,
+        &[],
+        tmp.path(),
+    );
+
+    // Second add: --no-default-features -F indicators (fresh selection)
+    add(
+        "fancy",
+        "fancy-battery-pack",
+        &["indicators"],
+        FeatureMode::NoDefault,
+        &[],
+        tmp.path(),
+    );
+
+    let state = read_bp_state_toml(&tmp);
+    let entry = extract_state_entry(&state, "fancy-battery-pack").expect("state entry exists");
+    let features: Vec<&str> = entry
+        .get("features")
+        .and_then(|v| v.as_array())
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+
+    assert!(
+        features.contains(&"indicators"),
+        "explicitly requested feature should be present"
+    );
+    assert!(
+        !features.contains(&"default"),
+        "--no-default-features should not merge in previously stored default"
     );
 }

--- a/src/battery-pack/bphelper-cli/src/commands/tests.rs
+++ b/src/battery-pack/bphelper-cli/src/commands/tests.rs
@@ -2081,3 +2081,66 @@ fn render_status_text_no_warnings_omits_sync_hint() {
     assert!(text.contains("all dependencies up to date"));
     assert!(!text.contains("cargo bp sync"));
 }
+
+// ============================================================================
+// cli.add.features — re-adding preserves existing features
+// ============================================================================
+
+/// Regression test: `cargo bp add fancy -F indicators` followed by
+/// `cargo bp add fancy -F default` should preserve the indicators feature
+/// in battery-pack.toml rather than wiping it.
+#[test]
+fn add_preserves_existing_features_on_re_add() {
+    let tmp = make_temp_project();
+
+    // First add: install with indicators (gives default + indicators)
+    add(
+        "fancy",
+        "fancy-battery-pack",
+        &["indicators"],
+        FeatureMode::Default,
+        &[],
+        tmp.path(),
+    );
+
+    // Verify initial state has both features
+    let state = read_bp_state_toml(&tmp);
+    let entry = extract_state_entry(&state, "fancy-battery-pack").expect("state entry exists");
+    let features: Vec<&str> = entry
+        .get("features")
+        .and_then(|v| v.as_array())
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(features.contains(&"default"));
+    assert!(features.contains(&"indicators"));
+
+    // Second add: re-add with only explicit "default" feature flag.
+    // BUG: this wipes the previously stored "indicators" feature.
+    add(
+        "fancy",
+        "fancy-battery-pack",
+        &["default"],
+        FeatureMode::Default,
+        &[],
+        tmp.path(),
+    );
+
+    let state = read_bp_state_toml(&tmp);
+    let entry = extract_state_entry(&state, "fancy-battery-pack").expect("state entry exists");
+    let features: Vec<&str> = entry
+        .get("features")
+        .and_then(|v| v.as_array())
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+
+    // INVERTED: This asserts the BUGGY behavior. Once fixed, flip to assert
+    // that indicators IS present.
+    assert!(
+        !features.contains(&"indicators"),
+        "BUG: indicators should be preserved but is currently wiped"
+    );
+}


### PR DESCRIPTION
AI: Code was AI-generated, reviewed by human.

### Summary

`cargo bp add foo -F bar` now merges `bar` into the previously stored feature set instead of replacing it. Explicit narrowing flags (`--no-default-features`, `--all-features`, specific crates) still start fresh.

### Testing

Two new unit tests: one verifying additive behavior on re-add, one verifying `--no-default-features` bypasses the merge.