### PR TITLE
fix: make audit.yml only run on the main repo

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -17,6 +17,7 @@ permissions:
 
 jobs:
   security_audit:
+    if: github.repository == 'battery-pack-rs/battery-pack'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Afaict this fails in forks so it should only run here. 