### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,7 +395,7 @@ checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 
 [[package]]
 name = "backend-service-battery-pack"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -462,7 +462,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "battery-pack"
-version = "0.5.5"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "battery-pack",
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "bphelper-build"
-version = "0.4.8"
+version = "0.5.0"
 dependencies = [
  "bphelper-manifest",
  "cargo_metadata",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "bphelper-cli"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "bphelper-manifest",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "bphelper-manifest"
-version = "0.5.6"
+version = "0.6.0"
 dependencies = [
  "cargo_metadata",
  "indoc",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-bp"
-version = "0.5.6"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-bp-script"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "ci-battery-pack"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "arbitrary",
  "battery-pack",
@@ -947,7 +947,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-battery-pack"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "embedded-battery-pack"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "atsamd-hal",
  "battery-pack",
@@ -2145,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "error-battery-pack"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "battery-pack",
@@ -3561,7 +3561,7 @@ checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "logging-battery-pack"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "battery-pack",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-battery-pack = { path = "src/battery-pack", version = "0.5" }
+battery-pack = { path = "src/battery-pack", version = "0.6" }
 cargo-bp-script = { path = "src/cargo-bp-script", version = "0.2" }
 anyhow = "1"
 minijinja = { version = "2", features = ["loader"] }

--- a/battery-packs/backend-service-battery-pack/CHANGELOG.md
+++ b/battery-packs/backend-service-battery-pack/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/battery-pack-rs/battery-pack/compare/backend-service-battery-pack-v0.1.1...backend-service-battery-pack-v0.1.2) - 2026-07-16
+
+### Fixed
+
+- use stable backend skills link
+- update paths after battery pack merge
+
+### Other
+
+- merge battery pack directories
+
 ## [0.1.1](https://github.com/battery-pack-rs/battery-pack/compare/backend-service-battery-pack-v0.1.0...backend-service-battery-pack-v0.1.1) - 2026-06-03
 
 ### Added

--- a/battery-packs/backend-service-battery-pack/Cargo.toml
+++ b/battery-packs/backend-service-battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "backend-service-battery-pack"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 description = "Opinionated battery pack for resilient async backend services in Rust"
 license = "MIT OR Apache-2.0"

--- a/battery-packs/ci-battery-pack/CHANGELOG.md
+++ b/battery-packs/ci-battery-pack/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/battery-pack-rs/battery-pack/compare/ci-battery-pack-v0.1.5...ci-battery-pack-v0.1.6) - 2026-07-16
+
+### Added
+
+- *(packs)* add category metadata to cli, ci, and backend-service packs (Phase 8)
+- *(ci)* add security scanning template
+- *(ci)* default generated dependency policy
+- *(ci)* document generated audit policy
+- *(ci)* add optional dependency policy template
+
+### Fixed
+
+- *(ci)* refresh dependency policy snapshots
+- *(ci)* remove path filter from dependency-policy pull_request trigger
+- *(ci)* warn on wildcard dependencies in policy template
+- *(ci)* run generated audit workflow on config changes
+
+### Other
+
+- Fix mdBook links and add link checking
+- *(ci)* drop action ref comments from snapshots
+- *(ci)* clarify unresolved action redaction
+- *(ci)* simplify snapshot normalization
+- *(ci)* normalize workflow snapshot pins
+- allow NCSA license in dependency policy
+- *(ci)* clarify audit issue prompt
+- *(ci)* align skill template commands
+- *(ci)* simplify optional feature guidance
+- *(ci)* tighten security scanning text
+- *(ci)* keep audit issue option out of feature table
+- add repository license policy
+
+### Security
+
+- fix rustsec vulnerabilities
+
 ## [0.1.5](https://github.com/battery-pack-rs/battery-pack/compare/ci-battery-pack-v0.1.4...ci-battery-pack-v0.1.5) - 2026-06-03
 
 ### Added

--- a/battery-packs/ci-battery-pack/Cargo.toml
+++ b/battery-packs/ci-battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ci-battery-pack"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 description = "Battery pack for CI/CD workflows in Rust projects"
 license = "MIT OR Apache-2.0"

--- a/battery-packs/cli-battery-pack/CHANGELOG.md
+++ b/battery-packs/cli-battery-pack/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3](https://github.com/battery-pack-rs/battery-pack/compare/cli-battery-pack-v0.6.2...cli-battery-pack-v0.6.3) - 2026-07-16
+
+### Added
+
+- *(packs)* add category metadata to cli, ci, and backend-service packs (Phase 8)
+
+### Fixed
+
+- *(cli-battery-pack)* stabilize help snapshots
+- *(cli-battery-pack)* normalize help snapshots
+
+### Other
+
+- Fix mdBook links and add link checking
+- *(packs)* update battery pack content for auto-generated docs
+
 ## [0.6.2](https://github.com/battery-pack-rs/battery-pack/compare/cli-battery-pack-v0.6.1...cli-battery-pack-v0.6.2) - 2026-06-03
 
 ### Fixed

--- a/battery-packs/cli-battery-pack/Cargo.toml
+++ b/battery-packs/cli-battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli-battery-pack"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2024"
 description = "Battery pack for building CLI applications in Rust"
 license = "MIT OR Apache-2.0"

--- a/battery-packs/embedded-battery-pack/CHANGELOG.md
+++ b/battery-packs/embedded-battery-pack/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/battery-pack-rs/battery-pack/compare/embedded-battery-pack-v0.1.0...embedded-battery-pack-v0.1.1) - 2026-07-16
+
+### Other
+
+- updated the following local packages: battery-pack, battery-pack

--- a/battery-packs/embedded-battery-pack/Cargo.toml
+++ b/battery-packs/embedded-battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-battery-pack"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Opinionated battery pack for embedded Rust — curates HALs, drivers, RTOSes, and no_std utilities from the awesome-embedded-rust ecosystem"
 license = "MIT OR Apache-2.0"

--- a/battery-packs/error-battery-pack/CHANGELOG.md
+++ b/battery-packs/error-battery-pack/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.5](https://github.com/battery-pack-rs/battery-pack/compare/error-battery-pack-v0.6.4...error-battery-pack-v0.6.5) - 2026-07-16
+
+### Other
+
+- Fix mdBook links and add link checking
+- *(packs)* update battery pack content for auto-generated docs
+
 ## [0.6.4](https://github.com/battery-pack-rs/battery-pack/compare/error-battery-pack-v0.6.3...error-battery-pack-v0.6.4) - 2026-06-03
 
 ### Other

--- a/battery-packs/error-battery-pack/Cargo.toml
+++ b/battery-packs/error-battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "error-battery-pack"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2024"
 description = "Error handling done well — anyhow for apps, thiserror for libraries"
 license = "MIT OR Apache-2.0"

--- a/battery-packs/logging-battery-pack/CHANGELOG.md
+++ b/battery-packs/logging-battery-pack/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.3](https://github.com/battery-pack-rs/battery-pack/compare/logging-battery-pack-v0.5.2...logging-battery-pack-v0.5.3) - 2026-07-16
+
+### Other
+
+- Fix mdBook links and add link checking
+- *(packs)* update battery pack content for auto-generated docs
+
 ## [0.5.2](https://github.com/battery-pack-rs/battery-pack/compare/logging-battery-pack-v0.5.1...logging-battery-pack-v0.5.2) - 2026-06-03
 
 ### Other

--- a/battery-packs/logging-battery-pack/Cargo.toml
+++ b/battery-packs/logging-battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logging-battery-pack"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2024"
 description = "Battery pack for logging and tracing in Rust"
 license = "MIT OR Apache-2.0"

--- a/src/battery-pack/CHANGELOG.md
+++ b/src/battery-pack/CHANGELOG.md
@@ -7,6 +7,79 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.5.5...battery-pack-v0.6.0) - 2026-07-16
+
+### Added
+
+- *(docgen)* category-aware crate-table with unified rendering
+- *(template)* derive select-placeholder options from a category (Phase 6)
+- *(show)* surface categories in cargo bp show text and JSON (Phase 7)
+- *(cli)* wire categories into picker and validate exclusive -F picks (Phase 4+5)
+- *(picker)* add radio mode, collapsing, and item descriptions (Phase 3)
+- wire up `p` preview action in the `cargo bp add` picker
+- extract sectioned-picker into standalone crate
+- record applied template in state when using `cargo bp new`
+- track applied templates in battery-pack.toml and surface in status
+- show templates in the interactive `cargo bp add` picker
+- *(state)* [**breaking**] bump format to v2, use all-features flag for ActiveFeatures::All
+- *(manifest)* parse and validate category metadata (Phase 1+2)
+- *(packs)* add category metadata to cli, ci, and backend-service packs (Phase 8)
+- *(ci)* add security scanning template
+- *(ci)* default generated dependency policy
+- *(ci)* document generated audit policy
+- *(ci)* add optional dependency policy template
+
+### Fixed
+
+- use stable backend skills link
+- update paths after battery pack merge
+- cargo fmt for bphelper-build
+- address post-implementation review findings (Phase 9)
+- address adversarial review findings in categories impl
+- *(cli)* propagate existing All state as all_features flag instead of sentinel
+- *(manifest)* include implicit-feature optional deps under ActiveFeatures::All
+- spelling :)
+- spelling and formatting
+- *(ci)* refresh dependency policy snapshots
+- *(ci)* remove path filter from dependency-policy pull_request trigger
+- *(ci)* warn on wildcard dependencies in policy template
+- *(ci)* run generated audit workflow on config changes
+- *(cli-battery-pack)* stabilize help snapshots
+- *(cli-battery-pack)* normalize help snapshots
+
+### Other
+
+- merge battery pack directories
+- Fix mdBook links and add link checking
+- switch feature lists to a parsed FeatureRef
+- Merge branch 'main' of https://github.com/battery-pack-rs/battery-pack into fix/issue-13-cargo-metadata
+- add the cargo.toml metadata
+- *(spec)* document category rules in format/cli/tui specs
+- *(picker)* improve the picker UI and make it inline
+- migrate bphelper-cli modules to new layout
+- fix rustfmt line-joining for CI toolchain
+- Merge branch 'main' of https://github.com/battery-pack-rs/battery-pack into fix/issue-13-cargo-metadata
+- ActiveFeatures enum + resolver hardening
+- *(manifest)* restrict resolve_all() to test-only visibility
+- Update src/battery-pack/bphelper-manifest/src/lib.rs
+- add a cargo-metadata oracle test
+- *(ci)* drop action ref comments from snapshots
+- *(ci)* clarify unresolved action redaction
+- *(ci)* simplify snapshot normalization
+- *(ci)* normalize workflow snapshot pins
+- allow NCSA license in dependency policy
+- *(ci)* clarify audit issue prompt
+- *(ci)* align skill template commands
+- *(ci)* simplify optional feature guidance
+- *(ci)* tighten security scanning text
+- *(ci)* keep audit issue option out of feature table
+- add repository license policy
+- *(packs)* update battery pack content for auto-generated docs
+
+### Security
+
+- fix rustsec vulnerabilities
+
 ## [0.5.5](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.5.4...battery-pack-v0.5.5) - 2026-06-03
 
 ### Added

--- a/src/battery-pack/Cargo.toml
+++ b/src/battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "battery-pack"
-version = "0.5.5"
+version = "0.6.0"
 edition = "2024"
 description = "Curated crate bundles with docs, templates, and agentic skills"
 license = "MIT OR Apache-2.0"
@@ -21,9 +21,9 @@ build = ["bphelper-build"]
 cli = ["bphelper-cli"]
 
 [dependencies]
-bphelper-build = { path = "bphelper-build", version = "0.4.8", optional = true }
-bphelper-cli = { path = "bphelper-cli", version = "0.9.0", optional = true }
-bphelper-manifest = { path = "bphelper-manifest", version = "0.5.6" }
+bphelper-build = { path = "bphelper-build", version = "0.5.0", optional = true }
+bphelper-cli = { path = "bphelper-cli", version = "0.10.0", optional = true }
+bphelper-manifest = { path = "bphelper-manifest", version = "0.6.0" }
 anyhow.workspace = true
 
 [dev-dependencies]

--- a/src/battery-pack/bphelper-build/CHANGELOG.md
+++ b/src/battery-pack/bphelper-build/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-build-v0.4.8...bphelper-build-v0.5.0) - 2026-07-16
+
+### Added
+
+- *(docgen)* category-aware crate-table with unified rendering
+
+### Fixed
+
+- update paths after battery pack merge
+- cargo fmt for bphelper-build
+
+### Other
+
+- Fix mdBook links and add link checking
+- switch feature lists to a parsed FeatureRef
+- Merge branch 'main' of https://github.com/battery-pack-rs/battery-pack into fix/issue-13-cargo-metadata
+
 ## [0.4.8](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-build-v0.4.7...bphelper-build-v0.4.8) - 2026-06-03
 
 ### Fixed

--- a/src/battery-pack/bphelper-build/Cargo.toml
+++ b/src/battery-pack/bphelper-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bphelper-build"
-version = "0.4.8"
+version = "0.5.0"
 edition = "2024"
 description = "Build-time documentation generation for battery packs"
 license = "MIT OR Apache-2.0"
@@ -8,7 +8,7 @@ repository = "https://github.com/battery-pack-rs/battery-pack"
 keywords = ["battery-pack"]
 
 [dependencies]
-bphelper-manifest = { path = "../bphelper-manifest", version = "0.5.6" }
+bphelper-manifest = { path = "../bphelper-manifest", version = "0.6.0" }
 handlebars.workspace = true
 cargo_metadata.workspace = true
 serde.workspace = true

--- a/src/battery-pack/bphelper-cli/CHANGELOG.md
+++ b/src/battery-pack/bphelper-cli/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.9.0...bphelper-cli-v0.10.0) - 2026-07-16
+
+### Added
+
+- *(template)* derive select-placeholder options from a category (Phase 6)
+- *(show)* surface categories in cargo bp show text and JSON (Phase 7)
+- *(cli)* wire categories into picker and validate exclusive -F picks (Phase 4+5)
+- *(picker)* add radio mode, collapsing, and item descriptions (Phase 3)
+- wire up `p` preview action in the `cargo bp add` picker
+- extract sectioned-picker into standalone crate
+- record applied template in state when using `cargo bp new`
+- track applied templates in battery-pack.toml and surface in status
+- show templates in the interactive `cargo bp add` picker
+- *(state)* [**breaking**] bump format to v2, use all-features flag for ActiveFeatures::All
+
+### Fixed
+
+- address post-implementation review findings (Phase 9)
+- address adversarial review findings in categories impl
+- *(cli)* propagate existing All state as all_features flag instead of sentinel
+- *(manifest)* include implicit-feature optional deps under ActiveFeatures::All
+
+### Other
+
+- add the cargo.toml metadata
+- *(spec)* document category rules in format/cli/tui specs
+- *(picker)* improve the picker UI and make it inline
+- migrate bphelper-cli modules to new layout
+- fix rustfmt line-joining for CI toolchain
+- Merge branch 'main' of https://github.com/battery-pack-rs/battery-pack into fix/issue-13-cargo-metadata
+- ActiveFeatures enum + resolver hardening
+- switch feature lists to a parsed FeatureRef
+- Merge branch 'main' of https://github.com/battery-pack-rs/battery-pack into fix/issue-13-cargo-metadata
+
 ## [0.9.0](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.8.2...bphelper-cli-v0.9.0) - 2026-06-03
 
 ### Added

--- a/src/battery-pack/bphelper-cli/Cargo.toml
+++ b/src/battery-pack/bphelper-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bphelper-cli"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 description = "CLI for creating and managing battery packs"
 license = "MIT OR Apache-2.0"
@@ -8,7 +8,7 @@ repository = "https://github.com/battery-pack-rs/battery-pack"
 keywords = ["battery-pack", "cli", "cargo"]
 
 [dependencies]
-bphelper-manifest = { path = "../bphelper-manifest", version = "0.5.6" }
+bphelper-manifest = { path = "../bphelper-manifest", version = "0.6.0" }
 cargo-bp-script.workspace = true
 clap.workspace = true
 clap_complete = { workspace = true, features = ["unstable-dynamic"] }

--- a/src/battery-pack/bphelper-manifest/CHANGELOG.md
+++ b/src/battery-pack/bphelper-manifest/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-manifest-v0.5.6...bphelper-manifest-v0.6.0) - 2026-07-16
+
+### Added
+
+- *(cli)* wire categories into picker and validate exclusive -F picks (Phase 4+5)
+- *(manifest)* parse and validate category metadata (Phase 1+2)
+
+### Fixed
+
+- address post-implementation review findings (Phase 9)
+- address adversarial review findings in categories impl
+- *(manifest)* include implicit-feature optional deps under ActiveFeatures::All
+- spelling :)
+- spelling and formatting
+
+### Other
+
+- *(manifest)* restrict resolve_all() to test-only visibility
+- Update src/battery-pack/bphelper-manifest/src/lib.rs
+- ActiveFeatures enum + resolver hardening
+- add a cargo-metadata oracle test
+- switch feature lists to a parsed FeatureRef
+- Merge branch 'main' of https://github.com/battery-pack-rs/battery-pack into fix/issue-13-cargo-metadata
+
 ## [0.5.6](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-manifest-v0.5.5...bphelper-manifest-v0.5.6) - 2026-06-03
 
 ### Fixed

--- a/src/battery-pack/bphelper-manifest/Cargo.toml
+++ b/src/battery-pack/bphelper-manifest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bphelper-manifest"
-version = "0.5.6"
+version = "0.6.0"
 edition = "2024"
 description = "Shared battery pack manifest parsing"
 license = "MIT OR Apache-2.0"

--- a/src/cargo-bp-script/CHANGELOG.md
+++ b/src/cargo-bp-script/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-script-v0.2.0...cargo-bp-script-v0.2.1) - 2026-07-16
+
+### Added
+
+- *(show)* surface categories in cargo bp show text and JSON (Phase 7)
+- track applied templates in battery-pack.toml and surface in status
+
 ## [0.2.0](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-script-v0.1.0...cargo-bp-script-v0.2.0) - 2026-06-03
 
 ### Added

--- a/src/cargo-bp-script/Cargo.toml
+++ b/src/cargo-bp-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-bp-script"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "Schema and process runner for scripting `cargo bp` commands (e.g. `cargo bp status --json`)"
 license = "MIT OR Apache-2.0"

--- a/src/cargo-bp/CHANGELOG.md
+++ b/src/cargo-bp/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-v0.5.6...cargo-bp-v0.6.0) - 2026-07-16
+
+### Added
+
+- record applied template in state when using `cargo bp new`
+- track applied templates in battery-pack.toml and surface in status
+- *(template)* derive select-placeholder options from a category (Phase 6)
+- *(show)* surface categories in cargo bp show text and JSON (Phase 7)
+- *(cli)* wire categories into picker and validate exclusive -F picks (Phase 4+5)
+- *(picker)* add radio mode, collapsing, and item descriptions (Phase 3)
+- wire up `p` preview action in the `cargo bp add` picker
+- extract sectioned-picker into standalone crate
+- show templates in the interactive `cargo bp add` picker
+- *(state)* [**breaking**] bump format to v2, use all-features flag for ActiveFeatures::All
+
+### Fixed
+
+- address post-implementation review findings (Phase 9)
+- address adversarial review findings in categories impl
+- *(cli)* propagate existing All state as all_features flag instead of sentinel
+- *(manifest)* include implicit-feature optional deps under ActiveFeatures::All
+
+### Other
+
+- add the cargo.toml metadata
+- *(spec)* document category rules in format/cli/tui specs
+- *(picker)* improve the picker UI and make it inline
+- migrate bphelper-cli modules to new layout
+- fix rustfmt line-joining for CI toolchain
+- Merge branch 'main' of https://github.com/battery-pack-rs/battery-pack into fix/issue-13-cargo-metadata
+- ActiveFeatures enum + resolver hardening
+- switch feature lists to a parsed FeatureRef
+- Merge branch 'main' of https://github.com/battery-pack-rs/battery-pack into fix/issue-13-cargo-metadata
+
 ## [0.5.6](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-v0.5.5...cargo-bp-v0.5.6) - 2026-06-03
 
 ### Added

--- a/src/cargo-bp/Cargo.toml
+++ b/src/cargo-bp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-bp"
-version = "0.5.6"
+version = "0.6.0"
 edition = "2024"
 description = "CLI for creating and managing battery packs (cargo bp)"
 license = "MIT OR Apache-2.0"
@@ -23,7 +23,7 @@ name = "cargo-bp"
 path = "src/main.rs"
 
 [dependencies]
-bphelper-cli = { path = "../battery-pack/bphelper-cli", version = "0.9" }
+bphelper-cli = { path = "../battery-pack/bphelper-cli", version = "0.10" }
 anyhow.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION



## 🤖 New release

* `bphelper-manifest`: 0.5.6 -> 0.6.0 (⚠ API breaking changes)
* `bphelper-build`: 0.4.8 -> 0.5.0 (⚠ API breaking changes)
* `cargo-bp-script`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `bphelper-cli`: 0.9.0 -> 0.10.0 (✓ API compatible changes)
* `battery-pack`: 0.5.5 -> 0.6.0 (✓ API compatible changes)
* `cargo-bp`: 0.5.6 -> 0.6.0
* `backend-service-battery-pack`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `cli-battery-pack`: 0.6.2 -> 0.6.3 (✓ API compatible changes)
* `ci-battery-pack`: 0.1.5 -> 0.1.6 (✓ API compatible changes)
* `error-battery-pack`: 0.6.4 -> 0.6.5 (✓ API compatible changes)
* `logging-battery-pack`: 0.5.2 -> 0.5.3 (✓ API compatible changes)
* `embedded-battery-pack`: 0.1.0 -> 0.1.1

### ⚠ `bphelper-manifest` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field TemplateSpec.categories in /tmp/.tmpwSEZWS/battery-pack/src/battery-pack/bphelper-manifest/src/lib.rs:215
  field BatteryPackSpec.categories in /tmp/.tmpwSEZWS/battery-pack/src/battery-pack/bphelper-manifest/src/lib.rs:270
  field BatteryPackSpec.feature_meta in /tmp/.tmpwSEZWS/battery-pack/src/battery-pack/bphelper-manifest/src/lib.rs:274
  field BatteryPackSpec.dep_meta in /tmp/.tmpwSEZWS/battery-pack/src/battery-pack/bphelper-manifest/src/lib.rs:278

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant Error:FeatureRefParse in /tmp/.tmpwSEZWS/battery-pack/src/battery-pack/bphelper-manifest/src/lib.rs:38
  variant Error:FeatureCycle in /tmp/.tmpwSEZWS/battery-pack/src/battery-pack/bphelper-manifest/src/lib.rs:46
  variant Error:Metadata in /tmp/.tmpwSEZWS/battery-pack/src/battery-pack/bphelper-manifest/src/lib.rs:56
  variant Error:MetadataDecode in /tmp/.tmpwSEZWS/battery-pack/src/battery-pack/bphelper-manifest/src/lib.rs:59

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_missing.ron

Failed in:
  function bphelper_manifest::discover_from_crate_root, previously in file /tmp/.tmpFmbcGC/bphelper-manifest/src/lib.rs:861
  function bphelper_manifest::parse_battery_pack, previously in file /tmp/.tmpFmbcGC/bphelper-manifest/src/lib.rs:676

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  BatteryPackSpec::resolve_all, previously in file /tmp/.tmpFmbcGC/bphelper-manifest/src/lib.rs:336
  BatteryPackSpec::resolve_all_visible, previously in file /tmp/.tmpFmbcGC/bphelper-manifest/src/lib.rs:342
```

### ⚠ `bphelper-build` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field DocsContext.categories in /tmp/.tmpwSEZWS/battery-pack/src/battery-pack/bphelper-build/src/lib.rs:56
  field DocsContext.templates in /tmp/.tmpwSEZWS/battery-pack/src/battery-pack/bphelper-build/src/lib.rs:58
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `bphelper-manifest`

<blockquote>

## [0.6.0](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-manifest-v0.5.6...bphelper-manifest-v0.6.0) - 2026-07-16

### Added

- *(cli)* wire categories into picker and validate exclusive -F picks (Phase 4+5)
- *(manifest)* parse and validate category metadata (Phase 1+2)

### Fixed

- address post-implementation review findings (Phase 9)
- address adversarial review findings in categories impl
- *(manifest)* include implicit-feature optional deps under ActiveFeatures::All
- spelling :)
- spelling and formatting

### Other

- *(manifest)* restrict resolve_all() to test-only visibility
- Update src/battery-pack/bphelper-manifest/src/lib.rs
- ActiveFeatures enum + resolver hardening
- add a cargo-metadata oracle test
- switch feature lists to a parsed FeatureRef
- Merge branch 'main' of https://github.com/battery-pack-rs/battery-pack into fix/issue-13-cargo-metadata
</blockquote>

## `bphelper-build`

<blockquote>

## [0.5.0](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-build-v0.4.8...bphelper-build-v0.5.0) - 2026-07-16

### Added

- *(docgen)* category-aware crate-table with unified rendering

### Fixed

- update paths after battery pack merge
- cargo fmt for bphelper-build

### Other

- Fix mdBook links and add link checking
- switch feature lists to a parsed FeatureRef
- Merge branch 'main' of https://github.com/battery-pack-rs/battery-pack into fix/issue-13-cargo-metadata
</blockquote>

## `cargo-bp-script`

<blockquote>

## [0.2.1](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-script-v0.2.0...cargo-bp-script-v0.2.1) - 2026-07-16

### Added

- *(show)* surface categories in cargo bp show text and JSON (Phase 7)
- track applied templates in battery-pack.toml and surface in status
</blockquote>

## `bphelper-cli`

<blockquote>

## [0.10.0](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.9.0...bphelper-cli-v0.10.0) - 2026-07-16

### Added

- *(template)* derive select-placeholder options from a category (Phase 6)
- *(show)* surface categories in cargo bp show text and JSON (Phase 7)
- *(cli)* wire categories into picker and validate exclusive -F picks (Phase 4+5)
- *(picker)* add radio mode, collapsing, and item descriptions (Phase 3)
- wire up `p` preview action in the `cargo bp add` picker
- extract sectioned-picker into standalone crate
- record applied template in state when using `cargo bp new`
- track applied templates in battery-pack.toml and surface in status
- show templates in the interactive `cargo bp add` picker
- *(state)* [**breaking**] bump format to v2, use all-features flag for ActiveFeatures::All

### Fixed

- address post-implementation review findings (Phase 9)
- address adversarial review findings in categories impl
- *(cli)* propagate existing All state as all_features flag instead of sentinel
- *(manifest)* include implicit-feature optional deps under ActiveFeatures::All

### Other

- add the cargo.toml metadata
- *(spec)* document category rules in format/cli/tui specs
- *(picker)* improve the picker UI and make it inline
- migrate bphelper-cli modules to new layout
- fix rustfmt line-joining for CI toolchain
- Merge branch 'main' of https://github.com/battery-pack-rs/battery-pack into fix/issue-13-cargo-metadata
- ActiveFeatures enum + resolver hardening
- switch feature lists to a parsed FeatureRef
- Merge branch 'main' of https://github.com/battery-pack-rs/battery-pack into fix/issue-13-cargo-metadata
</blockquote>

## `battery-pack`

<blockquote>

## [0.6.0](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.5.5...battery-pack-v0.6.0) - 2026-07-16

### Added

- *(docgen)* category-aware crate-table with unified rendering
- *(template)* derive select-placeholder options from a category (Phase 6)
- *(show)* surface categories in cargo bp show text and JSON (Phase 7)
- *(cli)* wire categories into picker and validate exclusive -F picks (Phase 4+5)
- *(picker)* add radio mode, collapsing, and item descriptions (Phase 3)
- wire up `p` preview action in the `cargo bp add` picker
- extract sectioned-picker into standalone crate
- record applied template in state when using `cargo bp new`
- track applied templates in battery-pack.toml and surface in status
- show templates in the interactive `cargo bp add` picker
- *(state)* [**breaking**] bump format to v2, use all-features flag for ActiveFeatures::All
- *(manifest)* parse and validate category metadata (Phase 1+2)
- *(packs)* add category metadata to cli, ci, and backend-service packs (Phase 8)
- *(ci)* add security scanning template
- *(ci)* default generated dependency policy
- *(ci)* document generated audit policy
- *(ci)* add optional dependency policy template

### Fixed

- use stable backend skills link
- update paths after battery pack merge
- cargo fmt for bphelper-build
- address post-implementation review findings (Phase 9)
- address adversarial review findings in categories impl
- *(cli)* propagate existing All state as all_features flag instead of sentinel
- *(manifest)* include implicit-feature optional deps under ActiveFeatures::All
- spelling :)
- spelling and formatting
- *(ci)* refresh dependency policy snapshots
- *(ci)* remove path filter from dependency-policy pull_request trigger
- *(ci)* warn on wildcard dependencies in policy template
- *(ci)* run generated audit workflow on config changes
- *(cli-battery-pack)* stabilize help snapshots
- *(cli-battery-pack)* normalize help snapshots

### Other

- merge battery pack directories
- Fix mdBook links and add link checking
- switch feature lists to a parsed FeatureRef
- Merge branch 'main' of https://github.com/battery-pack-rs/battery-pack into fix/issue-13-cargo-metadata
- add the cargo.toml metadata
- *(spec)* document category rules in format/cli/tui specs
- *(picker)* improve the picker UI and make it inline
- migrate bphelper-cli modules to new layout
- fix rustfmt line-joining for CI toolchain
- Merge branch 'main' of https://github.com/battery-pack-rs/battery-pack into fix/issue-13-cargo-metadata
- ActiveFeatures enum + resolver hardening
- *(manifest)* restrict resolve_all() to test-only visibility
- Update src/battery-pack/bphelper-manifest/src/lib.rs
- add a cargo-metadata oracle test
- *(ci)* drop action ref comments from snapshots
- *(ci)* clarify unresolved action redaction
- *(ci)* simplify snapshot normalization
- *(ci)* normalize workflow snapshot pins
- allow NCSA license in dependency policy
- *(ci)* clarify audit issue prompt
- *(ci)* align skill template commands
- *(ci)* simplify optional feature guidance
- *(ci)* tighten security scanning text
- *(ci)* keep audit issue option out of feature table
- add repository license policy
- *(packs)* update battery pack content for auto-generated docs

### Security

- fix rustsec vulnerabilities
</blockquote>

## `cargo-bp`

<blockquote>

## [0.6.0](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-v0.5.6...cargo-bp-v0.6.0) - 2026-07-16

### Added

- record applied template in state when using `cargo bp new`
- track applied templates in battery-pack.toml and surface in status
- *(template)* derive select-placeholder options from a category (Phase 6)
- *(show)* surface categories in cargo bp show text and JSON (Phase 7)
- *(cli)* wire categories into picker and validate exclusive -F picks (Phase 4+5)
- *(picker)* add radio mode, collapsing, and item descriptions (Phase 3)
- wire up `p` preview action in the `cargo bp add` picker
- extract sectioned-picker into standalone crate
- show templates in the interactive `cargo bp add` picker
- *(state)* [**breaking**] bump format to v2, use all-features flag for ActiveFeatures::All

### Fixed

- address post-implementation review findings (Phase 9)
- address adversarial review findings in categories impl
- *(cli)* propagate existing All state as all_features flag instead of sentinel
- *(manifest)* include implicit-feature optional deps under ActiveFeatures::All

### Other

- add the cargo.toml metadata
- *(spec)* document category rules in format/cli/tui specs
- *(picker)* improve the picker UI and make it inline
- migrate bphelper-cli modules to new layout
- fix rustfmt line-joining for CI toolchain
- Merge branch 'main' of https://github.com/battery-pack-rs/battery-pack into fix/issue-13-cargo-metadata
- ActiveFeatures enum + resolver hardening
- switch feature lists to a parsed FeatureRef
- Merge branch 'main' of https://github.com/battery-pack-rs/battery-pack into fix/issue-13-cargo-metadata
</blockquote>

## `backend-service-battery-pack`

<blockquote>

## [0.1.2](https://github.com/battery-pack-rs/battery-pack/compare/backend-service-battery-pack-v0.1.1...backend-service-battery-pack-v0.1.2) - 2026-07-16

### Fixed

- use stable backend skills link
- update paths after battery pack merge

### Other

- merge battery pack directories
</blockquote>

## `cli-battery-pack`

<blockquote>

## [0.6.3](https://github.com/battery-pack-rs/battery-pack/compare/cli-battery-pack-v0.6.2...cli-battery-pack-v0.6.3) - 2026-07-16

### Added

- *(packs)* add category metadata to cli, ci, and backend-service packs (Phase 8)

### Fixed

- *(cli-battery-pack)* stabilize help snapshots
- *(cli-battery-pack)* normalize help snapshots

### Other

- Fix mdBook links and add link checking
- *(packs)* update battery pack content for auto-generated docs
</blockquote>

## `ci-battery-pack`

<blockquote>

## [0.1.6](https://github.com/battery-pack-rs/battery-pack/compare/ci-battery-pack-v0.1.5...ci-battery-pack-v0.1.6) - 2026-07-16

### Added

- *(packs)* add category metadata to cli, ci, and backend-service packs (Phase 8)
- *(ci)* add security scanning template
- *(ci)* default generated dependency policy
- *(ci)* document generated audit policy
- *(ci)* add optional dependency policy template

### Fixed

- *(ci)* refresh dependency policy snapshots
- *(ci)* remove path filter from dependency-policy pull_request trigger
- *(ci)* warn on wildcard dependencies in policy template
- *(ci)* run generated audit workflow on config changes

### Other

- Fix mdBook links and add link checking
- *(ci)* drop action ref comments from snapshots
- *(ci)* clarify unresolved action redaction
- *(ci)* simplify snapshot normalization
- *(ci)* normalize workflow snapshot pins
- allow NCSA license in dependency policy
- *(ci)* clarify audit issue prompt
- *(ci)* align skill template commands
- *(ci)* simplify optional feature guidance
- *(ci)* tighten security scanning text
- *(ci)* keep audit issue option out of feature table
- add repository license policy

### Security

- fix rustsec vulnerabilities
</blockquote>

## `error-battery-pack`

<blockquote>

## [0.6.5](https://github.com/battery-pack-rs/battery-pack/compare/error-battery-pack-v0.6.4...error-battery-pack-v0.6.5) - 2026-07-16

### Other

- Fix mdBook links and add link checking
- *(packs)* update battery pack content for auto-generated docs
</blockquote>

## `logging-battery-pack`

<blockquote>

## [0.5.3](https://github.com/battery-pack-rs/battery-pack/compare/logging-battery-pack-v0.5.2...logging-battery-pack-v0.5.3) - 2026-07-16

### Other

- Fix mdBook links and add link checking
- *(packs)* update battery pack content for auto-generated docs
</blockquote>

## `embedded-battery-pack`

<blockquote>

## [0.1.1](https://github.com/battery-pack-rs/battery-pack/compare/embedded-battery-pack-v0.1.0...embedded-battery-pack-v0.1.1) - 2026-07-16

### Other

- updated the following local packages: battery-pack, battery-pack
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).