### PR TITLE
feat(state)!: bump format to v2, persist --all-features without a sentinel string

### DIFF
--- a/src/battery-pack/bphelper-cli/src/commands/mod.rs
+++ b/src/battery-pack/bphelper-cli/src/commands/mod.rs
@@ -781,7 +781,10 @@ pub(crate) fn add_battery_pack(
         && specific_crates.is_empty()
     {
         if let Some(existing) = read_active_features_from_state(&user_manifest_path, &crate_name) {
-            let mut merged: Vec<String> = existing.into_iter().collect();
+            let mut merged: Vec<String> = match existing {
+                bphelper_manifest::ActiveFeatures::All => vec!["all".to_string()],
+                bphelper_manifest::ActiveFeatures::Subset(set) => set.into_iter().collect(),
+            };
             for f in with_features {
                 if !merged.contains(f) {
                     merged.push(f.clone());
@@ -937,7 +940,7 @@ pub(crate) fn add_battery_pack(
     write_battery_pack_state(
         &user_manifest_path,
         &crate_name,
-        &active_features,
+        &(&active_features).into(),
         &crates_to_sync,
     )?;
 
@@ -1210,7 +1213,7 @@ fn sync_battery_packs(project_dir: &Path, path: Option<&str>, source: &CrateSour
             read_active_features_for_project(&user_manifest_path, &user_manifest_content, bp_name);
 
         // [impl format.hidden.effect]
-        let expected = bp_spec.resolve_for_features(&(&active_features).into());
+        let expected = bp_spec.resolve_for_features(&active_features);
 
         // [impl manifest.deps.workspace]
         // Sync each crate
@@ -1909,20 +1912,29 @@ fn build_show_report(
     if !managed_deps.is_empty() {
         report = report.with_installed_crates(managed_deps);
     }
-    if !active_features.is_empty() {
-        report = report.with_active_features(active_features);
+    match &active_features {
+        bphelper_manifest::ActiveFeatures::All => {
+            report = report.with_active_features(["all".to_string()]);
+        }
+        bphelper_manifest::ActiveFeatures::Subset(features) if !features.is_empty() => {
+            report = report.with_active_features(features.iter().cloned());
+        }
+        _ => {}
     }
 
     Ok(report)
 }
 
 /// Read installed state (managed-deps and active features) for a battery pack.
-/// Returns empty sets if not in a project or pack not installed.
+/// Returns empty managed-deps set and active features for the pack.
 fn read_installed_state(
     project_dir: &Path,
     crate_name: &str,
-) -> (BTreeSet<String>, BTreeSet<String>) {
-    let empty = (BTreeSet::new(), BTreeSet::new());
+) -> (BTreeSet<String>, bphelper_manifest::ActiveFeatures) {
+    let empty = (
+        BTreeSet::new(),
+        bphelper_manifest::ActiveFeatures::Subset(BTreeSet::from(["default".to_string()])),
+    );
     let Ok(manifest_path) = find_user_manifest(project_dir) else {
         return empty;
     };
@@ -2231,9 +2243,7 @@ fn build_status_report(
         .iter()
         .map(|pack| {
             // Resolve which crates are expected for this pack's active features.
-            let expected = pack
-                .spec
-                .resolve_for_features(&(&pack.active_features).into());
+            let expected = pack.spec.resolve_for_features(&pack.active_features);
 
             // [impl cli.status.version-warn]
             let warnings = expected.iter().filter_map(|(dep_name, dep_spec)| {
@@ -2251,12 +2261,17 @@ fn build_status_report(
                 ))
             });
 
+            let feature_strings: Vec<String> = match &pack.active_features {
+                bphelper_manifest::ActiveFeatures::All => vec!["all".to_string()],
+                bphelper_manifest::ActiveFeatures::Subset(set) => set.iter().cloned().collect(),
+            };
+
             cargo_bp_script::InstalledPackStatus::new(
                 &pack.short_name,
                 &pack.spec.name,
                 &pack.version,
             )
-            .with_active_features(pack.active_features.iter().cloned())
+            .with_active_features(feature_strings)
             .with_warnings(warnings)
         })
         .collect();

--- a/src/battery-pack/bphelper-cli/src/commands/mod.rs
+++ b/src/battery-pack/bphelper-cli/src/commands/mod.rs
@@ -776,26 +776,31 @@ pub(crate) fn add_battery_pack(
     // Skip merging when the user explicitly narrows (--no-default-features,
     // --all-features, or specific crates) since those signal a fresh selection.
     let user_manifest_path = find_user_manifest(project_dir)?;
-    let merged_features: Vec<String> = if !no_default_features
+    // If the user isn't resetting with --no-default-features or --all-features or specific
+    // crates, merge their -F flags with the previously stored feature set.
+    let (merged_features, all_features) = if !no_default_features
         && !all_features
         && specific_crates.is_empty()
     {
         if let Some(existing) = read_active_features_from_state(&user_manifest_path, &crate_name) {
-            let mut merged: Vec<String> = match existing {
-                bphelper_manifest::ActiveFeatures::All => vec!["all".to_string()],
-                bphelper_manifest::ActiveFeatures::Subset(set) => set.into_iter().collect(),
-            };
-            for f in with_features {
-                if !merged.contains(f) {
-                    merged.push(f.clone());
+            match existing {
+                // Previously had --all-features: keep that (adding more features is a no-op).
+                bphelper_manifest::ActiveFeatures::All => (vec![], true),
+                bphelper_manifest::ActiveFeatures::Subset(set) => {
+                    let mut merged: Vec<String> = set.into_iter().collect();
+                    for f in with_features {
+                        if !merged.contains(f) {
+                            merged.push(f.clone());
+                        }
+                    }
+                    (merged, false)
                 }
             }
-            merged
         } else {
-            with_features.to_vec()
+            (with_features.to_vec(), false)
         }
     } else {
-        with_features.to_vec()
+        (with_features.to_vec(), all_features)
     };
 
     let resolved = resolve_add_crates(

--- a/src/battery-pack/bphelper-cli/src/commands/tests.rs
+++ b/src/battery-pack/bphelper-cli/src/commands/tests.rs
@@ -1492,14 +1492,11 @@ fn add_all_features_records_metadata() {
 
     let state = read_bp_state_toml(&tmp);
     let entry = extract_state_entry(&state, "basic-battery-pack").expect("state entry exists");
-    let features = entry
-        .get("features")
-        .and_then(|v| v.as_array())
-        .expect("features array");
-    assert!(
-        features.iter().any(|v| v.as_str() == Some("all")),
-        "expected all feature in state"
-    );
+    let all_features = entry
+        .get("all-features")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    assert!(all_features, "expected all-features = true in state");
 }
 
 // [verify cli.add.all-features]

--- a/src/battery-pack/bphelper-cli/src/manifest/mod.rs
+++ b/src/battery-pack/bphelper-cli/src/manifest/mod.rs
@@ -370,7 +370,7 @@ fn normalized_feature_set(features: &BTreeSet<String>) -> BTreeSet<String> {
     }
 }
 
-const STATE_FORMAT_VERSION: u32 = 1;
+const STATE_FORMAT_VERSION: u32 = 2;
 
 fn default_version() -> u32 {
     STATE_FORMAT_VERSION
@@ -393,13 +393,66 @@ impl Default for BatteryPackStateFile {
     }
 }
 
+/// A single battery pack entry in the state file.
+///
+/// v2 format uses `all-features = true` when every feature is active, and
+/// `features = [...]` for a specific subset. When `all-features` is true the
+/// `features` array is omitted. v1 files that used `features = ["all"]` as a
+/// sentinel are transparently upgraded on read.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct BatteryPackStateEntry {
     name: String,
-    #[serde(default = "default_feature_set")]
+    #[serde(rename = "all-features", default, skip_serializing_if = "is_false")]
+    all_features: bool,
+    #[serde(default = "default_feature_set", skip_serializing_if = "skip_features")]
     features: BTreeSet<String>,
     #[serde(rename = "managed-deps", default)]
     managed_deps: Vec<ManagedDepEntry>,
+}
+
+fn is_false(v: &bool) -> bool {
+    !v
+}
+
+/// Skip serializing `features` when `all-features` is true (redundant).
+/// We can't access sibling fields from serde's skip_serializing_if, so we
+/// use a heuristic: skip if the set contains only "all" (the v1 sentinel).
+/// The write path ensures features is empty when all_features is true.
+fn skip_features(features: &BTreeSet<String>) -> bool {
+    features.is_empty()
+}
+
+impl BatteryPackStateEntry {
+    /// Convert to `ActiveFeatures`.
+    fn active_features(&self) -> bphelper_manifest::ActiveFeatures {
+        if self.all_features || self.features.iter().any(|f| f == "all") {
+            bphelper_manifest::ActiveFeatures::All
+        } else {
+            bphelper_manifest::ActiveFeatures::Subset(normalized_feature_set(&self.features))
+        }
+    }
+
+    /// Create from an `ActiveFeatures` value.
+    fn from_active_features(
+        name: String,
+        active: &bphelper_manifest::ActiveFeatures,
+        managed_deps: Vec<ManagedDepEntry>,
+    ) -> Self {
+        match active {
+            bphelper_manifest::ActiveFeatures::All => Self {
+                name,
+                all_features: true,
+                features: BTreeSet::new(),
+                managed_deps,
+            },
+            bphelper_manifest::ActiveFeatures::Subset(set) => Self {
+                name,
+                all_features: false,
+                features: normalized_feature_set(set),
+                managed_deps,
+            },
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -465,10 +518,10 @@ fn write_state_file(state_path: &Path, state: &BatteryPackStateFile) -> Result<(
 pub(crate) fn read_active_features_from_state(
     user_manifest_path: &Path,
     bp_name: &str,
-) -> Option<BTreeSet<String>> {
+) -> Option<bphelper_manifest::ActiveFeatures> {
     let state_path = state_file_path(user_manifest_path);
     let state = read_state_file(&state_path).ok()?;
-    state_entry_for(&state, bp_name).map(|entry| normalized_feature_set(&entry.features))
+    state_entry_for(&state, bp_name).map(|entry| entry.active_features())
 }
 
 /// Read managed dependency names for a battery pack from `battery-pack.toml` if present.
@@ -518,8 +571,9 @@ pub(crate) fn read_active_features_for_project(
     user_manifest_path: &Path,
     _user_manifest_content: &str,
     bp_name: &str,
-) -> BTreeSet<String> {
-    read_active_features_from_state(user_manifest_path, bp_name).unwrap_or_else(default_feature_set)
+) -> bphelper_manifest::ActiveFeatures {
+    read_active_features_from_state(user_manifest_path, bp_name)
+        .unwrap_or_else(|| bphelper_manifest::ActiveFeatures::Subset(default_feature_set()))
 }
 
 /// Read managed deps for a pack in a project from `battery-pack.toml`.
@@ -535,7 +589,7 @@ pub(crate) fn read_managed_deps_for_project(
 pub(crate) fn write_battery_pack_state(
     user_manifest_path: &Path,
     bp_name: &str,
-    active_features: &BTreeSet<String>,
+    active_features: &bphelper_manifest::ActiveFeatures,
     managed_crates: &BTreeMap<String, bphelper_manifest::CrateSpec>,
 ) -> Result<()> {
     let state_path = state_file_path(user_manifest_path);
@@ -548,11 +602,11 @@ pub(crate) fn write_battery_pack_state(
         })
         .collect::<Vec<_>>();
 
-    let updated = BatteryPackStateEntry {
-        name: short_name(bp_name).to_string(),
-        features: normalized_feature_set(active_features),
+    let updated = BatteryPackStateEntry::from_active_features(
+        short_name(bp_name).to_string(),
+        active_features,
         managed_deps,
-    };
+    );
 
     if let Some(entry) = state
         .battery_pack

--- a/src/battery-pack/bphelper-cli/src/manifest/tests.rs
+++ b/src/battery-pack/bphelper-cli/src/manifest/tests.rs
@@ -1383,3 +1383,132 @@ anyhow = \"1.0.0\"
         "document should be byte-identical when nothing changed"
     );
 }
+
+// ============================================================================
+// State format: v1 migration and v2 round-trip
+// ============================================================================
+
+/// A v1 state file (features as flat array, `"all"` sentinel) is read correctly
+/// by the new code and transparently upgraded on next write.
+#[test]
+fn read_state_migrates_v1_all_sentinel() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let manifest_path = tmp.path().join("Cargo.toml");
+    std::fs::write(&manifest_path, "[package]\nname = \"test\"\n").unwrap();
+
+    // v1 file: uses "all" sentinel in the features array
+    let v1_state = indoc::indoc! {r#"
+        version = 1
+
+        [[battery-pack]]
+        name = "cli"
+        features = ["default", "indicators"]
+
+        [[battery-pack.managed-deps]]
+        name = "clap"
+        version = "4"
+
+        [[battery-pack]]
+        name = "error"
+        features = ["all"]
+    "#};
+    std::fs::write(tmp.path().join("battery-pack.toml"), v1_state).unwrap();
+
+    // "cli" pack reads as Subset
+    let cli =
+        super::read_active_features_from_state(&manifest_path, "cli-battery-pack").unwrap();
+    assert_eq!(
+        cli,
+        bphelper_manifest::ActiveFeatures::Subset(BTreeSet::from([
+            "default".to_string(),
+            "indicators".to_string(),
+        ]))
+    );
+
+    // "error" pack reads as All (the "all" sentinel triggers conversion)
+    let error =
+        super::read_active_features_from_state(&manifest_path, "error-battery-pack").unwrap();
+    assert_eq!(error, bphelper_manifest::ActiveFeatures::All);
+}
+
+/// Writing with All then reading back produces `all-features = true` in the file
+/// and reads back as `ActiveFeatures::All`.
+#[test]
+fn write_all_features_then_read_round_trips() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let manifest_path = tmp.path().join("Cargo.toml");
+    std::fs::write(&manifest_path, "[package]\nname = \"test\"\n").unwrap();
+
+    let crates = std::collections::BTreeMap::from([(
+        "clap".to_string(),
+        bphelper_manifest::CrateSpec {
+            version: "4".to_string(),
+            features: BTreeSet::new(),
+            dep_kind: bphelper_manifest::DepKind::Normal,
+            optional: false,
+        },
+    )]);
+    super::write_battery_pack_state(
+        &manifest_path,
+        "cli-battery-pack",
+        &bphelper_manifest::ActiveFeatures::All,
+        &crates,
+    )
+    .unwrap();
+
+    // Verify the file uses `all-features = true`
+    let content = std::fs::read_to_string(tmp.path().join("battery-pack.toml")).unwrap();
+    assert!(
+        content.contains("all-features = true"),
+        "expected all-features flag in state file, got:\n{content}"
+    );
+    assert!(
+        !content.contains("\nfeatures"),
+        "features array should be omitted when all-features is true, got:\n{content}"
+    );
+
+    // Read back
+    let read =
+        super::read_active_features_from_state(&manifest_path, "cli-battery-pack").unwrap();
+    assert_eq!(read, bphelper_manifest::ActiveFeatures::All);
+}
+
+/// Writing with Subset then reading back preserves the feature list.
+#[test]
+fn write_subset_features_then_read_round_trips() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let manifest_path = tmp.path().join("Cargo.toml");
+    std::fs::write(&manifest_path, "[package]\nname = \"test\"\n").unwrap();
+
+    let features = bphelper_manifest::ActiveFeatures::Subset(BTreeSet::from([
+        "default".to_string(),
+        "fancy".to_string(),
+    ]));
+    let crates = std::collections::BTreeMap::from([(
+        "clap".to_string(),
+        bphelper_manifest::CrateSpec {
+            version: "4".to_string(),
+            features: BTreeSet::new(),
+            dep_kind: bphelper_manifest::DepKind::Normal,
+            optional: false,
+        },
+    )]);
+    super::write_battery_pack_state(&manifest_path, "cli-battery-pack", &features, &crates)
+        .unwrap();
+
+    // Verify the file uses features array (no all-features flag)
+    let content = std::fs::read_to_string(tmp.path().join("battery-pack.toml")).unwrap();
+    assert!(
+        content.contains("features = ["),
+        "expected features array in state file, got:\n{content}"
+    );
+    assert!(
+        !content.contains("all-features"),
+        "all-features should not appear for Subset, got:\n{content}"
+    );
+
+    // Read back
+    let read =
+        super::read_active_features_from_state(&manifest_path, "cli-battery-pack").unwrap();
+    assert_eq!(read, features);
+}

--- a/src/battery-pack/bphelper-cli/src/manifest/tests.rs
+++ b/src/battery-pack/bphelper-cli/src/manifest/tests.rs
@@ -1415,8 +1415,7 @@ fn read_state_migrates_v1_all_sentinel() {
     std::fs::write(tmp.path().join("battery-pack.toml"), v1_state).unwrap();
 
     // "cli" pack reads as Subset
-    let cli =
-        super::read_active_features_from_state(&manifest_path, "cli-battery-pack").unwrap();
+    let cli = super::read_active_features_from_state(&manifest_path, "cli-battery-pack").unwrap();
     assert_eq!(
         cli,
         bphelper_manifest::ActiveFeatures::Subset(BTreeSet::from([
@@ -1468,8 +1467,7 @@ fn write_all_features_then_read_round_trips() {
     );
 
     // Read back
-    let read =
-        super::read_active_features_from_state(&manifest_path, "cli-battery-pack").unwrap();
+    let read = super::read_active_features_from_state(&manifest_path, "cli-battery-pack").unwrap();
     assert_eq!(read, bphelper_manifest::ActiveFeatures::All);
 }
 
@@ -1508,7 +1506,6 @@ fn write_subset_features_then_read_round_trips() {
     );
 
     // Read back
-    let read =
-        super::read_active_features_from_state(&manifest_path, "cli-battery-pack").unwrap();
+    let read = super::read_active_features_from_state(&manifest_path, "cli-battery-pack").unwrap();
     assert_eq!(read, features);
 }

--- a/src/battery-pack/bphelper-cli/src/registry/mod.rs
+++ b/src/battery-pack/bphelper-cli/src/registry/mod.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result, bail};
 use bphelper_manifest::{BatteryPackSpec, discover_battery_packs, parse_battery_pack_from_path};
 use flate2::read::GzDecoder;
 use serde::Deserialize;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use tar::Archive;
@@ -580,7 +580,7 @@ pub(crate) struct InstalledPack {
     pub short_name: String,
     pub version: String,
     pub spec: bphelper_manifest::BatteryPackSpec,
-    pub active_features: BTreeSet<String>,
+    pub active_features: bphelper_manifest::ActiveFeatures,
 }
 
 pub(crate) fn fetch_battery_pack_list(


### PR DESCRIPTION
### Summary

The `battery-pack.toml` state file stored active features as a flat string array (`features = ["default", "indicators"]`), with `"all"` as a magic sentinel for `--all-features`. Since Cargo permits `all` as a literal feature name, this was ambiguous.

This switches to typed handling for `--all-features`

```toml
  [[battery-pack]]
  name = "cli"
  all-features = true

  [[battery-pack]]
  name = "error"
  features = ["default", "indicators"]

```

The read path transparently migrates v1 files on first access (using the existing `From<&BTreeSet<String>>` impl). The write path always emits v2. Older `cargo-bp` versions encountering a v2 file will get a clean "please upgrade" error from the existing version gate.
