### PR TITLE
style(picker): improve the picker UI and make it inline

### DIFF
--- a/src/battery-pack/bphelper-cli/src/commands.rs
+++ b/src/battery-pack/bphelper-cli/src/commands.rs
@@ -840,7 +840,6 @@ pub(crate) fn add_battery_pack(
                     result.selected_templates,
                 ),
                 None => {
-                    println!("Cancelled.");
                     return Ok(());
                 }
             }

--- a/src/sectioned-picker/src/lib.rs
+++ b/src/sectioned-picker/src/lib.rs
@@ -67,6 +67,13 @@ mod state;
 mod tests;
 
 use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
+use ratatui::{
+    TerminalOptions, Viewport,
+    crossterm::{
+        ExecutableCommand,
+        terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+    },
+};
 use std::time::Duration;
 
 pub use render::render_picker;
@@ -144,15 +151,36 @@ pub fn run_picker(
     sections: Vec<Section>,
     actions: Vec<PickerAction<'_>>,
 ) -> anyhow::Result<PickerOutcome> {
+    let height: u16 = sections
+        .iter()
+        .map(|sec| sec.items.len() as u16 + 2)
+        .sum::<u16>()
+        + 2;
     let mut state = PickerState::new(sections);
-
     if state.is_empty() {
         return Ok(PickerOutcome::Confirmed(Vec::new()));
     }
 
-    let mut terminal = ratatui::init();
+    let mut is_fullscreen = false;
+    let viewport = if let Ok((_, r)) = ratatui::crossterm::terminal::size()
+        && r > height
+    {
+        Viewport::Inline(height)
+    } else {
+        is_fullscreen = true;
+        Viewport::Fullscreen
+    };
+
+    let mut terminal = ratatui::init_with_options(TerminalOptions { viewport });
+    enable_raw_mode()?;
+    if is_fullscreen {
+        terminal.backend_mut().execute(EnterAlternateScreen)?;
+    }
     let result = run_picker_loop(&mut terminal, title, &mut state, actions);
-    ratatui::restore();
+    disable_raw_mode()?;
+    if is_fullscreen {
+        terminal.backend_mut().execute(LeaveAlternateScreen)?;
+    }
     result
 }
 

--- a/src/sectioned-picker/src/render.rs
+++ b/src/sectioned-picker/src/render.rs
@@ -2,6 +2,9 @@
 
 use crate::PickerAction;
 use crate::state::{Entry, PickerState};
+use ratatui::macros::span;
+use ratatui::style::Stylize;
+use ratatui::widgets::Padding;
 use ratatui::{
     Frame,
     layout::{Constraint, Layout},
@@ -22,28 +25,12 @@ pub fn render_picker(
 ) {
     let area = frame.area();
 
-    let [header_area, main_area, footer_area] = Layout::vertical([
-        Constraint::Length(2),
-        Constraint::Fill(1),
-        Constraint::Length(1),
-    ])
-    .areas(area);
+    let [main_area, footer_area] =
+        Layout::vertical([Constraint::Fill(1), Constraint::Length(1)]).areas(area);
 
     // Update visible height from actual terminal geometry.
     state.visible_height = main_area.height.saturating_sub(2) as usize;
     state.ensure_cursor_visible();
-
-    // Title
-    frame.render_widget(
-        Paragraph::new(title)
-            .style(
-                Style::default()
-                    .fg(Color::Green)
-                    .add_modifier(Modifier::BOLD),
-            )
-            .centered(),
-        header_area,
-    );
 
     // Build the content lines.
     let current_entry_idx = state.current_entry_idx();
@@ -80,13 +67,25 @@ pub fn render_picker(
     }
 
     let content = Paragraph::new(lines)
-        .block(Block::default().borders(Borders::ALL))
+        .block(
+            Block::default()
+                .borders(Borders::TOP)
+                .padding(Padding::horizontal(1))
+                .border_style(Style::new().dim()),
+        )
         .scroll((state.scroll as u16, 0));
     frame.render_widget(content, main_area);
 
     // Footer — built-in keys + caller-defined action labels.
+    let [footer_left, footer_right] = Layout::horizontal([
+        Constraint::Length(title.len() as u16 + 2),
+        Constraint::Fill(1),
+    ])
+    .areas(footer_area);
+    let left_footer = span!(" {title} ").on_green().black().bold();
+    frame.render_widget(left_footer, footer_left);
     let mut footer_parts = vec![
-        "↑↓/jk Navigate".to_string(),
+        " ↑↓/jk Navigate".to_string(),
         "Space Toggle".to_string(),
         "a Toggle section".to_string(),
     ];
@@ -98,6 +97,6 @@ pub fn render_picker(
 
     frame.render_widget(
         Paragraph::new(footer_parts.join(" | ")).style(Style::default().white().on_dark_gray()),
-        footer_area,
+        footer_right,
     );
 }

--- a/src/sectioned-picker/src/tests/render.rs
+++ b/src/sectioned-picker/src/tests/render.rs
@@ -76,7 +76,7 @@ fn toggle_updates_checkbox() {
 #[test]
 fn footer_shows_keybindings() {
     let mut state = PickerState::new(vec![section("S:", &[("a", false)])]);
-    let output = render_to_string(80, 8, "test", &mut state);
+    let output = render_to_string(160, 8, "test", &mut state);
 
     assert!(output.contains("Navigate"), "navigation hint missing");
     assert!(output.contains("Toggle"), "toggle hint missing");
@@ -135,16 +135,16 @@ fn snapshot_single_section() {
     assert_data_eq!(
         output,
         str![[r#"
-"                        cli-pack v2.0                       "
+"────────────────────────────────────────────────────────────"
+" Dependencies:                                              "
+" > [x] tokio (1.38)                                         "
+"   [x] serde (1.0)                                          "
+"   [ ] anyhow (1)                                           "
 "                                                            "
-"┌──────────────────────────────────────────────────────────┐"
-"│Dependencies:                                             │"
-"│> [x] tokio (1.38)                                        │"
-"│  [x] serde (1.0)                                         │"
-"│  [ ] anyhow (1)                                          │"
-"│                                                          │"
-"└──────────────────────────────────────────────────────────┘"
-"↑↓/jk Navigate | Space Toggle | a Toggle section | Enter Con"
+"                                                            "
+"                                                            "
+"                                                            "
+" cli-pack v2.0  ↑↓/jk Navigate | Space Toggle | a Toggle sec"
 
 "#]]
     );
@@ -164,20 +164,20 @@ fn snapshot_multiple_sections() {
     assert_data_eq!(
         output,
         str![[r#"
-"                         fancy v1.0                         "
+"────────────────────────────────────────────────────────────"
+" Features:                                                  "
+" > [x] observability                                        "
+"   [ ] resilience                                           "
 "                                                            "
-"┌──────────────────────────────────────────────────────────┐"
-"│Features:                                                 │"
-"│> [x] observability                                       │"
-"│  [ ] resilience                                          │"
-"│                                                          │"
-"│Dependencies:                                             │"
-"│  [x] tokio                                               │"
-"│                                                          │"
-"│Actions:                                                  │"
-"│  [ ] Add `ci` template                                   │"
-"└──────────────────────────────────────────────────────────┘"
-"↑↓/jk Navigate | Space Toggle | a Toggle section | Enter Con"
+" Dependencies:                                              "
+"   [x] tokio                                                "
+"                                                            "
+" Actions:                                                   "
+"   [ ] Add `ci` template                                    "
+"                                                            "
+"                                                            "
+"                                                            "
+" fancy v1.0  ↑↓/jk Navigate | Space Toggle | a Toggle sectio"
 
 "#]]
     );


### PR DESCRIPTION
<img width="1710" height="595" alt="image" src="https://github.com/user-attachments/assets/0eb63ddd-947a-4bda-87d3-9f2e5762e47b" />

1. the picker is now inline, except if the calculated height exceeds the terminal height. In that case, it switches to normal fullscreen TUI mode
2. The title has moved to the left of the footer. 
3. Moved some borders for a cleaner look

@nikomatsakis @jlizen what do you think?