### PR TITLE
Add UI 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,6 +481,7 @@ dependencies = [
  "ratatui",
  "regex",
  "reqwest",
+ "sectioned-picker",
  "semver",
  "serde",
  "serde_json",
@@ -3792,6 +3793,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sectioned-picker"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "crossterm 0.28.1",
+ "ratatui",
+ "snapbox",
+]
 
 [[package]]
 name = "security-framework"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "src/battery-pack/bphelper-build",
     "src/battery-pack/bphelper-cli",
     "src/battery-pack/bphelper-manifest",
+    "src/sectioned-picker",
 	# --- battery packs
     "battery-packs/cli-battery-pack",
     "battery-packs/ci-battery-pack",

--- a/src/battery-pack/bphelper-cli/Cargo.toml
+++ b/src/battery-pack/bphelper-cli/Cargo.toml
@@ -28,6 +28,7 @@ urlencoding = "2"
 ratatui = "0.30"
 crossterm = "0.28"
 open = "5"
+sectioned-picker = { path = "../../sectioned-picker" }
 dialoguer = "0.11"
 regex = "1"
 syn = { version = "2", features = ["full"] }

--- a/src/battery-pack/bphelper-cli/src/commands.rs
+++ b/src/battery-pack/bphelper-cli/src/commands.rs
@@ -13,9 +13,9 @@ use std::path::{Path, PathBuf};
 use crate::manifest::{
     add_dep_to_table, dep_kind_section, find_installed_bp_names, find_user_manifest,
     find_workspace_manifest, read_active_features_for_project, read_active_features_from_state,
-    read_managed_deps_for_project, remove_battery_pack_state_entry, remove_deps_by_kind,
-    should_upgrade_version, sync_dep_in_table, write_battery_pack_state, write_deps_by_kind,
-    write_workspace_refs_by_kind,
+    read_applied_templates_from_state, read_managed_deps_for_project, record_applied_template,
+    remove_battery_pack_state_entry, remove_deps_by_kind, should_upgrade_version,
+    sync_dep_in_table, write_battery_pack_state, write_deps_by_kind, write_workspace_refs_by_kind,
 };
 use crate::registry::{
     CrateSource, InstalledPack, TemplateConfig, fetch_battery_pack_detail,
@@ -695,6 +695,10 @@ fn add_template(opts: AddTemplateOpts<'_>) -> Result<()> {
     };
     let results = crate::merge::apply_rendered_files(&files, &apply_opts)?;
     crate::merge::print_summary(&results);
+
+    // Record the applied template in battery-pack.toml.
+    let user_manifest_path = find_user_manifest(opts.project_dir)?;
+    record_applied_template(&user_manifest_path, &crate_name, opts.template)?;
 
     // Print post-merge hints if the template defines any.
     if !hints.is_empty() {
@@ -2344,12 +2348,16 @@ fn build_status_report(
                 bphelper_manifest::ActiveFeatures::Subset(set) => set.iter().cloned().collect(),
             };
 
+            let applied_templates =
+                read_applied_templates_from_state(&user_manifest_path, &pack.spec.name);
+
             cargo_bp_script::InstalledPackStatus::new(
                 &pack.short_name,
                 &pack.spec.name,
                 &pack.version,
             )
             .with_active_features(feature_strings)
+            .with_applied_templates(applied_templates)
             .with_warnings(warnings)
         })
         .collect();

--- a/src/battery-pack/bphelper-cli/src/commands.rs
+++ b/src/battery-pack/bphelper-cli/src/commands.rs
@@ -1388,35 +1388,27 @@ pub(crate) struct PickerResult {
     pub selected_templates: Vec<String>,
 }
 
-/// An item in the picker — either a feature, an individual crate, or a template.
-enum PickerItem {
-    Feature(String),  // feature name
-    Crate(String),    // crate name
-    Template(String), // template name
-}
-
 /// Show an interactive multi-select picker for choosing which crates to install.
 ///
-/// Features are listed first, then individual crates. `pre_selected` contains
-/// crate names already present in the project (for edit mode); when empty,
-/// the pack's default feature set is used for initial selection.
+/// Features are listed first, then individual crates, then actions (templates).
+/// `pre_selected` contains crate names already present in the project (for edit
+/// mode); when empty, the pack's default feature set is used for initial selection.
 ///
 /// Returns `None` if the user cancels.
 fn pick_crates_interactive(
     bp_spec: &bphelper_manifest::BatteryPackSpec,
     pre_selected: &BTreeSet<String>,
 ) -> Result<Option<PickerResult>> {
-    use console::style;
-    use dialoguer::MultiSelect;
+    use sectioned_picker::{PickerOutcome, Section, SectionItem, run_picker};
 
-    // Collect non-default features with their member crates
+    // Collect non-default features with their member crates.
     let features: Vec<(&String, &BTreeSet<bphelper_manifest::FeatureRef>)> = bp_spec
         .features
         .iter()
         .filter(|(name, _)| name.as_str() != "default")
         .collect();
 
-    // Collect all visible crates
+    // Collect all visible crates.
     let visible_crates: Vec<(&String, &bphelper_manifest::CrateSpec)> = bp_spec
         .crates
         .iter()
@@ -1438,120 +1430,141 @@ fn pick_crates_interactive(
         BTreeSet::new()
     };
 
-    // Build picker items: features first, then crates
-    let mut items: Vec<PickerItem> = Vec::new();
-    let mut labels: Vec<String> = Vec::new();
-    let mut defaults: Vec<bool> = Vec::new();
+    // Build sections for the picker.
+    let mut sections: Vec<Section> = Vec::new();
 
-    for (feat_name, feat_crates) in &features {
-        let member_list = feat_crates
+    // -- Features section --
+    if !features.is_empty() {
+        let items = features
             .iter()
-            .map(|fref| fref.dep_name())
-            .filter(|c| !bp_spec.is_hidden(c))
-            .collect::<Vec<_>>()
-            .join(", ");
-        labels.push(format!(
-            "✦ {} {}",
-            feat_name,
-            style(format!("[{}]", member_list)).dim()
-        ));
-        let checked = if use_defaults {
-            // Feature is checked if all its visible members are in defaults
-            feat_crates
-                .iter()
-                .map(|fref| fref.dep_name())
-                .filter(|c| !bp_spec.is_hidden(c))
-                .all(|c| default_crates.contains(c))
-        } else {
-            // Feature is checked if all its visible members are pre-selected
-            feat_crates
-                .iter()
-                .map(|fref| fref.dep_name())
-                .filter(|c| !bp_spec.is_hidden(c))
-                .all(|c| pre_selected.contains(c))
-        };
-        defaults.push(checked);
-        items.push(PickerItem::Feature(feat_name.to_string()));
-    }
-
-    for (crate_name, spec) in &visible_crates {
-        let version_info = if spec.features.is_empty() {
-            format!("({})", spec.version)
-        } else {
-            format!(
-                "({}, features: {})",
-                spec.version,
-                spec.features
+            .map(|(feat_name, feat_crates)| {
+                let member_list = feat_crates
                     .iter()
-                    .map(|s| s.as_str())
+                    .map(|fref| fref.dep_name())
+                    .filter(|c| !bp_spec.is_hidden(c))
                     .collect::<Vec<_>>()
-                    .join(", ")
-            )
-        };
-        labels.push(format!("  {} {}", crate_name, style(&version_info).dim()));
-        let checked = if use_defaults {
-            default_crates.contains(crate_name.as_str())
-        } else {
-            pre_selected.contains(crate_name.as_str())
-        };
-        defaults.push(checked);
-        items.push(PickerItem::Crate(crate_name.to_string()));
+                    .join(", ");
+                let checked = if use_defaults {
+                    feat_crates
+                        .iter()
+                        .map(|fref| fref.dep_name())
+                        .filter(|c| !bp_spec.is_hidden(c))
+                        .all(|c| default_crates.contains(c))
+                } else {
+                    feat_crates
+                        .iter()
+                        .map(|fref| fref.dep_name())
+                        .filter(|c| !bp_spec.is_hidden(c))
+                        .all(|c| pre_selected.contains(c))
+                };
+                SectionItem {
+                    label: format!("✦ {} [{}]", feat_name, member_list),
+                    checked,
+                }
+            })
+            .collect();
+        sections.push(Section {
+            title: "Features:".to_string(),
+            items,
+        });
     }
 
-    // Templates shown last, unchecked by default.
-    for (tmpl_name, tmpl_spec) in &bp_spec.templates {
-        let desc = tmpl_spec
-            .description
-            .as_deref()
-            .unwrap_or("project template");
-        labels.push(format!("  ⎙ {} {}", tmpl_name, style(desc).dim()));
-        defaults.push(false);
-        items.push(PickerItem::Template(tmpl_name.clone()));
+    // -- Dependencies section --
+    let dep_items = visible_crates
+        .iter()
+        .map(|(crate_name, spec)| {
+            let version_info = if spec.features.is_empty() {
+                format!("({})", spec.version)
+            } else {
+                format!(
+                    "({}, features: {})",
+                    spec.version,
+                    spec.features
+                        .iter()
+                        .map(|s| s.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            };
+            let checked = if use_defaults {
+                default_crates.contains(crate_name.as_str())
+            } else {
+                pre_selected.contains(crate_name.as_str())
+            };
+            SectionItem {
+                label: format!("{} {}", crate_name, version_info),
+                checked,
+            }
+        })
+        .collect();
+    sections.push(Section {
+        title: "Dependencies:".to_string(),
+        items: dep_items,
+    });
+
+    // -- Actions section --
+    if !bp_spec.templates.is_empty() {
+        let items = bp_spec
+            .templates
+            .keys()
+            .map(|tmpl_name| SectionItem {
+                label: format!("Add `{}` template", tmpl_name),
+                checked: false,
+            })
+            .collect();
+        sections.push(Section {
+            title: "Actions:".to_string(),
+            items,
+        });
     }
 
-    // Show the picker
-    println!();
-    println!(
-        "  {} v{}",
-        style(&bp_spec.name).green().bold(),
-        style(&bp_spec.version).dim()
-    );
-    println!();
+    // Run the picker.
+    let title = format!("{} v{}", bp_spec.name, bp_spec.version);
+    let outcome = run_picker(&title, sections, Vec::new())?;
 
-    let selections = MultiSelect::new()
-        .with_prompt("Select features and crates")
-        .items(&labels)
-        .defaults(&defaults)
-        .interact_opt()
-        .context("Failed to show crate picker")?;
-
-    let Some(selected_indices) = selections else {
-        return Ok(None);
+    let section_results = match outcome {
+        PickerOutcome::Confirmed(results) => results,
+        PickerOutcome::Cancelled => return Ok(None),
     };
 
-    // Split the picker selection into feature names, direct crate names, and templates.
-    let selected_set: BTreeSet<usize> = selected_indices.into_iter().collect();
-    let mut picked_features = Vec::new();
-    let mut picked_crates = BTreeSet::new();
+    // Interpret the results by section.
+    let mut section_iter = section_results.into_iter();
+    let mut picked_features: Vec<String> = Vec::new();
+    let mut picked_crates: BTreeSet<String> = BTreeSet::new();
     let mut selected_templates: Vec<String> = Vec::new();
 
-    for (index, item) in items.iter().enumerate() {
-        if !selected_set.contains(&index) {
-            continue;
-        }
-
-        match item {
-            PickerItem::Feature(name) => picked_features.push(name.clone()),
-            PickerItem::Crate(name) => {
-                picked_crates.insert(name.clone());
-            }
-            PickerItem::Template(name) => {
-                selected_templates.push(name.clone());
+    // Features section (if present).
+    if !features.is_empty() {
+        if let Some(feature_checks) = section_iter.next() {
+            for (checked, (feat_name, _)) in feature_checks.iter().zip(features.iter()) {
+                if *checked {
+                    picked_features.push(feat_name.to_string());
+                }
             }
         }
     }
 
-    // Route picked features through the main resolver so per-dep features (`serde/derive`)
+    // Dependencies section.
+    if let Some(dep_checks) = section_iter.next() {
+        for (checked, (crate_name, _)) in dep_checks.iter().zip(visible_crates.iter()) {
+            if *checked {
+                picked_crates.insert(crate_name.to_string());
+            }
+        }
+    }
+
+    // Actions section (if present).
+    if !bp_spec.templates.is_empty() {
+        if let Some(action_checks) = section_iter.next() {
+            for (checked, tmpl_name) in action_checks.iter().zip(bp_spec.templates.keys()) {
+                if *checked {
+                    selected_templates.push(tmpl_name.clone());
+                }
+            }
+        }
+    }
+
+    // Route picked features through the main resolver so per-dep features (`serde/derive`),
     // weak refs (`serde?/derive`), and nested refs (`bundle = ["fancy"]`) reach the
     // result with correct CrateSpec.features.
     let feature_strs = picked_features
@@ -1565,7 +1578,7 @@ fn pick_crates_interactive(
         bp_spec.resolve_crates(&feature_strs)
     };
 
-    // Layer in directly-picked crates (their declared spec -- picked by name, not via
+    // Layer in directly-picked crates (their declared spec, picked by name, not via
     // a feature gate, so no per-dep feature accumulation).
     for name in &picked_crates {
         if bp_spec.is_hidden(name) {

--- a/src/battery-pack/bphelper-cli/src/commands.rs
+++ b/src/battery-pack/bphelper-cli/src/commands.rs
@@ -828,7 +828,12 @@ pub(crate) fn add_battery_pack(
         ResolvedAdd::Interactive if std::io::stdout().is_terminal() => {
             // Pre-select crates already in the project (edit mode)
             let pre_selected = compute_pre_selection(&bp_spec, project_dir);
-            match pick_crates_interactive(&bp_spec, &pre_selected)? {
+            let preview_ctx = Some(PickerPreviewContext {
+                battery_pack: crate_name.clone(),
+                path: path.map(|s| s.to_string()),
+                source: source.clone(),
+            });
+            match pick_crates_interactive(&bp_spec, &pre_selected, preview_ctx)? {
                 Some(result) => (
                     result.active_features,
                     result.crates,
@@ -945,38 +950,6 @@ pub(crate) fn add_battery_pack(
                 removed_count = remove_deps_by_kind(&mut user_doc, &to_remove);
             }
         }
-
-        // Write workspace Cargo.toml once (deps combined)
-        if let (Some(ws_path), Some(doc)) = (&workspace_manifest, &ws_doc) {
-            // [impl manifest.toml.preserve]
-            std::fs::write(ws_path, doc.to_string())
-                .context("Failed to write workspace Cargo.toml")?;
-        }
-
-        // Write the final Cargo.toml
-        // [impl manifest.toml.preserve]
-        std::fs::write(&user_manifest_path, user_doc.to_string())
-            .context("Failed to write Cargo.toml")?;
-
-        write_battery_pack_state(
-            &user_manifest_path,
-            &crate_name,
-            &active_features,
-            &crates_to_sync,
-        )?;
-
-        println!(
-            "Added {} with {} crate(s)",
-            crate_name,
-            crates_to_sync.len()
-        );
-        for dep_name in crates_to_sync.keys() {
-            println!("  + {}", dep_name);
-        }
-        if removed_count > 0 {
-            println!("Removed {} deselected crate(s)", removed_count);
-        }
-    }
 
         // Write workspace Cargo.toml once (deps combined)
         if let (Some(ws_path), Some(doc)) = (&workspace_manifest, &ws_doc) {
@@ -1388,6 +1361,13 @@ pub(crate) struct PickerResult {
     pub selected_templates: Vec<String>,
 }
 
+/// Context needed for template preview in the interactive picker.
+struct PickerPreviewContext {
+    battery_pack: String,
+    path: Option<String>,
+    source: CrateSource,
+}
+
 /// Show an interactive multi-select picker for choosing which crates to install.
 ///
 /// Features are listed first, then individual crates, then actions (templates).
@@ -1398,8 +1378,9 @@ pub(crate) struct PickerResult {
 fn pick_crates_interactive(
     bp_spec: &bphelper_manifest::BatteryPackSpec,
     pre_selected: &BTreeSet<String>,
+    preview_ctx: Option<PickerPreviewContext>,
 ) -> Result<Option<PickerResult>> {
-    use sectioned_picker::{PickerOutcome, Section, SectionItem, run_picker};
+    use sectioned_picker::{PickerAction, PickerOutcome, Section, SectionItem, run_picker};
 
     // Collect non-default features with their member crates.
     let features: Vec<(&String, &BTreeSet<bphelper_manifest::FeatureRef>)> = bp_spec
@@ -1506,10 +1487,16 @@ fn pick_crates_interactive(
     if !bp_spec.templates.is_empty() {
         let items = bp_spec
             .templates
-            .keys()
-            .map(|tmpl_name| SectionItem {
-                label: format!("Add `{}` template", tmpl_name),
-                checked: false,
+            .iter()
+            .map(|(tmpl_name, tmpl_spec)| {
+                let label = match &tmpl_spec.description {
+                    Some(desc) => format!("Add `{}` template — {}", tmpl_name, desc),
+                    None => format!("Add `{}` template", tmpl_name),
+                };
+                SectionItem {
+                    label,
+                    checked: false,
+                }
             })
             .collect();
         sections.push(Section {
@@ -1518,9 +1505,73 @@ fn pick_crates_interactive(
         });
     }
 
+    // Build preview action: press 'p' to preview templates.
+    let has_features = !features.is_empty();
+    let has_templates = !bp_spec.templates.is_empty();
+    let template_names: Vec<String> = bp_spec.templates.keys().cloned().collect();
+    let template_paths: Vec<String> = bp_spec.templates.values().map(|t| t.path.clone()).collect();
+
+    let mut actions: Vec<PickerAction<'_>> = Vec::new();
+    if let Some(ref ctx) = preview_ctx
+        && has_templates
+    {
+        let battery_pack = ctx.battery_pack.clone();
+        let path = ctx.path.clone();
+        let source = ctx.source.clone();
+        let tmpl_paths = template_paths.clone();
+        let tmpl_names = template_names.clone();
+
+        // Determine the section index for Actions (depends on whether features exist).
+        let actions_section_idx = if has_features { 2 } else { 1 };
+
+        actions.push(PickerAction {
+            key: 'p',
+            label: "Preview",
+            handler: Box::new(move |ctx: &mut sectioned_picker::ActionContext<'_>| {
+                // Only handle preview for the Actions section.
+                if ctx.section() != actions_section_idx {
+                    return;
+                }
+
+                let Some(template_path) = tmpl_paths.get(ctx.item()) else {
+                    return;
+                };
+                let template_name = tmpl_names
+                    .get(ctx.item())
+                    .map(|s| s.as_str())
+                    .unwrap_or("template");
+
+                // Resolve crate directory and render the template preview.
+                let content = match crate::registry::resolve_crate_dir(
+                    &battery_pack,
+                    path.as_deref(),
+                    &source,
+                ) {
+                    Ok(resolved) => {
+                        let opts = crate::template_engine::RenderOpts {
+                            crate_root: resolved.dir,
+                            template_path: template_path.clone(),
+                            project_name: "my-project".to_string(),
+                            defines: std::collections::BTreeMap::new(),
+                            interactive_override: Some(false),
+                        };
+                        match crate::template_engine::preview(opts) {
+                            Ok(files) => crate::tui::highlight_preview(&files),
+                            Err(e) => ratatui::text::Text::from(format!("Preview error: {e}")),
+                        }
+                    }
+                    Err(e) => ratatui::text::Text::from(format!("Preview unavailable: {e:#}")),
+                };
+
+                let title = format!("Preview: {}", template_name);
+                crate::tui::show_preview(ctx.terminal(), &title, content);
+            }),
+        });
+    }
+
     // Run the picker.
     let title = format!("{} v{}", bp_spec.name, bp_spec.version);
-    let outcome = run_picker(&title, sections, Vec::new())?;
+    let outcome = run_picker(&title, sections, actions)?;
 
     let section_results = match outcome {
         PickerOutcome::Confirmed(results) => results,
@@ -1534,12 +1585,12 @@ fn pick_crates_interactive(
     let mut selected_templates: Vec<String> = Vec::new();
 
     // Features section (if present).
-    if !features.is_empty() {
-        if let Some(feature_checks) = section_iter.next() {
-            for (checked, (feat_name, _)) in feature_checks.iter().zip(features.iter()) {
-                if *checked {
-                    picked_features.push(feat_name.to_string());
-                }
+    if !features.is_empty()
+        && let Some(feature_checks) = section_iter.next()
+    {
+        for (checked, (feat_name, _)) in feature_checks.iter().zip(features.iter()) {
+            if *checked {
+                picked_features.push(feat_name.to_string());
             }
         }
     }
@@ -1554,12 +1605,12 @@ fn pick_crates_interactive(
     }
 
     // Actions section (if present).
-    if !bp_spec.templates.is_empty() {
-        if let Some(action_checks) = section_iter.next() {
-            for (checked, tmpl_name) in action_checks.iter().zip(bp_spec.templates.keys()) {
-                if *checked {
-                    selected_templates.push(tmpl_name.clone());
-                }
+    if !bp_spec.templates.is_empty()
+        && let Some(action_checks) = section_iter.next()
+    {
+        for (checked, tmpl_name) in action_checks.iter().zip(bp_spec.templates.keys()) {
+            if *checked {
+                selected_templates.push(tmpl_name.clone());
             }
         }
     }

--- a/src/battery-pack/bphelper-cli/src/commands.rs
+++ b/src/battery-pack/bphelper-cli/src/commands.rs
@@ -811,16 +811,20 @@ pub(crate) fn add_battery_pack(
         all_features,
         specific_crates,
     );
-    let (active_features, crates_to_sync) = match resolved {
+    let (active_features, crates_to_sync, selected_templates) = match resolved {
         ResolvedAdd::Crates {
             active_features,
             crates,
-        } => (active_features, crates),
+        } => (active_features, crates, Vec::new()),
         ResolvedAdd::Interactive if std::io::stdout().is_terminal() => {
             // Pre-select crates already in the project (edit mode)
             let pre_selected = compute_pre_selection(&bp_spec, project_dir);
             match pick_crates_interactive(&bp_spec, &pre_selected)? {
-                Some(result) => (result.active_features, result.crates),
+                Some(result) => (
+                    result.active_features,
+                    result.crates,
+                    result.selected_templates,
+                ),
                 None => {
                     println!("Cancelled.");
                     return Ok(());
@@ -830,135 +834,185 @@ pub(crate) fn add_battery_pack(
         ResolvedAdd::Interactive => {
             // Non-interactive fallback: use defaults
             let crates = bp_spec.resolve_crates(&["default"]);
-            (BTreeSet::from(["default".to_string()]), crates)
+            (BTreeSet::from(["default".to_string()]), crates, Vec::new())
         }
     };
 
-    if crates_to_sync.is_empty() {
-        println!("No crates selected.");
+    if crates_to_sync.is_empty() && selected_templates.is_empty() {
+        println!("No crates or templates selected.");
         return Ok(());
     }
 
     // Step 3: Now write everything — build-dep, workspace deps, crate deps, metadata.
-    let user_manifest_content =
-        std::fs::read_to_string(&user_manifest_path).context("Failed to read Cargo.toml")?;
-    // [impl manifest.toml.preserve]
-    let mut user_doc: toml_edit::DocumentMut = user_manifest_content
-        .parse()
-        .context("Failed to parse Cargo.toml")?;
+    if !crates_to_sync.is_empty() {
+        let user_manifest_content =
+            std::fs::read_to_string(&user_manifest_path).context("Failed to read Cargo.toml")?;
+        // [impl manifest.toml.preserve]
+        let mut user_doc: toml_edit::DocumentMut = user_manifest_content
+            .parse()
+            .context("Failed to parse Cargo.toml")?;
 
-    // [impl manifest.register.workspace-default]
-    let workspace_manifest = find_workspace_manifest(&user_manifest_path)?;
+        // [impl manifest.register.workspace-default]
+        let workspace_manifest = find_workspace_manifest(&user_manifest_path)?;
 
-    // [impl manifest.deps.workspace]
-    // Add crate dependencies + workspace deps (including the battery pack itself).
-    // Load workspace doc once; both deps and metadata are written to it before a
-    // single flush at the end (avoids a double read-modify-write).
-    let mut ws_doc: Option<toml_edit::DocumentMut> = if let Some(ref ws_path) = workspace_manifest {
-        let ws_content =
-            std::fs::read_to_string(ws_path).context("Failed to read workspace Cargo.toml")?;
-        Some(
-            ws_content
-                .parse()
-                .context("Failed to parse workspace Cargo.toml")?,
-        )
-    } else {
-        None
-    };
-
-    if let Some(ref mut doc) = ws_doc {
-        let ws_deps = doc["workspace"]["dependencies"]
-            .or_insert(toml_edit::Item::Table(toml_edit::Table::new()));
-        if let Some(ws_table) = ws_deps.as_table_mut() {
-            // Add the battery pack itself to workspace deps
-            if let Some(local_path) = path {
-                let mut dep = toml_edit::InlineTable::new();
-                dep.insert("path", toml_edit::Value::from(local_path));
-                ws_table.insert(
-                    &crate_name,
-                    toml_edit::Item::Value(toml_edit::Value::InlineTable(dep)),
-                );
+        // [impl manifest.deps.workspace]
+        // Add crate dependencies + workspace deps (including the battery pack itself).
+        // Load workspace doc once; both deps and metadata are written to it before a
+        // single flush at the end (avoids a double read-modify-write).
+        let mut ws_doc: Option<toml_edit::DocumentMut> =
+            if let Some(ref ws_path) = workspace_manifest {
+                let ws_content = std::fs::read_to_string(ws_path)
+                    .context("Failed to read workspace Cargo.toml")?;
+                Some(
+                    ws_content
+                        .parse()
+                        .context("Failed to parse workspace Cargo.toml")?,
+                )
             } else {
-                let version = bp_version
-                    .as_ref()
-                    .context("battery pack version not available (--path without workspace)")?;
-                ws_table.insert(&crate_name, toml_edit::value(version));
-            }
-            // Add the resolved crate dependencies
-            for (dep_name, dep_spec) in &crates_to_sync {
-                add_dep_to_table(ws_table, dep_name, dep_spec);
-            }
-        }
+                None
+            };
 
-        // [impl cli.add.dep-kind]
-        write_workspace_refs_by_kind(&mut user_doc, &crates_to_sync, false);
-    } else {
-        // [impl manifest.deps.no-workspace]
-        // [impl cli.add.dep-kind]
-        write_deps_by_kind(&mut user_doc, &crates_to_sync, false);
-    }
-
-    // Edit semantics: remove deselected crates from previous installation
-    let prev_managed =
-        read_managed_deps_for_project(&user_manifest_path, &user_manifest_content, &crate_name);
-    let new_crate_names: BTreeSet<String> = crates_to_sync.keys().cloned().collect();
-    let mut removed_count = 0;
-
-    if let Some(prev) = &prev_managed {
-        // Find crates that were previously managed but are no longer selected
-        let to_remove: BTreeMap<String, bphelper_manifest::CrateSpec> = prev
-            .iter()
-            .filter(|name| !new_crate_names.contains(name.as_str()))
-            .filter_map(|name| {
-                bp_spec
-                    .crates
-                    .get(name)
-                    .map(|spec| (name.clone(), spec.clone()))
-            })
-            .collect();
-
-        if !to_remove.is_empty() {
-            if let Some(ref mut doc) = ws_doc {
-                // Remove from workspace deps
-                let ws_deps = doc["workspace"]["dependencies"].as_table_mut();
-                if let Some(ws_table) = ws_deps {
-                    for name in to_remove.keys() {
-                        ws_table.remove(name);
-                    }
+        if let Some(ref mut doc) = ws_doc {
+            let ws_deps = doc["workspace"]["dependencies"]
+                .or_insert(toml_edit::Item::Table(toml_edit::Table::new()));
+            if let Some(ws_table) = ws_deps.as_table_mut() {
+                // Add the battery pack itself to workspace deps
+                if let Some(local_path) = path {
+                    let mut dep = toml_edit::InlineTable::new();
+                    dep.insert("path", toml_edit::Value::from(local_path));
+                    ws_table.insert(
+                        &crate_name,
+                        toml_edit::Item::Value(toml_edit::Value::InlineTable(dep)),
+                    );
+                } else {
+                    let version = bp_version
+                        .as_ref()
+                        .context("battery pack version not available (--path without workspace)")?;
+                    ws_table.insert(&crate_name, toml_edit::value(version));
+                }
+                // Add the resolved crate dependencies
+                for (dep_name, dep_spec) in &crates_to_sync {
+                    add_dep_to_table(ws_table, dep_name, dep_spec);
                 }
             }
-            removed_count = remove_deps_by_kind(&mut user_doc, &to_remove);
+
+            // [impl cli.add.dep-kind]
+            write_workspace_refs_by_kind(&mut user_doc, &crates_to_sync, false);
+        } else {
+            // [impl manifest.deps.no-workspace]
+            // [impl cli.add.dep-kind]
+            write_deps_by_kind(&mut user_doc, &crates_to_sync, false);
+        }
+
+        // Edit semantics: remove deselected crates from previous installation
+        let prev_managed =
+            read_managed_deps_for_project(&user_manifest_path, &user_manifest_content, &crate_name);
+        let new_crate_names: BTreeSet<String> = crates_to_sync.keys().cloned().collect();
+        let mut removed_count = 0;
+
+        if let Some(prev) = &prev_managed {
+            // Find crates that were previously managed but are no longer selected
+            let to_remove: BTreeMap<String, bphelper_manifest::CrateSpec> = prev
+                .iter()
+                .filter(|name| !new_crate_names.contains(name.as_str()))
+                .filter_map(|name| {
+                    bp_spec
+                        .crates
+                        .get(name)
+                        .map(|spec| (name.clone(), spec.clone()))
+                })
+                .collect();
+
+            if !to_remove.is_empty() {
+                if let Some(ref mut doc) = ws_doc {
+                    // Remove from workspace deps
+                    let ws_deps = doc["workspace"]["dependencies"].as_table_mut();
+                    if let Some(ws_table) = ws_deps {
+                        for name in to_remove.keys() {
+                            ws_table.remove(name);
+                        }
+                    }
+                }
+                removed_count = remove_deps_by_kind(&mut user_doc, &to_remove);
+            }
+        }
+
+        // Write workspace Cargo.toml once (deps combined)
+        if let (Some(ws_path), Some(doc)) = (&workspace_manifest, &ws_doc) {
+            // [impl manifest.toml.preserve]
+            std::fs::write(ws_path, doc.to_string())
+                .context("Failed to write workspace Cargo.toml")?;
+        }
+
+        // Write the final Cargo.toml
+        // [impl manifest.toml.preserve]
+        std::fs::write(&user_manifest_path, user_doc.to_string())
+            .context("Failed to write Cargo.toml")?;
+
+        write_battery_pack_state(
+            &user_manifest_path,
+            &crate_name,
+            &active_features,
+            &crates_to_sync,
+        )?;
+
+        println!(
+            "Added {} with {} crate(s)",
+            crate_name,
+            crates_to_sync.len()
+        );
+        for dep_name in crates_to_sync.keys() {
+            println!("  + {}", dep_name);
+        }
+        if removed_count > 0 {
+            println!("Removed {} deselected crate(s)", removed_count);
         }
     }
 
-    // Write workspace Cargo.toml once (deps combined)
-    if let (Some(ws_path), Some(doc)) = (&workspace_manifest, &ws_doc) {
+        // Write workspace Cargo.toml once (deps combined)
+        if let (Some(ws_path), Some(doc)) = (&workspace_manifest, &ws_doc) {
+            // [impl manifest.toml.preserve]
+            std::fs::write(ws_path, doc.to_string())
+                .context("Failed to write workspace Cargo.toml")?;
+        }
+
+        // Write the final Cargo.toml
         // [impl manifest.toml.preserve]
-        std::fs::write(ws_path, doc.to_string()).context("Failed to write workspace Cargo.toml")?;
+        std::fs::write(&user_manifest_path, user_doc.to_string())
+            .context("Failed to write Cargo.toml")?;
+
+        write_battery_pack_state(
+            &user_manifest_path,
+            &crate_name,
+            &(&active_features).into(),
+            &crates_to_sync,
+        )?;
+
+        println!(
+            "Added {} with {} crate(s)",
+            crate_name,
+            crates_to_sync.len()
+        );
+        for dep_name in crates_to_sync.keys() {
+            println!("  + {}", dep_name);
+        }
+        if removed_count > 0 {
+            println!("Removed {} deselected crate(s)", removed_count);
+        }
     }
 
-    // Write the final Cargo.toml
-    // [impl manifest.toml.preserve]
-    std::fs::write(&user_manifest_path, user_doc.to_string())
-        .context("Failed to write Cargo.toml")?;
-
-    write_battery_pack_state(
-        &user_manifest_path,
-        &crate_name,
-        &(&active_features).into(),
-        &crates_to_sync,
-    )?;
-
-    println!(
-        "Added {} with {} crate(s)",
-        crate_name,
-        crates_to_sync.len()
-    );
-    for dep_name in crates_to_sync.keys() {
-        println!("  + {}", dep_name);
-    }
-    if removed_count > 0 {
-        println!("Removed {} deselected crate(s)", removed_count);
+    // Step 4: Apply any selected templates.
+    for tmpl_name in &selected_templates {
+        add_template(AddTemplateOpts {
+            battery_pack: name,
+            template: tmpl_name,
+            path_override: path,
+            source,
+            project_dir,
+            defines: BTreeMap::new(),
+            overwrite: false,
+            interactive: std::io::stdout().is_terminal(),
+        })?;
     }
 
     Ok(())
@@ -1321,12 +1375,15 @@ pub(crate) struct PickerResult {
     pub crates: BTreeMap<String, bphelper_manifest::CrateSpec>,
     /// Which feature names are fully selected (for metadata recording).
     pub active_features: BTreeSet<String>,
+    /// Template names selected by the user for application.
+    pub selected_templates: Vec<String>,
 }
 
-/// An item in the picker — either a feature or an individual crate.
+/// An item in the picker — either a feature, an individual crate, or a template.
 enum PickerItem {
-    Feature(String), // feature name
-    Crate(String),   // crate name
+    Feature(String),  // feature name
+    Crate(String),    // crate name
+    Template(String), // template name
 }
 
 /// Show an interactive multi-select picker for choosing which crates to install.
@@ -1432,6 +1489,17 @@ fn pick_crates_interactive(
         items.push(PickerItem::Crate(crate_name.to_string()));
     }
 
+    // Templates shown last, unchecked by default.
+    for (tmpl_name, tmpl_spec) in &bp_spec.templates {
+        let desc = tmpl_spec
+            .description
+            .as_deref()
+            .unwrap_or("project template");
+        labels.push(format!("  ⎙ {} {}", tmpl_name, style(desc).dim()));
+        defaults.push(false);
+        items.push(PickerItem::Template(tmpl_name.clone()));
+    }
+
     // Show the picker
     println!();
     println!(
@@ -1452,10 +1520,11 @@ fn pick_crates_interactive(
         return Ok(None);
     };
 
-    // Split the picker selection into feature names and direct crate names.
+    // Split the picker selection into feature names, direct crate names, and templates.
     let selected_set: BTreeSet<usize> = selected_indices.into_iter().collect();
     let mut picked_features = Vec::new();
     let mut picked_crates = BTreeSet::new();
+    let mut selected_templates: Vec<String> = Vec::new();
 
     for (index, item) in items.iter().enumerate() {
         if !selected_set.contains(&index) {
@@ -1466,6 +1535,9 @@ fn pick_crates_interactive(
             PickerItem::Feature(name) => picked_features.push(name.clone()),
             PickerItem::Crate(name) => {
                 picked_crates.insert(name.clone());
+            }
+            PickerItem::Template(name) => {
+                selected_templates.push(name.clone());
             }
         }
     }
@@ -1530,6 +1602,7 @@ fn pick_crates_interactive(
     Ok(Some(PickerResult {
         crates,
         active_features,
+        selected_templates,
     }))
 }
 

--- a/src/battery-pack/bphelper-cli/src/commands.rs
+++ b/src/battery-pack/bphelper-cli/src/commands.rs
@@ -473,10 +473,15 @@ fn new_from_battery_pack(opts: NewFromBpOpts<'_>) -> Result<()> {
     let templates = parse_template_metadata(&manifest_path, &crate_name)?;
 
     // Resolve which template to use
-    let template_path = resolve_template(&templates, opts.template.as_deref(), opts.interactive)?;
+    let resolved_tmpl = resolve_template(&templates, opts.template.as_deref(), opts.interactive)?;
 
     // Generate the project from the crate directory
-    generate_from_path(new_opts, &resolved.dir, &template_path)
+    generate_from_path(
+        new_opts,
+        &resolved.dir,
+        &resolved_tmpl.name,
+        &resolved_tmpl.path,
+    )
 }
 
 /// Result of resolving which crates to add from a battery pack.
@@ -668,10 +673,10 @@ fn add_template(opts: AddTemplateOpts<'_>) -> Result<()> {
     // Read template metadata and resolve which template to use.
     let manifest_path = crate_dir.join("Cargo.toml");
     let templates = parse_template_metadata(&manifest_path, &crate_name)?;
-    let template_path = resolve_template(&templates, Some(opts.template), opts.interactive)?;
+    let resolved_tmpl = resolve_template(&templates, Some(opts.template), opts.interactive)?;
 
     // Load post-merge hints before moving template_path.
-    let hints = crate::template_engine::load_template_hints(&crate_dir, &template_path);
+    let hints = crate::template_engine::load_template_hints(&crate_dir, &resolved_tmpl.path);
 
     // Infer project_name from the current Cargo.toml or directory name.
     let project_name = infer_project_name(opts.project_dir)?;
@@ -680,7 +685,7 @@ fn add_template(opts: AddTemplateOpts<'_>) -> Result<()> {
     let interactive_override = if opts.interactive { None } else { Some(false) };
     let render_opts = crate::template_engine::RenderOpts {
         crate_root: crate_dir,
-        template_path,
+        template_path: resolved_tmpl.path,
         project_name,
         defines: opts.defines,
         interactive_override,
@@ -698,7 +703,7 @@ fn add_template(opts: AddTemplateOpts<'_>) -> Result<()> {
 
     // Record the applied template in battery-pack.toml.
     let user_manifest_path = find_user_manifest(opts.project_dir)?;
-    record_applied_template(&user_manifest_path, &crate_name, opts.template)?;
+    record_applied_template(&user_manifest_path, &crate_name, &resolved_tmpl.name)?;
 
     // Print post-merge hints if the template defines any.
     if !hints.is_empty() {
@@ -1633,9 +1638,9 @@ fn generate_from_local(opts: NewOpts, local_path: &str, template: Option<String>
         .and_then(|s| s.to_str())
         .unwrap_or("unknown");
     let templates = parse_template_metadata(&manifest_path, crate_name)?;
-    let template_path = resolve_template(&templates, template.as_deref(), opts.interactive)?;
+    let resolved_tmpl = resolve_template(&templates, template.as_deref(), opts.interactive)?;
 
-    generate_from_path(opts, local_path, &template_path)
+    generate_from_path(opts, local_path, &resolved_tmpl.name, &resolved_tmpl.path)
 }
 
 /// Prompt for a project name if not provided.
@@ -1660,7 +1665,12 @@ fn ensure_battery_pack_suffix(name: String) -> String {
     }
 }
 
-fn generate_from_path(opts: NewOpts, crate_path: &Path, template_path: &str) -> Result<()> {
+fn generate_from_path(
+    opts: NewOpts,
+    crate_path: &Path,
+    template_name: &str,
+    template_path: &str,
+) -> Result<()> {
     let raw = prompt_project_name(opts.name)?;
     let project_name = if opts.battery_pack == "battery-pack" {
         ensure_battery_pack_suffix(raw)
@@ -1682,7 +1692,16 @@ fn generate_from_path(opts: NewOpts, crate_path: &Path, template_path: &str) -> 
         git_init: true,
     };
 
-    crate::template_engine::generate(gen_opts)?;
+    let project_dir = crate::template_engine::generate(gen_opts)?;
+
+    // Record the applied template in the new project's battery-pack.toml.
+    let user_manifest_path = project_dir.join("Cargo.toml");
+    if user_manifest_path.exists() {
+        let bp_name = resolve_crate_name(&opts.battery_pack);
+        if let Err(e) = record_applied_template(&user_manifest_path, &bp_name, template_name) {
+            eprintln!("warning: failed to record template in state: {e}");
+        }
+    }
 
     Ok(())
 }
@@ -1711,13 +1730,20 @@ fn parse_template_metadata(
     Ok(spec.templates)
 }
 
+/// Resolved template: the logical name and the filesystem path within the crate.
+#[derive(Debug)]
+pub(crate) struct ResolvedTemplate {
+    pub name: String,
+    pub path: String,
+}
+
 // [impl format.templates.selection]
 // [impl cli.new.template-select]
 pub(crate) fn resolve_template(
     templates: &BTreeMap<String, TemplateConfig>,
     requested: Option<&str>,
     interactive: bool,
-) -> Result<String> {
+) -> Result<ResolvedTemplate> {
     match requested {
         Some(name) => {
             let config = templates.get(name).ok_or_else(|| {
@@ -1728,14 +1754,23 @@ pub(crate) fn resolve_template(
                     available.join(", ")
                 )
             })?;
-            Ok(config.path.clone())
+            Ok(ResolvedTemplate {
+                name: name.to_string(),
+                path: config.path.clone(),
+            })
         }
         None => {
             if templates.len() == 1 {
-                let (_, config) = templates.iter().next().unwrap();
-                Ok(config.path.clone())
+                let (name, config) = templates.iter().next().unwrap();
+                Ok(ResolvedTemplate {
+                    name: name.clone(),
+                    path: config.path.clone(),
+                })
             } else if let Some(config) = templates.get("default") {
-                Ok(config.path.clone())
+                Ok(ResolvedTemplate {
+                    name: "default".to_string(),
+                    path: config.path.clone(),
+                })
             } else {
                 prompt_for_template(templates, interactive)
             }
@@ -1746,7 +1781,7 @@ pub(crate) fn resolve_template(
 fn prompt_for_template(
     templates: &BTreeMap<String, TemplateConfig>,
     interactive: bool,
-) -> Result<String> {
+) -> Result<ResolvedTemplate> {
     use dialoguer::{Select, theme::ColorfulTheme};
 
     // Build display items with descriptions
@@ -1779,12 +1814,15 @@ fn prompt_for_template(
         .interact()
         .context("Failed to select template")?;
 
-    // Get the selected template's path
-    let (_, config) = templates
+    // Get the selected template's name and path
+    let (name, config) = templates
         .iter()
         .nth(selection)
         .ok_or_else(|| anyhow::anyhow!("Invalid template selection"))?;
-    Ok(config.path.clone())
+    Ok(ResolvedTemplate {
+        name: name.clone(),
+        path: config.path.clone(),
+    })
 }
 
 // ============================================================================

--- a/src/battery-pack/bphelper-cli/src/commands/tests.rs
+++ b/src/battery-pack/bphelper-cli/src/commands/tests.rs
@@ -124,7 +124,8 @@ fn resolve_template_single_template_uses_it() {
     );
 
     let result = super::resolve_template(&templates, None, true).unwrap();
-    assert_eq!(result, "templates/simple");
+    assert_eq!(result.name, "simple");
+    assert_eq!(result.path, "templates/simple");
 }
 
 // [verify cli.new.template-select]
@@ -148,7 +149,8 @@ fn resolve_template_picks_default_when_present() {
     );
 
     let result = super::resolve_template(&templates, None, true).unwrap();
-    assert_eq!(result, "templates/default");
+    assert_eq!(result.name, "default");
+    assert_eq!(result.path, "templates/default");
 }
 
 // [verify cli.new.template-select]
@@ -202,7 +204,8 @@ fn resolve_template_explicit_flag_overrides() {
     );
 
     let result = super::resolve_template(&templates, Some("advanced"), true).unwrap();
-    assert_eq!(result, "templates/advanced");
+    assert_eq!(result.name, "advanced");
+    assert_eq!(result.path, "templates/advanced");
 }
 
 // ============================================================================

--- a/src/battery-pack/bphelper-cli/src/manifest.rs
+++ b/src/battery-pack/bphelper-cli/src/manifest.rs
@@ -408,6 +408,12 @@ struct BatteryPackStateEntry {
     features: BTreeSet<String>,
     #[serde(rename = "managed-deps", default)]
     managed_deps: Vec<ManagedDepEntry>,
+    #[serde(
+        rename = "applied-templates",
+        default,
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    applied_templates: Vec<String>,
 }
 
 fn is_false(v: &bool) -> bool {
@@ -540,6 +546,21 @@ pub(crate) fn read_managed_deps_from_state(
     })
 }
 
+/// Read applied template names for a battery pack from `battery-pack.toml`.
+pub(crate) fn read_applied_templates_from_state(
+    user_manifest_path: &Path,
+    bp_name: &str,
+) -> Vec<String> {
+    let state_path = state_file_path(user_manifest_path);
+    let state = match read_state_file(&state_path) {
+        Ok(s) => s,
+        Err(_) => return Vec::new(),
+    };
+    state_entry_for(&state, bp_name)
+        .map(|entry| entry.applied_templates.clone())
+        .unwrap_or_default()
+}
+
 /// Read active features from a parsed TOML value at a given path prefix.
 ///
 /// `prefix` is `&["package", "metadata"]` for package metadata or
@@ -602,11 +623,17 @@ pub(crate) fn write_battery_pack_state(
         })
         .collect::<Vec<_>>();
 
-    let updated = BatteryPackStateEntry::from_active_features(
+    // Preserve previously applied templates when only updating deps/features.
+    let prev_templates = state_entry_for(&state, bp_name)
+        .map(|e| e.applied_templates.clone())
+        .unwrap_or_default();
+
+    let mut updated = BatteryPackStateEntry::from_active_features(
         short_name(bp_name).to_string(),
         active_features,
         managed_deps,
     );
+    updated.applied_templates = prev_templates;
 
     if let Some(entry) = state
         .battery_pack
@@ -616,6 +643,39 @@ pub(crate) fn write_battery_pack_state(
         *entry = updated;
     } else {
         state.battery_pack.push(updated);
+    }
+
+    write_state_file(&state_path, &state)?;
+    Ok(())
+}
+
+/// Record that a template was applied for a battery pack.
+///
+/// Appends the template name if not already present.
+pub(crate) fn record_applied_template(
+    user_manifest_path: &Path,
+    bp_name: &str,
+    template_name: &str,
+) -> Result<()> {
+    let state_path = state_file_path(user_manifest_path);
+    let mut state = read_state_file(&state_path)?;
+
+    if let Some(entry) = state
+        .battery_pack
+        .iter_mut()
+        .find(|entry| state_name_matches(&entry.name, bp_name))
+    {
+        if !entry.applied_templates.contains(&template_name.to_string()) {
+            entry.applied_templates.push(template_name.to_string());
+        }
+    } else {
+        // No existing entry for this pack — create a minimal one.
+        state.battery_pack.push(BatteryPackStateEntry {
+            name: short_name(bp_name).to_string(),
+            features: default_feature_set(),
+            managed_deps: Vec::new(),
+            applied_templates: vec![template_name.to_string()],
+        });
     }
 
     write_state_file(&state_path, &state)?;

--- a/src/battery-pack/bphelper-cli/src/manifest.rs
+++ b/src/battery-pack/bphelper-cli/src/manifest.rs
@@ -450,12 +450,14 @@ impl BatteryPackStateEntry {
                 all_features: true,
                 features: BTreeSet::new(),
                 managed_deps,
+                applied_templates: Vec::new(),
             },
             bphelper_manifest::ActiveFeatures::Subset(set) => Self {
                 name,
                 all_features: false,
                 features: normalized_feature_set(set),
                 managed_deps,
+                applied_templates: Vec::new(),
             },
         }
     }
@@ -672,6 +674,7 @@ pub(crate) fn record_applied_template(
         // No existing entry for this pack — create a minimal one.
         state.battery_pack.push(BatteryPackStateEntry {
             name: short_name(bp_name).to_string(),
+            all_features: false,
             features: default_feature_set(),
             managed_deps: Vec::new(),
             applied_templates: vec![template_name.to_string()],

--- a/src/battery-pack/bphelper-cli/src/tui.rs
+++ b/src/battery-pack/bphelper-cli/src/tui.rs
@@ -1524,7 +1524,7 @@ fn render_form(frame: &mut Frame, state: &FormScreen) {
 }
 
 /// Convert rendered template files into syntax-highlighted [`Text`].
-fn highlight_preview(files: &[crate::template_engine::RenderedFile]) -> Text<'static> {
+pub(crate) fn highlight_preview(files: &[crate::template_engine::RenderedFile]) -> Text<'static> {
     use syntect::easy::HighlightLines;
     use syntect::highlighting::ThemeSet;
 
@@ -1571,6 +1571,86 @@ fn highlight_preview(files: &[crate::template_engine::RenderedFile]) -> Text<'st
     }
 
     Text::from(lines)
+}
+
+/// Show a scrollable syntax-highlighted preview. Blocks until the user presses Esc.
+pub(crate) fn show_preview(
+    terminal: &mut ratatui::DefaultTerminal,
+    title: &str,
+    content: Text<'static>,
+) {
+    let line_count = content.lines.len() as u16;
+    let mut scroll: u16 = 0;
+
+    loop {
+        let _ = terminal.draw(|frame| {
+            render_standalone_preview(frame, title, &content, scroll);
+        });
+
+        if event::poll(Duration::from_millis(100)).unwrap_or(false)
+            && let Ok(Event::Key(key)) = event::read()
+        {
+            if key.kind != KeyEventKind::Press {
+                continue;
+            }
+            match key.code {
+                KeyCode::Esc | KeyCode::Char('q') => break,
+                KeyCode::Down | KeyCode::Char('j') => {
+                    scroll = scroll.saturating_add(1).min(line_count.saturating_sub(1));
+                }
+                KeyCode::Up | KeyCode::Char('k') => {
+                    scroll = scroll.saturating_sub(1);
+                }
+                KeyCode::PageDown | KeyCode::Char('f') => {
+                    scroll = scroll.saturating_add(20).min(line_count.saturating_sub(1));
+                }
+                KeyCode::PageUp | KeyCode::Char('b') => {
+                    scroll = scroll.saturating_sub(20);
+                }
+                KeyCode::Home | KeyCode::Char('g') => {
+                    scroll = 0;
+                }
+                KeyCode::End | KeyCode::Char('G') => {
+                    scroll = line_count.saturating_sub(1);
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+fn render_standalone_preview(frame: &mut Frame, title: &str, content: &Text<'_>, scroll: u16) {
+    let area = frame.area();
+    let [header, main, footer] = Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Fill(1),
+        Constraint::Length(1),
+    ])
+    .areas(area);
+
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(
+            title,
+            Style::default().fg(Color::Cyan).bold(),
+        )))
+        .centered(),
+        header,
+    );
+
+    let preview = Paragraph::new(content.clone())
+        .block(
+            Block::default()
+                .borders(Borders::BOTTOM)
+                .padding(ratatui::widgets::Padding::horizontal(1)),
+        )
+        .scroll((scroll, 0));
+    frame.render_widget(preview, main);
+
+    frame.render_widget(
+        Paragraph::new("↑↓/jk/PgUp/PgDn Scroll | Esc Back")
+            .style(Style::default().white().on_dark_gray()),
+        footer,
+    );
 }
 
 fn render_preview(frame: &mut Frame, state: &PreviewScreen) {

--- a/src/cargo-bp-script/src/status.rs
+++ b/src/cargo-bp-script/src/status.rs
@@ -78,6 +78,10 @@ pub struct InstalledPackStatus {
     /// Sorted alphabetically.
     pub active_features: Vec<String>,
 
+    /// Templates that have been applied from this battery pack.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub applied_templates: Vec<String>,
+
     /// Per-dependency warnings for this pack — each entry indicates
     /// a dependency whose user-side version is older than what the
     /// battery pack recommends.
@@ -158,6 +162,7 @@ impl InstalledPackStatus {
             name: name.into(),
             version: version.into(),
             active_features: Vec::new(),
+            applied_templates: Vec::new(),
             warnings: Vec::new(),
         }
     }
@@ -176,6 +181,17 @@ impl InstalledPackStatus {
     {
         self.active_features
             .extend(features.into_iter().map(Into::into));
+        self
+    }
+
+    /// Append applied template names.
+    pub fn with_applied_templates<I, S>(mut self, templates: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.applied_templates
+            .extend(templates.into_iter().map(Into::into));
         self
     }
 

--- a/src/cargo-bp/tests/add_template.rs
+++ b/src/cargo-bp/tests/add_template.rs
@@ -505,3 +505,52 @@ fn add_template_twice_does_not_duplicate_in_state() {
         "should contain exactly one entry:\n{state_content}"
     );
 }
+
+#[test]
+fn new_from_template_records_in_state() {
+    let tmp = tempfile::tempdir().unwrap();
+    let fixture = fixtures_dir().join("fancy-battery-pack");
+
+    // Generate a new project from the fancy battery pack's "default" template.
+    let output = cargo_bp()
+        .args([
+            "bp",
+            "new",
+            "fancy",
+            "--name",
+            "my-app",
+            "--path",
+            &fixture.to_string_lossy(),
+            "-t",
+            "default",
+        ])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run cargo-bp");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // The generated project should have a battery-pack.toml recording the template.
+    let project_dir = tmp.path().join("my-app");
+    assert!(project_dir.join("Cargo.toml").exists());
+
+    let state_path = project_dir.join("battery-pack.toml");
+    assert!(
+        state_path.exists(),
+        "battery-pack.toml should be created in the new project"
+    );
+
+    let state_content = std::fs::read_to_string(&state_path).unwrap();
+    assert!(
+        state_content.contains(r#"applied-templates = ["default"]"#),
+        "state file should record the template used:\n{state_content}"
+    );
+    assert!(
+        state_content.contains(r#"name = "fancy""#),
+        "state file should reference the battery pack:\n{state_content}"
+    );
+}

--- a/src/cargo-bp/tests/add_template.rs
+++ b/src/cargo-bp/tests/add_template.rs
@@ -383,3 +383,125 @@ fn add_template_registry_download_keeps_tempdir_alive() {
         String::from_utf8_lossy(&output.stderr)
     );
 }
+
+#[test]
+fn add_template_records_in_state_and_shows_in_status() {
+    let tmp = tempfile::tempdir().unwrap();
+
+    let fixture = fixtures_dir().join("fancy-battery-pack");
+
+    // Create a project that has fancy-battery-pack as a build-dep so status can find it.
+    std::fs::write(
+        tmp.path().join("Cargo.toml"),
+        "[package]\nname = \"my-app\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[dependencies]\nserde = \"1\"\n\n[build-dependencies]\nfancy-battery-pack = \"0.2.0\"\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(tmp.path().join("src")).unwrap();
+    std::fs::write(tmp.path().join("src/main.rs"), "fn main() {}\n").unwrap();
+
+    // Apply a template.
+    let output = cargo_bp()
+        .args([
+            "bp",
+            "add",
+            "fancy",
+            "-t",
+            "default",
+            "--path",
+            &fixture.to_string_lossy(),
+            "-N",
+        ])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run cargo-bp");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Verify battery-pack.toml records the applied template.
+    let state_content = std::fs::read_to_string(tmp.path().join("battery-pack.toml")).unwrap();
+    assert!(
+        state_content.contains("applied-templates"),
+        "state file should contain applied-templates section:\n{state_content}"
+    );
+    assert!(
+        state_content.contains(r#"applied-templates = ["default"]"#),
+        "state file should record the 'default' template:\n{state_content}"
+    );
+
+    // Verify status --json includes the applied template.
+    let status_output = cargo_bp()
+        .args([
+            "bp",
+            "status",
+            "--json",
+            "--path",
+            &fixture.to_string_lossy(),
+        ])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run cargo-bp");
+
+    assert!(
+        status_output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&status_output.stderr)
+    );
+
+    let report: serde_json::Value =
+        serde_json::from_slice(&status_output.stdout).expect("valid JSON from status");
+    let pack = &report["packs"][0];
+    assert_eq!(
+        pack["applied_templates"],
+        serde_json::json!(["default"]),
+        "status JSON should include the applied template"
+    );
+}
+
+#[test]
+fn add_template_twice_does_not_duplicate_in_state() {
+    let tmp = tempfile::tempdir().unwrap();
+    create_existing_project(tmp.path());
+
+    let fixture = fixtures_dir().join("fancy-battery-pack");
+
+    // Apply the same template twice.
+    for _ in 0..2 {
+        let output = cargo_bp()
+            .args([
+                "bp",
+                "add",
+                "fancy",
+                "-t",
+                "default",
+                "--path",
+                &fixture.to_string_lossy(),
+                "-N",
+                "--overwrite",
+            ])
+            .current_dir(tmp.path())
+            .output()
+            .expect("failed to run cargo-bp");
+
+        assert!(
+            output.status.success(),
+            "stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    // Verify applied-templates list contains exactly one entry.
+    let state_content = std::fs::read_to_string(tmp.path().join("battery-pack.toml")).unwrap();
+    let count = state_content.matches("applied-templates").count();
+    assert_eq!(
+        count, 1,
+        "applied-templates should appear once in state, found {count}:\n{state_content}"
+    );
+    assert!(
+        state_content.contains(r#"applied-templates = ["default"]"#),
+        "should contain exactly one entry:\n{state_content}"
+    );
+}

--- a/src/sectioned-picker/Cargo.toml
+++ b/src/sectioned-picker/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "sectioned-picker"
+version = "0.1.0"
+edition = "2024"
+description = "Interactive terminal multi-select picker with non-selectable section headers"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/battery-pack-rs/battery-pack"
+keywords = ["tui", "picker", "multi-select", "ratatui"]
+
+[dependencies]
+ratatui = "0.30"
+crossterm = "0.28"
+anyhow = "1"
+
+[dev-dependencies]
+snapbox = { workspace = true }

--- a/src/sectioned-picker/src/lib.rs
+++ b/src/sectioned-picker/src/lib.rs
@@ -1,0 +1,210 @@
+//! Interactive terminal multi-select picker with non-selectable section headers.
+//!
+//! This crate provides a full-screen ratatui-based picker widget that groups
+//! selectable items under bold section headers. It's designed for CLI tools that
+//! need users to choose from categorized options.
+//!
+//! # Features
+//!
+//! - **Sectioned layout** — items grouped under bold, non-selectable headers
+//! - **Checkboxes** — `[x]`/`[ ]` with `>` cursor indicator
+//! - **Keyboard navigation** — arrow keys, j/k, Space to toggle, Enter to confirm
+//! - **Section toggle** — `a` checks/unchecks all items in the current section
+//! - **Smart scrolling** — keeps cursor visible; snaps to section header when near top
+//! - **Custom actions** — bind arbitrary keys to caller-defined handlers that can
+//!   take over the terminal (e.g., for previews)
+//!
+//! # Example
+//!
+//! ```no_run
+//! use sectioned_picker::{Section, SectionItem, PickerAction, PickerOutcome, run_picker};
+//!
+//! let sections = vec![
+//!     Section {
+//!         title: "Features:".to_string(),
+//!         items: vec![
+//!             SectionItem { label: "logging".to_string(), checked: true },
+//!             SectionItem { label: "metrics".to_string(), checked: false },
+//!         ],
+//!     },
+//!     Section {
+//!         title: "Dependencies:".to_string(),
+//!         items: vec![
+//!             SectionItem { label: "tokio (1.38)".to_string(), checked: true },
+//!         ],
+//!     },
+//! ];
+//!
+//! match run_picker("my-app v1.0", sections, Vec::new()).unwrap() {
+//!     PickerOutcome::Confirmed(results) => {
+//!         // results[0] = [true, false] — features section
+//!         // results[1] = [true]        — dependencies section
+//!     }
+//!     PickerOutcome::Cancelled => {}
+//! }
+//! ```
+//!
+//! # Scrolling behavior
+//!
+//! When the list exceeds the viewport height, the view scrolls to keep the
+//! cursor visible:
+//!
+//! - **Near section top:** scrolling up snaps to the section header when it fits
+//!   in the viewport alongside the cursor.
+//! - **Tall sections:** does NOT snap to a distant header on every up-movement;
+//!   only snaps when the cursor is close enough to the top of its section.
+//!
+//! # Enter behavior
+//!
+//! If no items are checked when the user presses Enter, the item under the
+//! cursor is checked before submitting. This makes single-item selection a
+//! one-key operation (navigate + Enter).
+
+mod render;
+mod state;
+
+#[cfg(test)]
+mod tests;
+
+use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
+use std::time::Duration;
+
+pub use render::render_picker;
+pub use state::PickerState;
+
+/// A section of items in the picker.
+pub struct Section {
+    pub title: String,
+    pub items: Vec<SectionItem>,
+}
+
+/// A selectable item within a section.
+pub struct SectionItem {
+    pub label: String,
+    pub checked: bool,
+}
+
+/// Context passed to action handlers when a custom key is pressed.
+///
+/// Provides access to the current cursor position and the terminal for
+/// full-screen takeover (e.g., rendering a preview).
+pub struct ActionContext<'a> {
+    section_idx: usize,
+    item_idx: usize,
+    terminal: &'a mut ratatui::DefaultTerminal,
+}
+
+impl ActionContext<'_> {
+    /// Which section the cursor is in (0-indexed, matching input order).
+    pub fn section(&self) -> usize {
+        self.section_idx
+    }
+
+    /// Which item within the section the cursor is on (0-indexed).
+    pub fn item(&self) -> usize {
+        self.item_idx
+    }
+
+    /// Mutable access to the terminal for drawing custom screens.
+    pub fn terminal(&mut self) -> &mut ratatui::DefaultTerminal {
+        self.terminal
+    }
+}
+
+/// Handler type for picker actions.
+pub type ActionHandler<'a> = Box<dyn FnMut(&mut ActionContext<'_>) + 'a>;
+
+/// A caller-defined action bound to a key.
+///
+/// When the user presses `key`, the picker calls `handler` with an
+/// [`ActionContext`] that provides the current section/item coordinates and
+/// mutable terminal access. The handler may take over the screen (e.g., for a
+/// preview) and should return when done — the picker redraws automatically.
+pub struct PickerAction<'a> {
+    pub key: char,
+    pub label: &'a str,
+    pub handler: ActionHandler<'a>,
+}
+
+/// The outcome of a picker interaction.
+pub enum PickerOutcome {
+    /// User confirmed — returns checked state per section (matching input order).
+    Confirmed(Vec<Vec<bool>>),
+    /// User cancelled (Esc).
+    Cancelled,
+}
+
+/// Run an interactive sectioned multi-select picker.
+///
+/// Sections are rendered with bold headers; items below them have checkboxes.
+/// Navigation skips headers automatically. Optional `actions` bind keys to
+/// caller-defined handlers that receive the terminal for full-screen takeover.
+pub fn run_picker(
+    title: &str,
+    sections: Vec<Section>,
+    actions: Vec<PickerAction<'_>>,
+) -> anyhow::Result<PickerOutcome> {
+    let mut state = PickerState::new(sections);
+
+    if state.is_empty() {
+        return Ok(PickerOutcome::Confirmed(Vec::new()));
+    }
+
+    let mut terminal = ratatui::init();
+    let result = run_picker_loop(&mut terminal, title, &mut state, actions);
+    ratatui::restore();
+    result
+}
+
+fn run_picker_loop(
+    terminal: &mut ratatui::DefaultTerminal,
+    title: &str,
+    state: &mut PickerState,
+    mut actions: Vec<PickerAction<'_>>,
+) -> anyhow::Result<PickerOutcome> {
+    let action_keys: Vec<char> = actions.iter().map(|a| a.key).collect();
+
+    loop {
+        terminal.draw(|frame| render_picker(frame, title, state, &actions))?;
+
+        if event::poll(Duration::from_millis(100))?
+            && let Event::Key(key) = event::read()?
+        {
+            if key.kind != KeyEventKind::Press {
+                continue;
+            }
+
+            if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+                return Ok(PickerOutcome::Cancelled);
+            }
+
+            match key.code {
+                KeyCode::Up | KeyCode::Char('k') => state.move_up(),
+                KeyCode::Down | KeyCode::Char('j') => state.move_down(),
+                KeyCode::Char(' ') => state.toggle(),
+                KeyCode::Enter => {
+                    if !state.has_any_checked() {
+                        state.toggle();
+                    }
+                    return Ok(PickerOutcome::Confirmed(state.into_results()));
+                }
+                KeyCode::Esc | KeyCode::Char('q') => {
+                    return Ok(PickerOutcome::Cancelled);
+                }
+                KeyCode::Char('a') => state.toggle_current_section(),
+                KeyCode::Char(c) => {
+                    if let Some(idx) = action_keys.iter().position(|&k| k == c) {
+                        let (section_idx, item_idx) = state.current_coordinates();
+                        let mut ctx = ActionContext {
+                            section_idx,
+                            item_idx,
+                            terminal,
+                        };
+                        (actions[idx].handler)(&mut ctx);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}

--- a/src/sectioned-picker/src/render.rs
+++ b/src/sectioned-picker/src/render.rs
@@ -1,0 +1,103 @@
+//! Rendering logic for the picker widget.
+
+use crate::PickerAction;
+use crate::state::{Entry, PickerState};
+use ratatui::{
+    Frame,
+    layout::{Constraint, Layout},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph},
+};
+
+/// Render the picker into the given frame.
+///
+/// This updates `state.visible_height` from the actual terminal geometry and
+/// calls `ensure_cursor_visible` so scroll is correct even after a resize.
+pub fn render_picker(
+    frame: &mut Frame,
+    title: &str,
+    state: &mut PickerState,
+    actions: &[PickerAction<'_>],
+) {
+    let area = frame.area();
+
+    let [header_area, main_area, footer_area] = Layout::vertical([
+        Constraint::Length(2),
+        Constraint::Fill(1),
+        Constraint::Length(1),
+    ])
+    .areas(area);
+
+    // Update visible height from actual terminal geometry.
+    state.visible_height = main_area.height.saturating_sub(2) as usize;
+    state.ensure_cursor_visible();
+
+    // Title
+    frame.render_widget(
+        Paragraph::new(title)
+            .style(
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD),
+            )
+            .centered(),
+        header_area,
+    );
+
+    // Build the content lines.
+    let current_entry_idx = state.current_entry_idx();
+    let mut lines: Vec<Line> = Vec::new();
+
+    for (i, entry) in state.entries.iter().enumerate() {
+        match entry {
+            Entry::Header(text) => {
+                if i > 0 {
+                    lines.push(Line::from(""));
+                }
+                lines.push(Line::from(Span::styled(
+                    text.as_str(),
+                    Style::default().add_modifier(Modifier::BOLD),
+                )));
+            }
+            Entry::Item { label, checked } => {
+                let is_cursor = i == current_entry_idx;
+                let checkbox = if *checked { "[x]" } else { "[ ]" };
+                let prefix = if is_cursor { "> " } else { "  " };
+                let text = format!("{prefix}{checkbox} {label}");
+
+                let style = if is_cursor {
+                    Style::default()
+                        .fg(Color::Black)
+                        .bg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default()
+                };
+                lines.push(Line::styled(text, style));
+            }
+        }
+    }
+
+    let content = Paragraph::new(lines)
+        .block(Block::default().borders(Borders::ALL))
+        .scroll((state.scroll as u16, 0));
+    frame.render_widget(content, main_area);
+
+    // Footer — built-in keys + caller-defined action labels.
+    let mut footer_parts = vec![
+        "↑↓/jk Navigate".to_string(),
+        "Space Toggle".to_string(),
+        "a Toggle section".to_string(),
+    ];
+    for action in actions {
+        footer_parts.push(format!("{} {}", action.key, action.label));
+    }
+    footer_parts.push("Enter Confirm".to_string());
+    footer_parts.push("Esc Cancel".to_string());
+
+    frame.render_widget(
+        Paragraph::new(footer_parts.join(" | ")).style(Style::default().white().on_dark_gray()),
+        footer_area,
+    );
+}

--- a/src/sectioned-picker/src/state.rs
+++ b/src/sectioned-picker/src/state.rs
@@ -1,0 +1,259 @@
+//! Picker state: navigation, toggle, scroll, and result extraction.
+
+use crate::Section;
+#[cfg(test)]
+use crate::SectionItem;
+
+/// A single item in the picker — either a section header or a selectable entry.
+pub(crate) enum Entry {
+    Header(String),
+    Item { label: String, checked: bool },
+}
+
+/// The internal state of the picker widget.
+///
+/// All sections are flattened into a single `entries` vec of headers and items.
+/// The `selectable` vec stores indices into `entries` for items only, so the
+/// cursor always lands on a selectable item.
+pub struct PickerState {
+    pub(crate) entries: Vec<Entry>,
+    /// Indices into `entries` that are selectable (non-header).
+    selectable: Vec<usize>,
+    /// For each selectable item, its (section_idx, item_idx) coordinates.
+    coordinates: Vec<(usize, usize)>,
+    /// Current cursor position within `selectable`.
+    cursor: usize,
+    /// Scroll offset (in rendered lines) for the viewport.
+    pub(crate) scroll: usize,
+    /// Height of the visible content area (updated each frame from terminal size).
+    pub(crate) visible_height: usize,
+}
+
+impl PickerState {
+    /// Create a new picker state from the given sections.
+    pub fn new(sections: Vec<Section>) -> Self {
+        let mut entries = Vec::new();
+        let mut selectable = Vec::new();
+        let mut coordinates = Vec::new();
+
+        for (section_idx, section) in sections.into_iter().enumerate() {
+            entries.push(Entry::Header(section.title));
+            for (item_idx, item) in section.items.into_iter().enumerate() {
+                selectable.push(entries.len());
+                coordinates.push((section_idx, item_idx));
+                entries.push(Entry::Item {
+                    label: item.label,
+                    checked: item.checked,
+                });
+            }
+        }
+
+        Self {
+            entries,
+            selectable,
+            coordinates,
+            cursor: 0,
+            scroll: 0,
+            visible_height: 0,
+        }
+    }
+
+    /// True if there are no selectable items.
+    pub fn is_empty(&self) -> bool {
+        self.selectable.is_empty()
+    }
+
+    /// Move the cursor up one selectable item.
+    pub fn move_up(&mut self) {
+        if self.cursor > 0 {
+            self.cursor -= 1;
+            self.ensure_cursor_visible();
+        }
+    }
+
+    /// Move the cursor down one selectable item.
+    pub fn move_down(&mut self) {
+        if self.cursor < self.selectable.len().saturating_sub(1) {
+            self.cursor += 1;
+            self.ensure_cursor_visible();
+        }
+    }
+
+    /// Toggle the checked state of the item under the cursor.
+    pub fn toggle(&mut self) {
+        let idx = self.selectable[self.cursor];
+        if let Entry::Item { checked, .. } = &mut self.entries[idx] {
+            *checked = !*checked;
+        }
+    }
+
+    /// Toggle all items in the section that contains the cursor.
+    ///
+    /// If any item in the section is unchecked, checks all; otherwise unchecks all.
+    pub fn toggle_current_section(&mut self) {
+        let cursor_entry_idx = self.selectable[self.cursor];
+
+        let header_idx = (0..=cursor_entry_idx)
+            .rev()
+            .find(|&i| matches!(self.entries[i], Entry::Header(_)))
+            .unwrap_or(0);
+
+        let section_end = ((header_idx + 1)..self.entries.len())
+            .find(|&i| matches!(self.entries[i], Entry::Header(_)))
+            .unwrap_or(self.entries.len());
+
+        let all_checked = (header_idx + 1..section_end)
+            .all(|i| matches!(self.entries[i], Entry::Item { checked: true, .. }));
+        let target = !all_checked;
+
+        for i in header_idx + 1..section_end {
+            if let Entry::Item { checked, .. } = &mut self.entries[i] {
+                *checked = target;
+            }
+        }
+    }
+
+    /// The (section_idx, item_idx) for the current cursor position.
+    pub fn current_coordinates(&self) -> (usize, usize) {
+        self.coordinates[self.cursor]
+    }
+
+    /// True if at least one item is checked across all sections.
+    pub fn has_any_checked(&self) -> bool {
+        self.entries
+            .iter()
+            .any(|e| matches!(e, Entry::Item { checked: true, .. }))
+    }
+
+    /// Extract checked state grouped by section (matching original input order).
+    ///
+    /// Consumes the state and returns a `Vec<Vec<bool>>` where each inner vec
+    /// corresponds to a section in the original input order.
+    pub fn into_results(&mut self) -> Vec<Vec<bool>> {
+        let entries = std::mem::take(&mut self.entries);
+        let mut results: Vec<Vec<bool>> = Vec::new();
+        let mut current_section: Vec<bool> = Vec::new();
+        let mut seen_header = false;
+
+        for entry in entries {
+            match entry {
+                Entry::Header(_) => {
+                    if seen_header {
+                        results.push(std::mem::take(&mut current_section));
+                    }
+                    seen_header = true;
+                }
+                Entry::Item { checked, .. } => {
+                    current_section.push(checked);
+                }
+            }
+        }
+        if seen_header {
+            results.push(current_section);
+        }
+        results
+    }
+
+    /// The entry index for the current cursor position.
+    pub(crate) fn current_entry_idx(&self) -> usize {
+        self.selectable[self.cursor]
+    }
+
+    /// Compute which rendered line the cursor currently occupies.
+    ///
+    /// The rendered layout inserts a blank line before each section header
+    /// (except the first), so the line count is not simply the entry index.
+    pub(crate) fn cursor_line(&self) -> usize {
+        Self::entry_to_line(&self.entries, self.selectable[self.cursor])
+    }
+
+    /// Compute the rendered line of the section header for the current cursor item.
+    fn section_header_line(&self) -> usize {
+        let cursor_entry_idx = self.selectable[self.cursor];
+        let header_entry_idx = (0..=cursor_entry_idx)
+            .rev()
+            .find(|&i| matches!(self.entries[i], Entry::Header(_)))
+            .unwrap_or(0);
+        Self::entry_to_line(&self.entries, header_entry_idx)
+    }
+
+    /// Map an entry index to its rendered line number.
+    fn entry_to_line(entries: &[Entry], target: usize) -> usize {
+        let mut line = 0;
+        for (i, entry) in entries.iter().enumerate() {
+            if i == target {
+                return line;
+            }
+            match entry {
+                Entry::Header(_) => {
+                    if i > 0 {
+                        line += 1; // blank separator before non-first headers
+                    }
+                    line += 1; // the header itself
+                }
+                Entry::Item { .. } => {
+                    line += 1;
+                }
+            }
+        }
+        line
+    }
+
+    /// Adjust scroll so the cursor stays within the visible viewport.
+    ///
+    /// When scrolling up, we try to include the section header if the cursor is
+    /// close enough that both cursor and header fit in one viewport. For tall
+    /// sections where the header is far above, we just scroll to the cursor.
+    pub(crate) fn ensure_cursor_visible(&mut self) {
+        if self.visible_height == 0 {
+            return;
+        }
+        let cursor_line = self.cursor_line();
+
+        // Scroll up if cursor is above viewport.
+        if cursor_line < self.scroll {
+            let header_line = self.section_header_line();
+            // Show the header too, but only if cursor-to-header distance fits.
+            if cursor_line - header_line < self.visible_height {
+                self.scroll = header_line;
+            } else {
+                self.scroll = cursor_line;
+            }
+        }
+
+        // Scroll down if cursor is below viewport.
+        if cursor_line >= self.scroll + self.visible_height {
+            self.scroll = cursor_line - self.visible_height + 1;
+        }
+    }
+
+    /// Current cursor index (for testing).
+    pub fn cursor(&self) -> usize {
+        self.cursor
+    }
+
+    /// Current scroll offset (for testing).
+    pub fn scroll_offset(&self) -> usize {
+        self.scroll
+    }
+
+    /// Set the visible height (normally set during render; exposed for testing).
+    pub fn set_visible_height(&mut self, h: usize) {
+        self.visible_height = h;
+    }
+}
+
+/// Helper to construct sections concisely (useful in tests and examples).
+#[cfg(test)]
+pub fn section(title: impl Into<String>, items: &[(&str, bool)]) -> Section {
+    Section {
+        title: title.into(),
+        items: items
+            .iter()
+            .map(|(label, checked)| SectionItem {
+                label: label.to_string(),
+                checked: *checked,
+            })
+            .collect(),
+    }
+}

--- a/src/sectioned-picker/src/tests/mod.rs
+++ b/src/sectioned-picker/src/tests/mod.rs
@@ -1,0 +1,2 @@
+mod render;
+mod state;

--- a/src/sectioned-picker/src/tests/render.rs
+++ b/src/sectioned-picker/src/tests/render.rs
@@ -1,0 +1,184 @@
+//! Rendering tests: verify the picker's visual output using TestBackend.
+//!
+//! These render the picker into an in-memory terminal buffer and assert on the
+//! text content. This catches regressions in layout, styling, and scroll behavior
+//! that pure state tests cannot detect.
+
+use crate::render::render_picker;
+use crate::state::{PickerState, section};
+use ratatui::Terminal;
+use ratatui::backend::TestBackend;
+use snapbox::{assert_data_eq, str};
+
+/// Render the picker into an in-memory buffer and return the text content.
+fn render_to_string(width: u16, height: u16, title: &str, state: &mut PickerState) -> String {
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| render_picker(frame, title, state, &[]))
+        .unwrap();
+    terminal.backend().to_string()
+}
+
+// ============================================================================
+// Basic rendering
+// ============================================================================
+
+#[test]
+fn renders_title_and_sections() {
+    let mut state = PickerState::new(vec![
+        section("Features:", &[("logging", true), ("metrics", false)]),
+        section("Actions:", &[("Add `ci` template", false)]),
+    ]);
+    let output = render_to_string(50, 12, "my-pack v1.0", &mut state);
+
+    assert!(output.contains("my-pack v1.0"), "title missing");
+    assert!(output.contains("Features:"), "features header missing");
+    assert!(output.contains("Actions:"), "actions header missing");
+    assert!(output.contains("[x] logging"), "checked item missing");
+    assert!(output.contains("[ ] metrics"), "unchecked item missing");
+    assert!(
+        output.contains("Add `ci` template"),
+        "template action missing"
+    );
+}
+
+#[test]
+fn cursor_shown_on_first_item() {
+    let mut state = PickerState::new(vec![section("S:", &[("first", false), ("second", false)])]);
+    let output = render_to_string(40, 8, "test", &mut state);
+
+    assert!(output.contains("> [ ] first"), "cursor indicator missing");
+    assert!(!output.contains("> [ ] second"), "cursor on wrong item");
+}
+
+#[test]
+fn cursor_moves_with_navigation() {
+    let mut state = PickerState::new(vec![section("S:", &[("a", false), ("b", false)])]);
+    state.set_visible_height(10);
+    state.move_down();
+
+    let output = render_to_string(40, 8, "test", &mut state);
+
+    assert!(!output.contains("> [ ] a"), "cursor still on first");
+    assert!(output.contains("> [ ] b"), "cursor not on second");
+}
+
+#[test]
+fn toggle_updates_checkbox() {
+    let mut state = PickerState::new(vec![section("S:", &[("item", false)])]);
+    state.toggle();
+
+    let output = render_to_string(40, 8, "test", &mut state);
+    assert!(output.contains("[x] item"), "toggle not reflected");
+}
+
+#[test]
+fn footer_shows_keybindings() {
+    let mut state = PickerState::new(vec![section("S:", &[("a", false)])]);
+    let output = render_to_string(80, 8, "test", &mut state);
+
+    assert!(output.contains("Navigate"), "navigation hint missing");
+    assert!(output.contains("Toggle"), "toggle hint missing");
+    assert!(output.contains("Confirm"), "confirm hint missing");
+    assert!(output.contains("Cancel"), "cancel hint missing");
+}
+
+// ============================================================================
+// Custom actions — footer rendering
+// ============================================================================
+
+#[test]
+fn footer_includes_custom_action_labels() {
+    use crate::PickerAction;
+
+    let mut state = PickerState::new(vec![section("S:", &[("a", false)])]);
+    let actions = vec![
+        PickerAction {
+            key: 'p',
+            label: "Preview",
+            handler: Box::new(|_ctx| {}),
+        },
+        PickerAction {
+            key: 'o',
+            label: "Open",
+            handler: Box::new(|_ctx| {}),
+        },
+    ];
+
+    let backend = TestBackend::new(80, 8);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| render_picker(frame, "test", &mut state, &actions))
+        .unwrap();
+    let output = terminal.backend().to_string();
+
+    assert!(output.contains("p Preview"), "action 'p Preview' missing");
+    assert!(output.contains("o Open"), "action 'o Open' missing");
+}
+
+// ============================================================================
+// Snapshot tests — full rendered output
+// ============================================================================
+
+#[test]
+fn snapshot_single_section() {
+    let mut state = PickerState::new(vec![section(
+        "Dependencies:",
+        &[
+            ("tokio (1.38)", true),
+            ("serde (1.0)", true),
+            ("anyhow (1)", false),
+        ],
+    )]);
+    let output = render_to_string(60, 10, "cli-pack v2.0", &mut state);
+    assert_data_eq!(
+        output,
+        str![[r#"
+"                        cli-pack v2.0                       "
+"                                                            "
+"┌──────────────────────────────────────────────────────────┐"
+"│Dependencies:                                             │"
+"│> [x] tokio (1.38)                                        │"
+"│  [x] serde (1.0)                                         │"
+"│  [ ] anyhow (1)                                          │"
+"│                                                          │"
+"└──────────────────────────────────────────────────────────┘"
+"↑↓/jk Navigate | Space Toggle | a Toggle section | Enter Con"
+
+"#]]
+    );
+}
+
+#[test]
+fn snapshot_multiple_sections() {
+    let mut state = PickerState::new(vec![
+        section(
+            "Features:",
+            &[("observability", true), ("resilience", false)],
+        ),
+        section("Dependencies:", &[("tokio", true)]),
+        section("Actions:", &[("Add `ci` template", false)]),
+    ]);
+    let output = render_to_string(60, 14, "fancy v1.0", &mut state);
+    assert_data_eq!(
+        output,
+        str![[r#"
+"                         fancy v1.0                         "
+"                                                            "
+"┌──────────────────────────────────────────────────────────┐"
+"│Features:                                                 │"
+"│> [x] observability                                       │"
+"│  [ ] resilience                                          │"
+"│                                                          │"
+"│Dependencies:                                             │"
+"│  [x] tokio                                               │"
+"│                                                          │"
+"│Actions:                                                  │"
+"│  [ ] Add `ci` template                                   │"
+"└──────────────────────────────────────────────────────────┘"
+"↑↓/jk Navigate | Space Toggle | a Toggle section | Enter Con"
+
+"#]]
+    );
+}

--- a/src/sectioned-picker/src/tests/state.rs
+++ b/src/sectioned-picker/src/tests/state.rs
@@ -1,0 +1,445 @@
+//! Tests for picker state: navigation, toggle, scroll, and results.
+//!
+//! These exercise `PickerState` without a terminal — we construct state directly,
+//! call navigation/toggle methods, then assert on cursor position, scroll offset,
+//! and result output.
+//!
+//! # Scroll edge cases covered
+//!
+//! - All items fit in viewport → scroll stays 0.
+//! - Cursor moves below viewport → scroll advances minimally.
+//! - Cursor moves above viewport → scroll retreats, snapping to section header
+//!   when the header is close enough to fit in the viewport.
+//! - Tall section (more items than viewport) → upward movement does NOT snap to
+//!   the distant header; only snaps when cursor is near the section top.
+//! - Blank lines between sections are accounted for in line calculations.
+
+use crate::state::{Entry, PickerState, section};
+
+fn make_state(sections: Vec<crate::Section>, visible_height: usize) -> PickerState {
+    let mut state = PickerState::new(sections);
+    state.set_visible_height(visible_height);
+    state
+}
+
+// ============================================================================
+// Navigation — cursor movement and header skipping
+// ============================================================================
+
+#[test]
+fn cursor_starts_at_first_item() {
+    let state = make_state(
+        vec![section("Features:", &[("feat-a", false), ("feat-b", true)])],
+        10,
+    );
+    assert_eq!(state.cursor(), 0);
+}
+
+#[test]
+fn move_down_advances_cursor() {
+    let mut state = make_state(
+        vec![section(
+            "Features:",
+            &[("a", false), ("b", false), ("c", false)],
+        )],
+        10,
+    );
+    state.move_down();
+    assert_eq!(state.cursor(), 1);
+    state.move_down();
+    assert_eq!(state.cursor(), 2);
+}
+
+#[test]
+fn move_down_stops_at_last_item() {
+    let mut state = make_state(vec![section("S:", &[("a", false), ("b", false)])], 10);
+    state.move_down();
+    state.move_down();
+    state.move_down();
+    assert_eq!(state.cursor(), 1);
+}
+
+#[test]
+fn move_up_stops_at_first_item() {
+    let mut state = make_state(vec![section("S:", &[("a", false), ("b", false)])], 10);
+    state.move_up();
+    assert_eq!(state.cursor(), 0);
+}
+
+#[test]
+fn navigation_skips_headers_across_sections() {
+    let mut state = make_state(
+        vec![
+            section("Features:", &[("a", false)]),
+            section("Dependencies:", &[("b", false)]),
+        ],
+        20,
+    );
+    state.move_down();
+    assert_eq!(state.cursor(), 1);
+    let entry_idx = state.current_entry_idx();
+    assert!(matches!(&state.entries[entry_idx], Entry::Item { label, .. } if label == "b"));
+}
+
+// ============================================================================
+// Toggle — individual items and whole sections
+// ============================================================================
+
+#[test]
+fn toggle_flips_checked_state() {
+    let mut state = make_state(vec![section("S:", &[("a", false), ("b", true)])], 10);
+    state.toggle();
+    let results = state.into_results();
+    assert_eq!(results, vec![vec![true, true]]);
+}
+
+#[test]
+fn toggle_section_checks_all_when_some_unchecked() {
+    let mut state = make_state(
+        vec![section("S:", &[("a", true), ("b", false), ("c", true)])],
+        10,
+    );
+    state.toggle_current_section();
+    let results = state.into_results();
+    assert_eq!(results, vec![vec![true, true, true]]);
+}
+
+#[test]
+fn toggle_section_unchecks_all_when_all_checked() {
+    let mut state = make_state(vec![section("S:", &[("a", true), ("b", true)])], 10);
+    state.toggle_current_section();
+    let results = state.into_results();
+    assert_eq!(results, vec![vec![false, false]]);
+}
+
+#[test]
+fn toggle_section_only_affects_current_section() {
+    let mut state = make_state(
+        vec![
+            section("A:", &[("a1", false), ("a2", false)]),
+            section("B:", &[("b1", true)]),
+        ],
+        20,
+    );
+    state.toggle_current_section();
+    let results = state.into_results();
+    assert_eq!(results, vec![vec![true, true], vec![true]]);
+}
+
+// ============================================================================
+// Enter behavior — auto-check when nothing selected
+// ============================================================================
+
+#[test]
+fn enter_with_nothing_checked_checks_cursor_item() {
+    let mut state = make_state(
+        vec![section("S:", &[("a", false), ("b", false), ("c", false)])],
+        10,
+    );
+    state.move_down();
+    assert!(!state.has_any_checked());
+    state.toggle();
+    let results = state.into_results();
+    assert_eq!(results, vec![vec![false, true, false]]);
+}
+
+#[test]
+fn enter_with_something_checked_does_not_toggle() {
+    let mut state = make_state(
+        vec![section("S:", &[("a", true), ("b", false), ("c", false)])],
+        10,
+    );
+    state.move_down();
+    assert!(state.has_any_checked());
+    let results = state.into_results();
+    assert_eq!(results, vec![vec![true, false, false]]);
+}
+
+// ============================================================================
+// Coordinates — section/item mapping (used by action handlers)
+// ============================================================================
+
+#[test]
+fn current_coordinates_tracks_section_and_item() {
+    let mut state = make_state(
+        vec![
+            section("A:", &[("a1", false), ("a2", false)]),
+            section("B:", &[("b1", false)]),
+        ],
+        20,
+    );
+    assert_eq!(state.current_coordinates(), (0, 0));
+    state.move_down();
+    assert_eq!(state.current_coordinates(), (0, 1));
+    state.move_down();
+    assert_eq!(state.current_coordinates(), (1, 0));
+}
+
+#[test]
+fn coordinates_correct_with_empty_sections() {
+    let mut state = make_state(
+        vec![
+            section("Empty:", &[]),
+            section("Full:", &[("x", false), ("y", false)]),
+        ],
+        20,
+    );
+    // First selectable item is in the second section (index 1).
+    assert_eq!(state.current_coordinates(), (1, 0));
+    state.move_down();
+    assert_eq!(state.current_coordinates(), (1, 1));
+}
+
+#[test]
+fn coordinates_correct_with_many_sections() {
+    let mut state = make_state(
+        vec![
+            section("A:", &[("a1", false)]),
+            section("B:", &[("b1", false), ("b2", false)]),
+            section("C:", &[("c1", false)]),
+        ],
+        20,
+    );
+    assert_eq!(state.current_coordinates(), (0, 0)); // a1
+    state.move_down();
+    assert_eq!(state.current_coordinates(), (1, 0)); // b1
+    state.move_down();
+    assert_eq!(state.current_coordinates(), (1, 1)); // b2
+    state.move_down();
+    assert_eq!(state.current_coordinates(), (2, 0)); // c1
+}
+
+// ============================================================================
+// Action dispatch simulation
+// ============================================================================
+
+/// Verifies the contract between PickerState and action handlers: navigating to
+/// an item and reading current_coordinates gives the handler correct context.
+#[test]
+fn action_handler_receives_correct_coordinates() {
+    let mut state = make_state(
+        vec![
+            section("Features:", &[("feat-a", false), ("feat-b", false)]),
+            section(
+                "Actions:",
+                &[("template-ci", false), ("template-svc", false)],
+            ),
+        ],
+        20,
+    );
+
+    // Simulate: user navigates to "template-svc" (section 1, item 1).
+    state.move_down(); // feat-b (0, 1)
+    state.move_down(); // template-ci (1, 0)
+    state.move_down(); // template-svc (1, 1)
+
+    // This is what the event loop passes to the handler.
+    let (section_idx, item_idx) = state.current_coordinates();
+    assert_eq!(section_idx, 1);
+    assert_eq!(item_idx, 1);
+}
+
+// ============================================================================
+// Results — checked state grouped by section
+// ============================================================================
+
+#[test]
+fn into_results_groups_by_section() {
+    let mut state = make_state(
+        vec![
+            section("Features:", &[("a", true), ("b", false)]),
+            section("Deps:", &[("c", true)]),
+            section("Actions:", &[("d", false), ("e", false)]),
+        ],
+        20,
+    );
+    let results = state.into_results();
+    assert_eq!(
+        results,
+        vec![vec![true, false], vec![true], vec![false, false]]
+    );
+}
+
+#[test]
+fn empty_sections_produce_empty_vecs() {
+    let mut state = make_state(
+        vec![
+            section("Empty:", &[]),
+            section("Has items:", &[("a", true)]),
+        ],
+        10,
+    );
+    let results = state.into_results();
+    assert_eq!(results, vec![vec![], vec![true]]);
+}
+
+// ============================================================================
+// Scrolling — viewport management
+// ============================================================================
+
+#[test]
+fn scroll_stays_zero_when_all_items_fit() {
+    let mut state = make_state(vec![section("S:", &[("a", false), ("b", false)])], 10);
+    state.move_down();
+    assert_eq!(state.scroll_offset(), 0);
+}
+
+#[test]
+fn scroll_advances_when_cursor_moves_below_viewport() {
+    let mut state = make_state(
+        vec![section(
+            "S:",
+            &[("a", false), ("b", false), ("c", false), ("d", false)],
+        )],
+        3,
+    );
+    assert_eq!(state.scroll_offset(), 0);
+    state.move_down();
+    assert_eq!(state.scroll_offset(), 0);
+    state.move_down();
+    assert_eq!(state.scroll_offset(), 1);
+    state.move_down();
+    assert_eq!(state.scroll_offset(), 2);
+}
+
+#[test]
+fn scroll_retreats_when_cursor_moves_above_viewport() {
+    let mut state = make_state(
+        vec![section(
+            "S:",
+            &[("a", false), ("b", false), ("c", false), ("d", false)],
+        )],
+        3,
+    );
+    state.move_down();
+    state.move_down();
+    state.move_down();
+    assert!(state.scroll_offset() > 0);
+    let bottom_scroll = state.scroll_offset();
+
+    state.move_up();
+    state.move_up();
+    state.move_up();
+    assert_eq!(state.scroll_offset(), 0);
+    assert!(state.scroll_offset() < bottom_scroll);
+}
+
+/// Regression: scrolling back to the first item must reveal the section header.
+#[test]
+fn scroll_back_to_top_shows_section_header() {
+    let mut state = make_state(
+        vec![
+            section("Features:", &[("a", false), ("b", false), ("c", false)]),
+            section("Deps:", &[("d", false)]),
+        ],
+        3,
+    );
+    state.move_down();
+    state.move_down();
+    state.move_down();
+    assert!(state.scroll_offset() > 0);
+
+    state.move_up();
+    state.move_up();
+    state.move_up();
+    assert_eq!(state.scroll_offset(), 0);
+}
+
+#[test]
+fn scroll_accounts_for_blank_lines_between_sections() {
+    let mut state = make_state(
+        vec![
+            section("A:", &[("a1", false)]),
+            section("B:", &[("b1", false), ("b2", false)]),
+        ],
+        3,
+    );
+    state.move_down();
+    assert!(
+        state.scroll_offset() >= 2,
+        "scroll={}",
+        state.scroll_offset()
+    );
+    state.move_down();
+    assert!(
+        state.scroll_offset() >= 3,
+        "scroll={}",
+        state.scroll_offset()
+    );
+}
+
+/// Tall section: moving up mid-section must NOT snap to the distant header.
+#[test]
+fn scroll_in_tall_section_does_not_snap_to_header() {
+    let items: Vec<(&str, bool)> = vec![
+        ("a", false),
+        ("b", false),
+        ("c", false),
+        ("d", false),
+        ("e", false),
+        ("f", false),
+        ("g", false),
+        ("h", false),
+        ("i", false),
+        ("j", false),
+    ];
+    let mut state = make_state(vec![section("S:", &items)], 3);
+
+    for _ in 0..6 {
+        state.move_down();
+    }
+    assert_eq!(state.cursor(), 6);
+    let scroll_at_g = state.scroll_offset();
+
+    state.move_up();
+    assert_eq!(state.cursor(), 5);
+    let scroll_at_f = state.scroll_offset();
+    assert!(scroll_at_f >= scroll_at_g - 1);
+    assert!(scroll_at_f > 0);
+}
+
+/// Complement: scrolling all the way up in a tall section still shows the header.
+#[test]
+fn scroll_shows_header_only_when_cursor_near_top_of_section() {
+    let items: Vec<(&str, bool)> = vec![
+        ("a", false),
+        ("b", false),
+        ("c", false),
+        ("d", false),
+        ("e", false),
+        ("f", false),
+    ];
+    let mut state = make_state(vec![section("S:", &items)], 3);
+
+    for _ in 0..5 {
+        state.move_down();
+    }
+    assert!(state.scroll_offset() > 0);
+
+    for _ in 0..5 {
+        state.move_up();
+    }
+    assert_eq!(state.cursor(), 0);
+    assert_eq!(state.scroll_offset(), 0);
+}
+
+// ============================================================================
+// cursor_line — verifies the rendered-line computation
+// ============================================================================
+
+#[test]
+fn cursor_line_matches_expected_positions() {
+    let mut state = make_state(
+        vec![
+            section("Features:", &[("a", false), ("b", false)]),
+            section("Deps:", &[("c", false)]),
+        ],
+        20,
+    );
+
+    assert_eq!(state.cursor_line(), 1);
+    state.move_down();
+    assert_eq!(state.cursor_line(), 2);
+    state.move_down();
+    assert_eq!(state.cursor_line(), 5);
+}


### PR DESCRIPTION
Revamp the `cargo bp add` TUI. It now looks like this:

```
                                                              ci-battery-pack v0.1.5

┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│Features:                                                                                                                                        │
│> [ ] ✦ benchmarks [criterion]                                                                                                                   │
│  [ ] ✦ fuzzing [arbitrary, libfuzzer-sys]                                                                                                       │
│  [ ] ✦ xtask [xflags, xshell]                                                                                                                   │
│                                                                                                                                                 │
│Dependencies:                                                                                                                                    │
│  [ ] arbitrary (1, features: derive)                                                                                                            │
│  [ ] criterion (0.8, features: html_reports)                                                                                                    │
│  [ ] libfuzzer-sys (0.4)                                                                                                                        │
│  [ ] xflags (0.3)                                                                                                                               │
│  [ ] xshell (0.2)                                                                                                                               │
│                                                                                                                                                 │
│Actions:                                                                                                                                         │
│  [ ] Add `benchmarks` template — Criterion bench scaffold + Bencher CI                                                                          │
│  [ ] Add `binary-release` template — Cross-platform binary builds for GitHub Releases + cargo-binstall                                          │
│  [ ] Add `clippy-sarif` template — Clippy with GitHub PR annotations via SARIF                                                                  │
│  [ ] Add `full` template — Full CI setup with optional benchmarks, fuzzing, mdbook, spellcheck, and xtask                                       │
│  [ ] Add `fuzzing` template — cargo-fuzz scaffold + CI workflows                                                                                │
│  [ ] Add `mdbook` template — mdBook scaffold + GitHub Pages deployment                                                                          │
│  [ ] Add `mutation-testing` template — Mutation testing with cargo-mutants                                                                      │
│  [ ] Add `spellcheck` template — crate-ci/typos config + CI workflow                                                                            │
│  [ ] Add `stress-test` template — nextest stress test workflow                                                                                  │
│  [ ] Add `trusted-publishing` template — release-plz with OIDC trusted publishing                                                               │
│  [ ] Add `xtask` template — cargo-xtask scaffold with codegen --check                                                                           │
│                                                                                                                                                 │
│                                                                                                                                                 │
│                                                                                                                                                 │
│                                                                                                                                                 │
│                                                                                                                                                 │
│                                                                                                                                                 │
│                                                                                                                                                 │
│                                                                                                                                                 │
│                                                                                                                                                 │
│                                                                                                                                                 │
│                                                                                                                                                 │
│                                                                                                                                                 │
│                                                                                                                                                 │
│                                                                                                                                                 │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
↑↓/jk Navigate | Space Toggle | a Toggle section | p Preview | Enter Confirm | Esc Cancel
```

You can press `p` on the "actions" to view a preview. This PR introduces a distinct crate for the widget and then uses it within cargo-bp.