### PR TITLE
`cargo bp add` templates

### DIFF
--- a/src/battery-pack/bphelper-cli/src/commands/mod.rs
+++ b/src/battery-pack/bphelper-cli/src/commands/mod.rs
@@ -11,9 +11,10 @@ use std::path::{Path, PathBuf};
 
 use crate::manifest::{
     add_dep_to_table, dep_kind_section, find_installed_bp_names, find_user_manifest,
-    find_workspace_manifest, read_active_features_for_project, read_managed_deps_for_project,
-    remove_battery_pack_state_entry, remove_deps_by_kind, should_upgrade_version,
-    sync_dep_in_table, write_battery_pack_state, write_deps_by_kind, write_workspace_refs_by_kind,
+    find_workspace_manifest, read_active_features_for_project, read_applied_templates_from_state,
+    read_managed_deps_for_project, record_applied_template, remove_battery_pack_state_entry,
+    remove_deps_by_kind, should_upgrade_version, sync_dep_in_table, write_battery_pack_state,
+    write_deps_by_kind, write_workspace_refs_by_kind,
 };
 use crate::registry::{
     CrateSource, InstalledPack, TemplateConfig, fetch_battery_pack_detail,
@@ -695,6 +696,10 @@ fn add_template(opts: AddTemplateOpts<'_>) -> Result<()> {
     };
     let results = crate::merge::apply_rendered_files(&files, &apply_opts)?;
     crate::merge::print_summary(&results);
+
+    // Record the applied template in battery-pack.toml.
+    let user_manifest_path = find_user_manifest(opts.project_dir)?;
+    record_applied_template(&user_manifest_path, &crate_name, opts.template)?;
 
     // Print post-merge hints if the template defines any.
     if !hints.is_empty() {
@@ -2250,12 +2255,16 @@ fn build_status_report(
                 ))
             });
 
+            let applied_templates =
+                read_applied_templates_from_state(&user_manifest_path, &pack.spec.name);
+
             cargo_bp_script::InstalledPackStatus::new(
                 &pack.short_name,
                 &pack.spec.name,
                 &pack.version,
             )
             .with_active_features(pack.active_features.iter().cloned())
+            .with_applied_templates(applied_templates)
             .with_warnings(warnings)
         })
         .collect();

--- a/src/battery-pack/bphelper-cli/src/commands/mod.rs
+++ b/src/battery-pack/bphelper-cli/src/commands/mod.rs
@@ -474,10 +474,15 @@ fn new_from_battery_pack(opts: NewFromBpOpts<'_>) -> Result<()> {
     let templates = parse_template_metadata(&manifest_content, &crate_name)?;
 
     // Resolve which template to use
-    let template_path = resolve_template(&templates, opts.template.as_deref(), opts.interactive)?;
+    let resolved_tmpl = resolve_template(&templates, opts.template.as_deref(), opts.interactive)?;
 
     // Generate the project from the crate directory
-    generate_from_path(new_opts, &resolved.dir, &template_path)
+    generate_from_path(
+        new_opts,
+        &resolved.dir,
+        &resolved_tmpl.name,
+        &resolved_tmpl.path,
+    )
 }
 
 /// Result of resolving which crates to add from a battery pack.
@@ -669,10 +674,10 @@ fn add_template(opts: AddTemplateOpts<'_>) -> Result<()> {
     let manifest_content = std::fs::read_to_string(&manifest_path)
         .with_context(|| format!("Failed to read {}", manifest_path.display()))?;
     let templates = parse_template_metadata(&manifest_content, &crate_name)?;
-    let template_path = resolve_template(&templates, Some(opts.template), opts.interactive)?;
+    let resolved_tmpl = resolve_template(&templates, Some(opts.template), opts.interactive)?;
 
     // Load post-merge hints before moving template_path.
-    let hints = crate::template_engine::load_template_hints(&crate_dir, &template_path);
+    let hints = crate::template_engine::load_template_hints(&crate_dir, &resolved_tmpl.path);
 
     // Infer project_name from the current Cargo.toml or directory name.
     let project_name = infer_project_name(opts.project_dir)?;
@@ -681,7 +686,7 @@ fn add_template(opts: AddTemplateOpts<'_>) -> Result<()> {
     let interactive_override = if opts.interactive { None } else { Some(false) };
     let render_opts = crate::template_engine::RenderOpts {
         crate_root: crate_dir,
-        template_path,
+        template_path: resolved_tmpl.path,
         project_name,
         defines: opts.defines,
         interactive_override,
@@ -699,7 +704,7 @@ fn add_template(opts: AddTemplateOpts<'_>) -> Result<()> {
 
     // Record the applied template in battery-pack.toml.
     let user_manifest_path = find_user_manifest(opts.project_dir)?;
-    record_applied_template(&user_manifest_path, &crate_name, opts.template)?;
+    record_applied_template(&user_manifest_path, &crate_name, &resolved_tmpl.name)?;
 
     // Print post-merge hints if the template defines any.
     if !hints.is_empty() {
@@ -1553,9 +1558,9 @@ fn generate_from_local(opts: NewOpts, local_path: &str, template: Option<String>
         .and_then(|s| s.to_str())
         .unwrap_or("unknown");
     let templates = parse_template_metadata(&manifest_content, crate_name)?;
-    let template_path = resolve_template(&templates, template.as_deref(), opts.interactive)?;
+    let resolved_tmpl = resolve_template(&templates, template.as_deref(), opts.interactive)?;
 
-    generate_from_path(opts, local_path, &template_path)
+    generate_from_path(opts, local_path, &resolved_tmpl.name, &resolved_tmpl.path)
 }
 
 /// Prompt for a project name if not provided.
@@ -1580,7 +1585,12 @@ fn ensure_battery_pack_suffix(name: String) -> String {
     }
 }
 
-fn generate_from_path(opts: NewOpts, crate_path: &Path, template_path: &str) -> Result<()> {
+fn generate_from_path(
+    opts: NewOpts,
+    crate_path: &Path,
+    template_name: &str,
+    template_path: &str,
+) -> Result<()> {
     let raw = prompt_project_name(opts.name)?;
     let project_name = if opts.battery_pack == "battery-pack" {
         ensure_battery_pack_suffix(raw)
@@ -1602,7 +1612,16 @@ fn generate_from_path(opts: NewOpts, crate_path: &Path, template_path: &str) -> 
         git_init: true,
     };
 
-    crate::template_engine::generate(gen_opts)?;
+    let project_dir = crate::template_engine::generate(gen_opts)?;
+
+    // Record the applied template in the new project's battery-pack.toml.
+    let user_manifest_path = project_dir.join("Cargo.toml");
+    if user_manifest_path.exists() {
+        let bp_name = resolve_crate_name(&opts.battery_pack);
+        if let Err(e) = record_applied_template(&user_manifest_path, &bp_name, template_name) {
+            eprintln!("warning: failed to record template in state: {e}");
+        }
+    }
 
     Ok(())
 }
@@ -1632,13 +1651,20 @@ fn parse_template_metadata(
     Ok(spec.templates)
 }
 
+/// Resolved template: the logical name and the filesystem path within the crate.
+#[derive(Debug)]
+pub(crate) struct ResolvedTemplate {
+    pub name: String,
+    pub path: String,
+}
+
 // [impl format.templates.selection]
 // [impl cli.new.template-select]
 pub(crate) fn resolve_template(
     templates: &BTreeMap<String, TemplateConfig>,
     requested: Option<&str>,
     interactive: bool,
-) -> Result<String> {
+) -> Result<ResolvedTemplate> {
     match requested {
         Some(name) => {
             let config = templates.get(name).ok_or_else(|| {
@@ -1649,14 +1675,23 @@ pub(crate) fn resolve_template(
                     available.join(", ")
                 )
             })?;
-            Ok(config.path.clone())
+            Ok(ResolvedTemplate {
+                name: name.to_string(),
+                path: config.path.clone(),
+            })
         }
         None => {
             if templates.len() == 1 {
-                let (_, config) = templates.iter().next().unwrap();
-                Ok(config.path.clone())
+                let (name, config) = templates.iter().next().unwrap();
+                Ok(ResolvedTemplate {
+                    name: name.clone(),
+                    path: config.path.clone(),
+                })
             } else if let Some(config) = templates.get("default") {
-                Ok(config.path.clone())
+                Ok(ResolvedTemplate {
+                    name: "default".to_string(),
+                    path: config.path.clone(),
+                })
             } else {
                 prompt_for_template(templates, interactive)
             }
@@ -1667,7 +1702,7 @@ pub(crate) fn resolve_template(
 fn prompt_for_template(
     templates: &BTreeMap<String, TemplateConfig>,
     interactive: bool,
-) -> Result<String> {
+) -> Result<ResolvedTemplate> {
     use dialoguer::{Select, theme::ColorfulTheme};
 
     // Build display items with descriptions
@@ -1700,12 +1735,15 @@ fn prompt_for_template(
         .interact()
         .context("Failed to select template")?;
 
-    // Get the selected template's path
-    let (_, config) = templates
+    // Get the selected template's name and path
+    let (name, config) = templates
         .iter()
         .nth(selection)
         .ok_or_else(|| anyhow::anyhow!("Invalid template selection"))?;
-    Ok(config.path.clone())
+    Ok(ResolvedTemplate {
+        name: name.clone(),
+        path: config.path.clone(),
+    })
 }
 
 // ============================================================================

--- a/src/battery-pack/bphelper-cli/src/commands/mod.rs
+++ b/src/battery-pack/bphelper-cli/src/commands/mod.rs
@@ -779,16 +779,20 @@ pub(crate) fn add_battery_pack(
         all_features,
         specific_crates,
     );
-    let (active_features, crates_to_sync) = match resolved {
+    let (active_features, crates_to_sync, selected_templates) = match resolved {
         ResolvedAdd::Crates {
             active_features,
             crates,
-        } => (active_features, crates),
+        } => (active_features, crates, Vec::new()),
         ResolvedAdd::Interactive if std::io::stdout().is_terminal() => {
             // Pre-select crates already in the project (edit mode)
             let pre_selected = compute_pre_selection(&bp_spec, project_dir);
             match pick_crates_interactive(&bp_spec, &pre_selected)? {
-                Some(result) => (result.active_features, result.crates),
+                Some(result) => (
+                    result.active_features,
+                    result.crates,
+                    result.selected_templates,
+                ),
                 None => {
                     println!("Cancelled.");
                     return Ok(());
@@ -798,136 +802,154 @@ pub(crate) fn add_battery_pack(
         ResolvedAdd::Interactive => {
             // Non-interactive fallback: use defaults
             let crates = bp_spec.resolve_crates(&["default"]);
-            (BTreeSet::from(["default".to_string()]), crates)
+            (BTreeSet::from(["default".to_string()]), crates, Vec::new())
         }
     };
 
-    if crates_to_sync.is_empty() {
-        println!("No crates selected.");
+    if crates_to_sync.is_empty() && selected_templates.is_empty() {
+        println!("No crates or templates selected.");
         return Ok(());
     }
 
     // Step 3: Now write everything — build-dep, workspace deps, crate deps, metadata.
-    let user_manifest_path = find_user_manifest(project_dir)?;
-    let user_manifest_content =
-        std::fs::read_to_string(&user_manifest_path).context("Failed to read Cargo.toml")?;
-    // [impl manifest.toml.preserve]
-    let mut user_doc: toml_edit::DocumentMut = user_manifest_content
-        .parse()
-        .context("Failed to parse Cargo.toml")?;
+    if !crates_to_sync.is_empty() {
+        let user_manifest_path = find_user_manifest(project_dir)?;
+        let user_manifest_content =
+            std::fs::read_to_string(&user_manifest_path).context("Failed to read Cargo.toml")?;
+        // [impl manifest.toml.preserve]
+        let mut user_doc: toml_edit::DocumentMut = user_manifest_content
+            .parse()
+            .context("Failed to parse Cargo.toml")?;
 
-    // [impl manifest.register.workspace-default]
-    let workspace_manifest = find_workspace_manifest(&user_manifest_path)?;
+        // [impl manifest.register.workspace-default]
+        let workspace_manifest = find_workspace_manifest(&user_manifest_path)?;
 
-    // [impl manifest.deps.workspace]
-    // Add crate dependencies + workspace deps (including the battery pack itself).
-    // Load workspace doc once; both deps and metadata are written to it before a
-    // single flush at the end (avoids a double read-modify-write).
-    let mut ws_doc: Option<toml_edit::DocumentMut> = if let Some(ref ws_path) = workspace_manifest {
-        let ws_content =
-            std::fs::read_to_string(ws_path).context("Failed to read workspace Cargo.toml")?;
-        Some(
-            ws_content
-                .parse()
-                .context("Failed to parse workspace Cargo.toml")?,
-        )
-    } else {
-        None
-    };
-
-    if let Some(ref mut doc) = ws_doc {
-        let ws_deps = doc["workspace"]["dependencies"]
-            .or_insert(toml_edit::Item::Table(toml_edit::Table::new()));
-        if let Some(ws_table) = ws_deps.as_table_mut() {
-            // Add the battery pack itself to workspace deps
-            if let Some(local_path) = path {
-                let mut dep = toml_edit::InlineTable::new();
-                dep.insert("path", toml_edit::Value::from(local_path));
-                ws_table.insert(
-                    &crate_name,
-                    toml_edit::Item::Value(toml_edit::Value::InlineTable(dep)),
-                );
+        // [impl manifest.deps.workspace]
+        // Add crate dependencies + workspace deps (including the battery pack itself).
+        // Load workspace doc once; both deps and metadata are written to it before a
+        // single flush at the end (avoids a double read-modify-write).
+        let mut ws_doc: Option<toml_edit::DocumentMut> =
+            if let Some(ref ws_path) = workspace_manifest {
+                let ws_content = std::fs::read_to_string(ws_path)
+                    .context("Failed to read workspace Cargo.toml")?;
+                Some(
+                    ws_content
+                        .parse()
+                        .context("Failed to parse workspace Cargo.toml")?,
+                )
             } else {
-                let version = bp_version
-                    .as_ref()
-                    .context("battery pack version not available (--path without workspace)")?;
-                ws_table.insert(&crate_name, toml_edit::value(version));
-            }
-            // Add the resolved crate dependencies
-            for (dep_name, dep_spec) in &crates_to_sync {
-                add_dep_to_table(ws_table, dep_name, dep_spec);
-            }
-        }
+                None
+            };
 
-        // [impl cli.add.dep-kind]
-        write_workspace_refs_by_kind(&mut user_doc, &crates_to_sync, false);
-    } else {
-        // [impl manifest.deps.no-workspace]
-        // [impl cli.add.dep-kind]
-        write_deps_by_kind(&mut user_doc, &crates_to_sync, false);
-    }
-
-    // Edit semantics: remove deselected crates from previous installation
-    let prev_managed =
-        read_managed_deps_for_project(&user_manifest_path, &user_manifest_content, &crate_name);
-    let new_crate_names: BTreeSet<String> = crates_to_sync.keys().cloned().collect();
-    let mut removed_count = 0;
-
-    if let Some(prev) = &prev_managed {
-        // Find crates that were previously managed but are no longer selected
-        let to_remove: BTreeMap<String, bphelper_manifest::CrateSpec> = prev
-            .iter()
-            .filter(|name| !new_crate_names.contains(name.as_str()))
-            .filter_map(|name| {
-                bp_spec
-                    .crates
-                    .get(name)
-                    .map(|spec| (name.clone(), spec.clone()))
-            })
-            .collect();
-
-        if !to_remove.is_empty() {
-            if let Some(ref mut doc) = ws_doc {
-                // Remove from workspace deps
-                let ws_deps = doc["workspace"]["dependencies"].as_table_mut();
-                if let Some(ws_table) = ws_deps {
-                    for name in to_remove.keys() {
-                        ws_table.remove(name);
-                    }
+        if let Some(ref mut doc) = ws_doc {
+            let ws_deps = doc["workspace"]["dependencies"]
+                .or_insert(toml_edit::Item::Table(toml_edit::Table::new()));
+            if let Some(ws_table) = ws_deps.as_table_mut() {
+                // Add the battery pack itself to workspace deps
+                if let Some(local_path) = path {
+                    let mut dep = toml_edit::InlineTable::new();
+                    dep.insert("path", toml_edit::Value::from(local_path));
+                    ws_table.insert(
+                        &crate_name,
+                        toml_edit::Item::Value(toml_edit::Value::InlineTable(dep)),
+                    );
+                } else {
+                    let version = bp_version
+                        .as_ref()
+                        .context("battery pack version not available (--path without workspace)")?;
+                    ws_table.insert(&crate_name, toml_edit::value(version));
+                }
+                // Add the resolved crate dependencies
+                for (dep_name, dep_spec) in &crates_to_sync {
+                    add_dep_to_table(ws_table, dep_name, dep_spec);
                 }
             }
-            removed_count = remove_deps_by_kind(&mut user_doc, &to_remove);
+
+            // [impl cli.add.dep-kind]
+            write_workspace_refs_by_kind(&mut user_doc, &crates_to_sync, false);
+        } else {
+            // [impl manifest.deps.no-workspace]
+            // [impl cli.add.dep-kind]
+            write_deps_by_kind(&mut user_doc, &crates_to_sync, false);
+        }
+
+        // Edit semantics: remove deselected crates from previous installation
+        let prev_managed =
+            read_managed_deps_for_project(&user_manifest_path, &user_manifest_content, &crate_name);
+        let new_crate_names: BTreeSet<String> = crates_to_sync.keys().cloned().collect();
+        let mut removed_count = 0;
+
+        if let Some(prev) = &prev_managed {
+            // Find crates that were previously managed but are no longer selected
+            let to_remove: BTreeMap<String, bphelper_manifest::CrateSpec> = prev
+                .iter()
+                .filter(|name| !new_crate_names.contains(name.as_str()))
+                .filter_map(|name| {
+                    bp_spec
+                        .crates
+                        .get(name)
+                        .map(|spec| (name.clone(), spec.clone()))
+                })
+                .collect();
+
+            if !to_remove.is_empty() {
+                if let Some(ref mut doc) = ws_doc {
+                    // Remove from workspace deps
+                    let ws_deps = doc["workspace"]["dependencies"].as_table_mut();
+                    if let Some(ws_table) = ws_deps {
+                        for name in to_remove.keys() {
+                            ws_table.remove(name);
+                        }
+                    }
+                }
+                removed_count = remove_deps_by_kind(&mut user_doc, &to_remove);
+            }
+        }
+
+        // Write workspace Cargo.toml once (deps combined)
+        if let (Some(ws_path), Some(doc)) = (&workspace_manifest, &ws_doc) {
+            // [impl manifest.toml.preserve]
+            std::fs::write(ws_path, doc.to_string())
+                .context("Failed to write workspace Cargo.toml")?;
+        }
+
+        // Write the final Cargo.toml
+        // [impl manifest.toml.preserve]
+        std::fs::write(&user_manifest_path, user_doc.to_string())
+            .context("Failed to write Cargo.toml")?;
+
+        write_battery_pack_state(
+            &user_manifest_path,
+            &crate_name,
+            &active_features,
+            &crates_to_sync,
+        )?;
+
+        println!(
+            "Added {} with {} crate(s)",
+            crate_name,
+            crates_to_sync.len()
+        );
+        for dep_name in crates_to_sync.keys() {
+            println!("  + {}", dep_name);
+        }
+        if removed_count > 0 {
+            println!("Removed {} deselected crate(s)", removed_count);
         }
     }
 
-    // Write workspace Cargo.toml once (deps combined)
-    if let (Some(ws_path), Some(doc)) = (&workspace_manifest, &ws_doc) {
-        // [impl manifest.toml.preserve]
-        std::fs::write(ws_path, doc.to_string()).context("Failed to write workspace Cargo.toml")?;
-    }
-
-    // Write the final Cargo.toml
-    // [impl manifest.toml.preserve]
-    std::fs::write(&user_manifest_path, user_doc.to_string())
-        .context("Failed to write Cargo.toml")?;
-
-    write_battery_pack_state(
-        &user_manifest_path,
-        &crate_name,
-        &active_features,
-        &crates_to_sync,
-    )?;
-
-    println!(
-        "Added {} with {} crate(s)",
-        crate_name,
-        crates_to_sync.len()
-    );
-    for dep_name in crates_to_sync.keys() {
-        println!("  + {}", dep_name);
-    }
-    if removed_count > 0 {
-        println!("Removed {} deselected crate(s)", removed_count);
+    // Step 4: Apply any selected templates.
+    for tmpl_name in &selected_templates {
+        add_template(AddTemplateOpts {
+            battery_pack: name,
+            template: tmpl_name,
+            path_override: path,
+            source,
+            project_dir,
+            defines: BTreeMap::new(),
+            overwrite: false,
+            interactive: std::io::stdout().is_terminal(),
+        })?;
     }
 
     Ok(())
@@ -1290,12 +1312,15 @@ pub(crate) struct PickerResult {
     pub crates: BTreeMap<String, bphelper_manifest::CrateSpec>,
     /// Which feature names are fully selected (for metadata recording).
     pub active_features: BTreeSet<String>,
+    /// Template names selected by the user for application.
+    pub selected_templates: Vec<String>,
 }
 
-/// An item in the picker — either a feature or an individual crate.
+/// An item in the picker — either a feature, an individual crate, or a template.
 enum PickerItem {
-    Feature(String), // feature name
-    Crate(String),   // crate name
+    Feature(String),  // feature name
+    Crate(String),    // crate name
+    Template(String), // template name
 }
 
 /// Show an interactive multi-select picker for choosing which crates to install.
@@ -1399,6 +1424,17 @@ fn pick_crates_interactive(
         items.push(PickerItem::Crate(crate_name.to_string()));
     }
 
+    // Templates shown last, unchecked by default.
+    for (tmpl_name, tmpl_spec) in &bp_spec.templates {
+        let desc = tmpl_spec
+            .description
+            .as_deref()
+            .unwrap_or("project template");
+        labels.push(format!("  ⎙ {} {}", tmpl_name, style(desc).dim()));
+        defaults.push(false);
+        items.push(PickerItem::Template(tmpl_name.clone()));
+    }
+
     // Show the picker
     println!();
     println!(
@@ -1419,9 +1455,10 @@ fn pick_crates_interactive(
         return Ok(None);
     };
 
-    // Determine which features and crates are selected
+    // Determine which features, crates, and templates are selected
     let selected_set: BTreeSet<usize> = selected_indices.into_iter().collect();
     let mut selected_crates: BTreeSet<String> = BTreeSet::new();
+    let mut selected_templates: Vec<String> = Vec::new();
 
     for (i, item) in items.iter().enumerate() {
         if !selected_set.contains(&i) {
@@ -1439,6 +1476,9 @@ fn pick_crates_interactive(
             }
             PickerItem::Crate(name) => {
                 selected_crates.insert(name.clone());
+            }
+            PickerItem::Template(name) => {
+                selected_templates.push(name.clone());
             }
         }
     }
@@ -1479,6 +1519,7 @@ fn pick_crates_interactive(
     Ok(Some(PickerResult {
         crates,
         active_features,
+        selected_templates,
     }))
 }
 

--- a/src/battery-pack/bphelper-cli/src/commands/tests.rs
+++ b/src/battery-pack/bphelper-cli/src/commands/tests.rs
@@ -123,7 +123,8 @@ fn resolve_template_single_template_uses_it() {
     );
 
     let result = super::resolve_template(&templates, None, true).unwrap();
-    assert_eq!(result, "templates/simple");
+    assert_eq!(result.name, "simple");
+    assert_eq!(result.path, "templates/simple");
 }
 
 // [verify cli.new.template-select]
@@ -147,7 +148,8 @@ fn resolve_template_picks_default_when_present() {
     );
 
     let result = super::resolve_template(&templates, None, true).unwrap();
-    assert_eq!(result, "templates/default");
+    assert_eq!(result.name, "default");
+    assert_eq!(result.path, "templates/default");
 }
 
 // [verify cli.new.template-select]
@@ -201,7 +203,8 @@ fn resolve_template_explicit_flag_overrides() {
     );
 
     let result = super::resolve_template(&templates, Some("advanced"), true).unwrap();
-    assert_eq!(result, "templates/advanced");
+    assert_eq!(result.name, "advanced");
+    assert_eq!(result.path, "templates/advanced");
 }
 
 // ============================================================================

--- a/src/battery-pack/bphelper-cli/src/manifest/mod.rs
+++ b/src/battery-pack/bphelper-cli/src/manifest/mod.rs
@@ -400,6 +400,12 @@ struct BatteryPackStateEntry {
     features: BTreeSet<String>,
     #[serde(rename = "managed-deps", default)]
     managed_deps: Vec<ManagedDepEntry>,
+    #[serde(
+        rename = "applied-templates",
+        default,
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    applied_templates: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -487,6 +493,21 @@ pub(crate) fn read_managed_deps_from_state(
     })
 }
 
+/// Read applied template names for a battery pack from `battery-pack.toml`.
+pub(crate) fn read_applied_templates_from_state(
+    user_manifest_path: &Path,
+    bp_name: &str,
+) -> Vec<String> {
+    let state_path = state_file_path(user_manifest_path);
+    let state = match read_state_file(&state_path) {
+        Ok(s) => s,
+        Err(_) => return Vec::new(),
+    };
+    state_entry_for(&state, bp_name)
+        .map(|entry| entry.applied_templates.clone())
+        .unwrap_or_default()
+}
+
 /// Read active features from a parsed TOML value at a given path prefix.
 ///
 /// `prefix` is `&["package", "metadata"]` for package metadata or
@@ -548,10 +569,16 @@ pub(crate) fn write_battery_pack_state(
         })
         .collect::<Vec<_>>();
 
+    // Preserve previously applied templates when only updating deps/features.
+    let prev_templates = state_entry_for(&state, bp_name)
+        .map(|e| e.applied_templates.clone())
+        .unwrap_or_default();
+
     let updated = BatteryPackStateEntry {
         name: short_name(bp_name).to_string(),
         features: normalized_feature_set(active_features),
         managed_deps,
+        applied_templates: prev_templates,
     };
 
     if let Some(entry) = state
@@ -562,6 +589,39 @@ pub(crate) fn write_battery_pack_state(
         *entry = updated;
     } else {
         state.battery_pack.push(updated);
+    }
+
+    write_state_file(&state_path, &state)?;
+    Ok(())
+}
+
+/// Record that a template was applied for a battery pack.
+///
+/// Appends the template name if not already present.
+pub(crate) fn record_applied_template(
+    user_manifest_path: &Path,
+    bp_name: &str,
+    template_name: &str,
+) -> Result<()> {
+    let state_path = state_file_path(user_manifest_path);
+    let mut state = read_state_file(&state_path)?;
+
+    if let Some(entry) = state
+        .battery_pack
+        .iter_mut()
+        .find(|entry| state_name_matches(&entry.name, bp_name))
+    {
+        if !entry.applied_templates.contains(&template_name.to_string()) {
+            entry.applied_templates.push(template_name.to_string());
+        }
+    } else {
+        // No existing entry for this pack — create a minimal one.
+        state.battery_pack.push(BatteryPackStateEntry {
+            name: short_name(bp_name).to_string(),
+            features: default_feature_set(),
+            managed_deps: Vec::new(),
+            applied_templates: vec![template_name.to_string()],
+        });
     }
 
     write_state_file(&state_path, &state)?;

--- a/src/cargo-bp-script/src/status.rs
+++ b/src/cargo-bp-script/src/status.rs
@@ -78,6 +78,10 @@ pub struct InstalledPackStatus {
     /// Sorted alphabetically.
     pub active_features: Vec<String>,
 
+    /// Templates that have been applied from this battery pack.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub applied_templates: Vec<String>,
+
     /// Per-dependency warnings for this pack — each entry indicates
     /// a dependency whose user-side version is older than what the
     /// battery pack recommends.
@@ -158,6 +162,7 @@ impl InstalledPackStatus {
             name: name.into(),
             version: version.into(),
             active_features: Vec::new(),
+            applied_templates: Vec::new(),
             warnings: Vec::new(),
         }
     }
@@ -176,6 +181,17 @@ impl InstalledPackStatus {
     {
         self.active_features
             .extend(features.into_iter().map(Into::into));
+        self
+    }
+
+    /// Append applied template names.
+    pub fn with_applied_templates<I, S>(mut self, templates: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.applied_templates
+            .extend(templates.into_iter().map(Into::into));
         self
     }
 

--- a/src/cargo-bp/tests/add_template.rs
+++ b/src/cargo-bp/tests/add_template.rs
@@ -505,3 +505,52 @@ fn add_template_twice_does_not_duplicate_in_state() {
         "should contain exactly one entry:\n{state_content}"
     );
 }
+
+#[test]
+fn new_from_template_records_in_state() {
+    let tmp = tempfile::tempdir().unwrap();
+    let fixture = fixtures_dir().join("fancy-battery-pack");
+
+    // Generate a new project from the fancy battery pack's "default" template.
+    let output = cargo_bp()
+        .args([
+            "bp",
+            "new",
+            "fancy",
+            "--name",
+            "my-app",
+            "--path",
+            &fixture.to_string_lossy(),
+            "-t",
+            "default",
+        ])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run cargo-bp");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // The generated project should have a battery-pack.toml recording the template.
+    let project_dir = tmp.path().join("my-app");
+    assert!(project_dir.join("Cargo.toml").exists());
+
+    let state_path = project_dir.join("battery-pack.toml");
+    assert!(
+        state_path.exists(),
+        "battery-pack.toml should be created in the new project"
+    );
+
+    let state_content = std::fs::read_to_string(&state_path).unwrap();
+    assert!(
+        state_content.contains(r#"applied-templates = ["default"]"#),
+        "state file should record the template used:\n{state_content}"
+    );
+    assert!(
+        state_content.contains(r#"name = "fancy""#),
+        "state file should reference the battery pack:\n{state_content}"
+    );
+}

--- a/src/cargo-bp/tests/add_template.rs
+++ b/src/cargo-bp/tests/add_template.rs
@@ -383,3 +383,125 @@ fn add_template_registry_download_keeps_tempdir_alive() {
         String::from_utf8_lossy(&output.stderr)
     );
 }
+
+#[test]
+fn add_template_records_in_state_and_shows_in_status() {
+    let tmp = tempfile::tempdir().unwrap();
+
+    let fixture = fixtures_dir().join("fancy-battery-pack");
+
+    // Create a project that has fancy-battery-pack as a build-dep so status can find it.
+    std::fs::write(
+        tmp.path().join("Cargo.toml"),
+        "[package]\nname = \"my-app\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[dependencies]\nserde = \"1\"\n\n[build-dependencies]\nfancy-battery-pack = \"0.2.0\"\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(tmp.path().join("src")).unwrap();
+    std::fs::write(tmp.path().join("src/main.rs"), "fn main() {}\n").unwrap();
+
+    // Apply a template.
+    let output = cargo_bp()
+        .args([
+            "bp",
+            "add",
+            "fancy",
+            "-t",
+            "default",
+            "--path",
+            &fixture.to_string_lossy(),
+            "-N",
+        ])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run cargo-bp");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Verify battery-pack.toml records the applied template.
+    let state_content = std::fs::read_to_string(tmp.path().join("battery-pack.toml")).unwrap();
+    assert!(
+        state_content.contains("applied-templates"),
+        "state file should contain applied-templates section:\n{state_content}"
+    );
+    assert!(
+        state_content.contains(r#"applied-templates = ["default"]"#),
+        "state file should record the 'default' template:\n{state_content}"
+    );
+
+    // Verify status --json includes the applied template.
+    let status_output = cargo_bp()
+        .args([
+            "bp",
+            "status",
+            "--json",
+            "--path",
+            &fixture.to_string_lossy(),
+        ])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run cargo-bp");
+
+    assert!(
+        status_output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&status_output.stderr)
+    );
+
+    let report: serde_json::Value =
+        serde_json::from_slice(&status_output.stdout).expect("valid JSON from status");
+    let pack = &report["packs"][0];
+    assert_eq!(
+        pack["applied_templates"],
+        serde_json::json!(["default"]),
+        "status JSON should include the applied template"
+    );
+}
+
+#[test]
+fn add_template_twice_does_not_duplicate_in_state() {
+    let tmp = tempfile::tempdir().unwrap();
+    create_existing_project(tmp.path());
+
+    let fixture = fixtures_dir().join("fancy-battery-pack");
+
+    // Apply the same template twice.
+    for _ in 0..2 {
+        let output = cargo_bp()
+            .args([
+                "bp",
+                "add",
+                "fancy",
+                "-t",
+                "default",
+                "--path",
+                &fixture.to_string_lossy(),
+                "-N",
+                "--overwrite",
+            ])
+            .current_dir(tmp.path())
+            .output()
+            .expect("failed to run cargo-bp");
+
+        assert!(
+            output.status.success(),
+            "stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    // Verify applied-templates list contains exactly one entry.
+    let state_content = std::fs::read_to_string(tmp.path().join("battery-pack.toml")).unwrap();
+    let count = state_content.matches("applied-templates").count();
+    assert_eq!(
+        count, 1,
+        "applied-templates should appear once in state, found {count}:\n{state_content}"
+    );
+    assert!(
+        state_content.contains(r#"applied-templates = ["default"]"#),
+        "should contain exactly one entry:\n{state_content}"
+    );
+}


### PR DESCRIPTION
Two changes: 

(a) `cargo bp add` will show templates now
(b) we track templates that have been "added" to a space so they can appear "checked"
(c) when instantiating with a template, we record the template in the generated project state