### PR TITLE
docs: add RFD for categories and exclusive picks

### DIFF
--- a/md/SUMMARY.md
+++ b/md/SUMMARY.md
@@ -21,6 +21,12 @@
 - [Manifest Manipulation](./spec/manifest.md)
 - [Documentation Generation](./spec/docgen.md)
 
+# RFDs
+
+- [RFDs](./rfds/README.md)
+  - [Categories and Exclusive Picks](./rfds/categories-and-alternatives/README.md)
+    - [Requirements](./rfds/categories-and-alternatives/requirements.md)
+
 # Agent guide
 
 - [Ratatui testing guide](./ratatui-testing-guide.md)

--- a/md/rfds/README.md
+++ b/md/rfds/README.md
@@ -1,0 +1,3 @@
+# RFDs
+
+Requests for Discussion — design proposals for battery-pack features.

--- a/md/rfds/categories-and-alternatives/README.md
+++ b/md/rfds/categories-and-alternatives/README.md
@@ -1,0 +1,587 @@
+# RFD: Categories and Exclusive Picks
+
+## Summary
+
+Extend battery packs with metadata to express **categories** (groupings of
+related items) and **exclusive picks** (choose at most one from a group). This
+enables battery packs like `embedded-battery-pack` that curate alternatives —
+"here are 5 ways to do X, pick the one that fits your chip" — with first-class
+UI support in `cargo bp add`.
+
+## Motivation
+
+Today, battery pack features are purely **additive**: every feature you enable
+adds crates on top of what's already there. This works well for "kitchen sink"
+packs like `cli-battery-pack` where you want clap *and* indicatif *and*
+dialoguer together.
+
+But some domains are about *choosing between alternatives*:
+
+- **Embedded**: you pick *one* HAL crate for your chip family (stm32f4xx-hal
+  *or* nrf52840-hal, never both)
+- **Async runtimes**: you pick tokio *or* async-std *or* smol
+- **TLS backends**: you pick rustls *or* native-tls
+- **Allocators**: you pick jemalloc *or* mimalloc (already awkward in
+  `backend-service-battery-pack` today)
+
+The [awesome-embedded-rust] repository curates hundreds of crates organized by
+vendor and category. A battery pack for this domain needs a way to say "here
+is a category of alternatives; present them to the user and let them pick
+one."
+
+### Relationship to Cargo mutually-exclusive globals
+
+There's an [active pre-RFC for mutually-exclusive global features][pre-rfc] in
+Cargo itself. That proposal would give Cargo native understanding of choices
+that are exclusive — making it impossible to compile two conflicting values in
+one build graph. Cargo doesn't have this today, so we need to build something
+on top. If Cargo grows first-class support, we would likely deprecate our
+custom metadata in favor of reading Cargo's native declarations. But we don't
+want to let perfect be the enemy of good and block on completion of the
+pre-RFC.
+
+Our design should be forward-compatible: if Cargo globals land, a battery pack
+author could migrate from `[package.metadata.battery-pack.categories]` to
+native `[globals]` declarations, and `cargo bp` would read the Cargo-native
+format instead.
+
+[awesome-embedded-rust]: https://github.com/rust-embedded/awesome-embedded-rust
+[pre-rfc]: https://internals.rust-lang.org/t/pre-rfc-mutually-excusive-global-features/19618
+
+## Design
+
+The core model is simple:
+
+1. **Any selectable item** (feature, dependency, or template) can have
+   metadata — including a `description` and zero or more `categories`.
+2. **Categories** have a title, a description, and a `pick` mode
+   (`at-most-one` or `any`).
+
+When displayed, items are grouped by category. `at-most-one` categories render
+as radio buttons. Items not in any category appear in generic sections
+("Features", "Dependencies", "Templates") as today.
+
+### Item metadata: `[package.metadata.battery-pack.<kind>.<name>]`
+
+Any selectable item can be annotated. The `<kind>` is `features`,
+`dependencies`, or `templates`:
+
+```toml
+[package.metadata.battery-pack.features.stm32f4]
+description = "STM32F4xx family"
+categories = ["hal"]
+
+[package.metadata.battery-pack.features.nrf52840]
+description = "nRF52840 SoC"
+categories = ["hal"]
+
+[package.metadata.battery-pack.features.embassy]
+description = "Embassy — async/await for embedded"
+categories = ["rtos"]
+
+[package.metadata.battery-pack.dependencies.embedded-hal]
+description = "Trait abstractions for embedded I/O"
+categories = ["portable"]
+```
+
+Fields:
+- `description` — shown in the picker next to the item name
+- `categories` — list of category names this item belongs to (default: `[]`)
+
+Both fields are optional. An item with no metadata entry behaves exactly as
+today.
+
+### Category metadata: `[package.metadata.battery-pack.categories.<name>]`
+
+```toml
+[package.metadata.battery-pack.categories.hal]
+title = "Hardware Abstraction Layer"
+description = "Pick the HAL for your target chip family"
+pick = "at-most-one"
+
+[package.metadata.battery-pack.categories.rtos]
+title = "Concurrency Framework"
+description = "Pick your scheduling / concurrency approach"
+pick = "at-most-one"
+
+[package.metadata.battery-pack.categories.portable]
+title = "Portable Utilities"
+description = "Works with any HAL"
+```
+
+Fields:
+- `title` — display name in the picker header
+- `description` — explanatory text (optional)
+- `pick` — `"at-most-one"` or `"any"` (default: `"any"`)
+
+Categories are **pack-scoped**: two different battery packs can both define a
+category named `"hal"` without conflict. Cross-pack category coordination is
+out of scope (future work; would need a pack extension mechanism).
+
+### Category-linked template placeholders
+
+Today, template `bp-template.toml` files duplicate category information in
+their `select` placeholders. For example, `backend-service-battery-pack`'s
+service template has:
+
+```toml
+[placeholders.allocator]
+type = "select"
+prompt = "Global allocator"
+options = ["jemalloc", "mimalloc", "system"]
+default = "jemalloc"
+```
+
+These options are manually kept in sync with the `allocator` category's
+features. Instead of a literal `options` array, the placeholder can reference
+a category to derive its options automatically:
+
+```toml
+[placeholders.allocator]
+type = "select"
+prompt = "Global allocator"
+options.category = "allocator"
+default = "jemalloc"
+```
+
+The `options` field accepts either a literal array (`options = [...]`) or a
+category reference (`options.category = "..."`). In serde terms, this is an
+untagged enum.
+
+Behavior:
+
+- The options list is automatically the set of items in the named category.
+- The template variable receives the chosen item name as its value
+  (e.g., `{{ allocator }}` = `"jemalloc"`).
+- If the user already made a selection in the `cargo bp add` picker, this
+  placeholder is pre-filled and can be skipped during template generation.
+- If the category has `pick = "at-most-one"` and no selection was made, the
+  template prompts as usual.
+
+The template still uses the value the same way:
+
+```toml
+{% if allocator == "jemalloc" %}
+tikv-jemallocator.bp-managed = true
+{% elif allocator == "mimalloc" %}
+mimalloc.bp-managed = true
+{% endif %}
+```
+
+The source of truth is the category definition, not a duplicated options list.
+Adding a new feature to the category automatically makes it available as a
+template option.
+
+## UI: How `cargo bp add embedded` looks
+
+### Interactive (TUI)
+
+The picker renders categories as sections with radio-button (●/○) or checkbox
+([x]/[ ]) semantics based on the `pick` constraint:
+
+```
+  embedded-battery-pack v0.1.0
+  ─────────────────────────────────────────────────
+
+  Hardware Abstraction Layer (pick at most one):
+      ○ stm32f0     STM32F0xx family
+      ○ stm32f1     STM32F1xx family
+      ○ stm32f3     STM32F3xx family
+      ● stm32f4     STM32F4xx family            ← selected
+      ○ stm32f7     STM32F7xx family
+      ○ nrf52840    nRF52840 SoC
+      ○ esp32       ESP32 (no_std via esp-hal)
+      ○ rp2040      RP2040 (Raspberry Pi Pico)
+
+  Concurrency Framework (pick at most one):
+      ○ rtic        RTIC — interrupt-driven concurrency
+      ● embassy     Embassy — async/await for embedded
+
+  Portable Utilities:
+      [x] embedded-hal    Trait abstractions for embedded I/O
+      [x] defmt           Efficient logging for constrained devices
+      [ ] embedded-io     Read/Write traits for embedded
+      [ ] heapless        Static-friendly data structures
+
+  ─────────────────────────────────────────────────
+  Space: toggle  ←/→: collapse/expand  Enter: confirm  q: cancel  p: preview
+```
+
+UX details:
+
+- **`at-most-one` categories** use radio-button rendering (●/○). Selecting one
+  deselects any other in the same category. Pressing Backspace clears the
+  current selection entirely (returns to zero selections). It's possible to
+  arrive at a state with multiple selections (e.g., the user previously ran
+  `cargo add` manually). In that case the picker shows the current state
+  honestly — multiple items selected — with a warning banner. Selecting a new
+  radio item clears the others; the deselected crates are removed from
+  `Cargo.toml` on confirm.
+- **`any` categories** use checkboxes as today. Pressing `a` on a category
+  header checks all items in that category (same as today's section toggle).
+  For `at-most-one` categories, `a` is a no-op (can't select all).
+- **Collapsing**: pressing left-arrow on a category header collapses it;
+  right-arrow expands it.
+- The header line says "(pick at most one)" for `at-most-one` categories.
+- **Validation on Enter**: if an `at-most-one` category has more than one
+  selection, the picker shows an inline error and refuses to confirm.
+
+### Non-interactive (CLI flags)
+
+```bash
+# Pick a specific HAL and concurrency framework:
+cargo bp add embedded -F stm32f4 -F embassy
+
+# Enable a portable utility:
+cargo bp add embedded -F stm32f4 -F embassy -F heapless
+
+# Validation: this is an error (two exclusive HALs):
+cargo bp add embedded -F stm32f4 -F nrf52840
+# error: features `stm32f4` and `nrf52840` are exclusive (category: hal)
+```
+
+### `cargo bp show`
+
+```
+embedded-battery-pack v0.1.0
+Curated hardware ecosystem for embedded Rust
+
+Categories:
+  hal — Hardware Abstraction Layer (pick at most one)
+    stm32f0, stm32f1, stm32f3, stm32f4, stm32f7, nrf52840, esp32, rp2040
+  rtos — Concurrency Framework (pick at most one)
+    rtic, embassy
+  portable — Portable Utilities
+    embedded-hal, defmt, embedded-io, heapless
+
+Templates:
+  blinky    — Minimal blinky LED example for your chosen HAL
+```
+
+## Example: Full `embedded-battery-pack` Cargo.toml
+
+```toml
+[package]
+name = "embedded-battery-pack"
+version = "0.1.0"
+edition = "2024"
+description = "Curated hardware ecosystem for embedded Rust"
+license = "MIT OR Apache-2.0"
+keywords = ["battery-pack", "embedded", "hal", "no-std"]
+
+# --- Category definitions ---
+
+[package.metadata.battery-pack.categories.hal]
+title = "Hardware Abstraction Layer"
+description = "Pick the HAL for your target chip family"
+pick = "at-most-one"
+
+[package.metadata.battery-pack.categories.rtos]
+title = "Concurrency Framework"
+description = "Pick your scheduling / concurrency approach"
+pick = "at-most-one"
+
+[package.metadata.battery-pack.categories.portable]
+title = "Portable Utilities"
+description = "Works with any HAL"
+
+# --- Feature metadata ---
+
+[package.metadata.battery-pack.features.stm32f0]
+description = "STM32F0xx family"
+categories = ["hal"]
+
+[package.metadata.battery-pack.features.stm32f1]
+description = "STM32F1xx family"
+categories = ["hal"]
+
+[package.metadata.battery-pack.features.stm32f4]
+description = "STM32F4xx family"
+categories = ["hal"]
+
+[package.metadata.battery-pack.features.nrf52840]
+description = "nRF52840 SoC"
+categories = ["hal"]
+
+[package.metadata.battery-pack.features.esp32]
+description = "ESP32 (no_std via esp-hal)"
+categories = ["hal"]
+
+[package.metadata.battery-pack.features.rp2040]
+description = "RP2040 (Raspberry Pi Pico)"
+categories = ["hal"]
+
+[package.metadata.battery-pack.features.rtic]
+description = "RTIC — interrupt-driven concurrency"
+categories = ["rtos"]
+
+[package.metadata.battery-pack.features.embassy]
+description = "Embassy — async/await for embedded"
+categories = ["rtos"]
+
+# --- Dependency metadata ---
+
+[package.metadata.battery-pack.dependencies.embedded-hal]
+description = "Trait abstractions for embedded I/O"
+categories = ["portable"]
+
+[package.metadata.battery-pack.dependencies.defmt]
+description = "Efficient logging for constrained devices"
+categories = ["portable"]
+
+[package.metadata.battery-pack.dependencies.embedded-io]
+description = "Read/Write traits for embedded"
+categories = ["portable"]
+
+[package.metadata.battery-pack.dependencies.heapless]
+description = "Static-friendly data structures"
+categories = ["portable"]
+
+# --- Hidden deps ---
+
+[package.metadata.battery-pack]
+hidden = ["battery-pack"]
+
+# --- Dependencies ---
+
+[dependencies]
+# Portable ecosystem
+embedded-hal = { version = "1", optional = true }
+defmt = { version = "1", optional = true }
+embedded-io = { version = "0.6", optional = true }
+heapless = { version = "0.8", optional = true }
+critical-section = { version = "1", optional = true }
+
+# HALs
+stm32f0xx-hal = { version = "0.18", optional = true }
+stm32f1xx-hal = { version = "0.10", optional = true }
+stm32f4xx-hal = { version = "0.22", features = ["rt"], optional = true }
+nrf52840-hal = { version = "0.18", optional = true }
+esp-hal = { version = "1", optional = true }
+rp2040-hal = { version = "0.10", optional = true }
+
+# Concurrency frameworks
+rtic = { version = "2", optional = true }
+embassy-executor = { version = "0.7", optional = true }
+embassy-time = { version = "0.4", optional = true }
+
+[build-dependencies]
+battery-pack = { version = "0.7", features = ["build"] }
+
+# --- Features ---
+
+[features]
+default = ["embedded-hal", "defmt", "critical-section"]
+
+# HAL features (exclusive within category)
+stm32f0 = ["stm32f0xx-hal", "embedded-hal"]
+stm32f1 = ["stm32f1xx-hal", "embedded-hal"]
+stm32f4 = ["stm32f4xx-hal", "embedded-hal"]
+nrf52840 = ["nrf52840-hal", "embedded-hal"]
+esp32 = ["esp-hal", "embedded-hal"]
+rp2040 = ["rp2040-hal", "embedded-hal"]
+
+# RTOS features (exclusive within category)
+rtic = ["dep:rtic", "critical-section"]
+embassy = ["embassy-executor", "embassy-time"]
+```
+
+## Error conditions
+
+### Authoring errors (`cargo bp validate`)
+
+| Rule | Condition | Message |
+|------|-----------|---------|
+| `format.categories.defined` | An item's `categories` list references an undefined category | `feature 'stm32f4' references undefined category 'hal'` |
+| `format.features.exclusive-conflict` | Two or more features in the same `at-most-one` category are both in `default` | `features 'jemalloc' and 'mimalloc-alloc' are both in default but belong to at-most-one category 'allocator'` |
+| `format.categories.empty` | A category is declared but nothing references it | warning: `category 'foo' is declared but has no members` |
+| `format.categories.pick-missing-title` | A category has `pick = "at-most-one"` but no `title` | warning: `at-most-one category 'hal' should have a title for the picker UI` |
+| `format.features.unknown-feature` | `[package.metadata.battery-pack.features.X]` where `X` is not in `[features]` | `feature metadata 'X' does not match any entry in [features]` |
+| `format.dependencies.unknown-dep` | `[package.metadata.battery-pack.dependencies.X]` where `X` is not in any dependency section | `dependency metadata 'X' does not match any dependency` |
+| `format.template.category-placeholder-mismatch` | A template placeholder uses `options.category` referencing an undefined category | `placeholder 'allocator' references undefined category 'allocator'` |
+
+### Usage errors (`cargo bp add`)
+
+| Context | Condition | Message |
+|---------|-----------|---------|
+| Non-interactive `-F` | Two features from the same `at-most-one` category | `error: features 'stm32f4' and 'nrf52840' are exclusive (category: hal)` |
+| Non-interactive `-t` | Two templates from the same `at-most-one` category | `error: templates 'X' and 'Y' are exclusive (category: Z)` |
+| Interactive (picker) | Enter with >1 selection in `at-most-one` category | Inline error: `"category 'hal' allows at most one selection"` |
+| `--all-features` | Multiple exclusive selections | No error — bypasses exclusive checks |
+
+### Edge case: pre-existing multi-selection
+
+If the user previously installed items via `cargo add` that conflict with an
+`at-most-one` constraint, the picker shows them honestly (multiple radio
+buttons filled) with a warning banner:
+
+```
+  ⚠ Multiple selections in "Global Allocator" — pick one to resolve
+```
+
+The user must deselect down to one (or zero) before the picker will confirm.
+Selecting a new item automatically deselects the others. On confirm, deselected
+crates are removed from `Cargo.toml`.
+
+## Impact on existing battery packs
+
+### `backend-service-battery-pack`
+
+Today the allocator choice (`jemalloc` vs `mimalloc-alloc`) is two independent
+features with no expressed relationship — a user could enable both and get
+linker errors. The tower-http middleware layers are a flat list that would
+benefit from grouping.
+
+```toml
+[package.metadata.battery-pack.categories.allocator]
+title = "Global Allocator"
+description = "Pick a high-performance allocator (or use system default)"
+pick = "at-most-one"
+
+[package.metadata.battery-pack.categories.http-layers]
+title = "HTTP Middleware Layers"
+description = "Tower-HTTP middleware for your service"
+
+[package.metadata.battery-pack.features.jemalloc]
+description = "jemalloc (not available on MSVC)"
+categories = ["allocator"]
+
+[package.metadata.battery-pack.features.mimalloc-alloc]
+description = "mimalloc (works everywhere including MSVC)"
+categories = ["allocator"]
+
+[package.metadata.battery-pack.features.http-trace]
+description = "Request/response tracing spans"
+categories = ["http-layers"]
+
+[package.metadata.battery-pack.features.http-request-id]
+description = "X-Request-Id propagation"
+categories = ["http-layers"]
+
+[package.metadata.battery-pack.features.http-timeout]
+description = "Request timeout enforcement"
+categories = ["http-layers"]
+
+[package.metadata.battery-pack.features.http-catch-panic]
+description = "Convert panics to 500 responses"
+categories = ["http-layers"]
+```
+
+The picker renders allocators as radio buttons (picking one deselects the
+other), and middleware layers as a checkbox group under a clear heading.
+
+The service template's `bp-template.toml` also benefits — its allocator
+placeholder uses `options.category` instead of a hardcoded list:
+
+```toml
+[placeholders.allocator]
+type = "select"
+options.category = "allocator"
+prompt = "Global allocator"
+default = "jemalloc"
+```
+
+### `ci-battery-pack`
+
+This pack is template-heavy. Its 13 templates are currently a flat list.
+Categories provide organizational grouping:
+
+```toml
+[package.metadata.battery-pack.categories.quality]
+title = "Code Quality"
+description = "Static analysis and testing tools"
+
+[package.metadata.battery-pack.categories.docs]
+title = "Documentation"
+```
+
+Templates declare their categories:
+
+```toml
+[package.metadata.battery.templates]
+fuzzing = { path = "...", description = "cargo-fuzz scaffold + CI workflows", categories = ["quality"] }
+mutation-testing = { path = "...", description = "Mutation testing with cargo-mutants", categories = ["quality"] }
+spellcheck = { path = "...", description = "crate-ci/typos config + CI workflow", categories = ["quality"] }
+clippy-sarif = { path = "...", description = "Clippy with GitHub PR annotations", categories = ["quality"] }
+security-scanning = { path = "...", description = "RustSec audit workflow", categories = ["quality"] }
+mdbook = { path = "...", description = "mdBook scaffold + GitHub Pages deployment", categories = ["docs"] }
+```
+
+All categories here use `pick = "any"` (the default) — purely organizational.
+The picker shows items grouped under meaningful headings instead of a flat
+list.
+
+### `cli-battery-pack`
+
+No exclusive choices — features are genuinely additive. Categories help
+organize the picker:
+
+```toml
+[package.metadata.battery-pack.categories.output]
+title = "Terminal Output"
+description = "Color, hyperlinks, and progress display"
+
+[package.metadata.battery-pack.categories.input]
+title = "User Input"
+description = "Argument parsing and interactive prompts"
+
+[package.metadata.battery-pack.features.indicators]
+description = "Progress bars and spinners (indicatif + console)"
+categories = ["output"]
+
+[package.metadata.battery-pack.features.search]
+description = "Regex search with .gitignore-aware file walking"
+
+[package.metadata.battery-pack.features.config]
+description = "XDG/platform config directories (etcetera)"
+categories = ["input"]
+```
+
+### `logging-battery-pack` / `error-battery-pack`
+
+Too small to benefit. No change needed.
+
+## Interaction with existing features
+
+- Items without category annotations work exactly as before.
+- A single battery pack can mix categorized and uncategorized items freely.
+- `cargo bp add --all-features` skips validation for exclusive categories
+  (since the user explicitly asked for everything — useful for CI builds
+  that test all combinations).
+- `battery-pack.toml` records which features were chosen, unchanged from
+  today's format.
+
+## Future work
+
+- **Cargo globals.** If/when Cargo gets mutually-exclusive globals, we'd
+  read Cargo's native format and deprecate custom metadata.
+
+- **Conditional visibility / `requires`.** jlizen raised a use case where
+  templates should only be visible if a certain feature is selected (e.g.,
+  GitHub-specific templates only shown when `github` feature is active).
+  This is a filtering mechanism orthogonal to categories.
+
+- **Pack extension.** There's no mechanism for one battery pack to extend
+  another (shared categories, feature forwarding, template inheritance).
+  A single big pack works for v1; extension is a separate RFD.
+
+- **Shared item identity across categories.** When an item belongs to multiple
+  categories it appears as independent rows in the picker. Toggling it in one
+  section doesn't live-update its copy in the other. The confirmed *result* is
+  correct (decoded by name into a set), but the picker visually desyncs during
+  interaction. Fixing this means adding an `Option<String>` identity to
+  `SectionItem` and propagating state across entries sharing an id. This also
+  introduces edge cases — e.g., an item in both an `at-most-one` and an `any`
+  category could be checked in the `any` section, putting the `at-most-one`
+  section into an invalid state. Needs its own design pass.
+
+## Prior art
+
+- **awesome-embedded-rust**: flat curated list organized by vendor, no
+  tooling support
+- **Cargo pre-RFC for mutually-exclusive globals**: build-system-level
+  enforcement of exclusive choices
+- **Gentoo USE flags**: global configuration flags with profile defaults
+- **Homebrew formulae with conflicts**: `conflicts_with` declarations between
+  packages
+- **VS Code extension packs**: curated bundles with categorized alternatives

--- a/md/rfds/categories-and-alternatives/requirements.md
+++ b/md/rfds/categories-and-alternatives/requirements.md
@@ -1,0 +1,484 @@
+# Requirements: Categories and Exclusive Picks
+
+Testable requirements for the [Categories and Exclusive Picks RFD](./README.md).
+Each requirement has a unique ID (`r[...]`) and maps to one or more tests.
+
+---
+
+## Parsing
+
+r[parse.category-definition]
+A `[package.metadata.battery-pack.categories.<name>]` table with `title`,
+`description`, and `pick` fields is parsed into a `CategorySpec`.
+
+- **Test**: Parse a manifest with `categories.hal` containing all three fields.
+  Assert `spec.categories["hal"].pick == AtMostOne`, title and description match.
+
+r[parse.category-pick-default]
+A category with no `pick` field defaults to `PickMode::Any`.
+
+- **Test**: Parse a manifest with `categories.portable` containing only `title`.
+  Assert `spec.categories["portable"].pick == Any`.
+
+r[parse.feature-metadata]
+`[package.metadata.battery-pack.features.<name>]` with `description` and
+`categories` fields is parsed into an `ItemMeta` stored in `feature_meta`.
+
+- **Test**: Parse manifest with `features.stm32f4` containing
+  `categories = ["hal"]` and `description = "STM32F4xx"`.
+  Assert correct values in `spec.feature_meta["stm32f4"]`.
+
+r[parse.dependency-metadata]
+`[package.metadata.battery-pack.dependencies.<name>]` with `description` and
+`categories` fields is parsed into an `ItemMeta` stored in `dep_meta`.
+
+- **Test**: Parse manifest with `dependencies.embedded-hal` containing
+  `categories = ["portable"]`. Assert correct values in `spec.dep_meta`.
+
+r[parse.template-categories]
+A template entry in `[package.metadata.battery.templates]` with a `categories`
+field stores the category list on `TemplateSpec`.
+
+- **Test**: Parse manifest with template `fuzzing` having
+  `categories = ["quality"]`. Assert `spec.templates["fuzzing"].categories`.
+
+r[parse.multiple-categories]
+An item's `categories` field is a list; an item can belong to multiple
+categories.
+
+- **Test**: Parse `categories = ["quality", "ci"]`. Assert both stored.
+
+r[parse.no-metadata-backward-compat]
+Items with no metadata entry parse identically to today — no new fields
+affect existing behavior.
+
+- **Test**: Parse a manifest with zero `[package.metadata.battery-pack.features.*]`
+  entries. Assert `feature_meta` is empty and all other spec fields unchanged.
+
+r[parse.options-category-in-template]
+A template placeholder with `options.category = "allocator"` is parsed as a
+category-derived options source (untagged enum: literal array vs category ref).
+
+- **Test**: Parse a `bp-template.toml` with `options.category = "allocator"`.
+  Assert the placeholder's options source is `Category("allocator")`.
+
+r[parse.options-literal-array]
+A template placeholder with `options = ["a", "b", "c"]` continues to work.
+
+- **Test**: Parse `options = ["jemalloc", "mimalloc", "system"]`.
+  Assert the placeholder's options source is `Literal(["jemalloc", ...])`.
+
+---
+
+## Validation
+
+r[validate.categories-defined]
+Every category name referenced in an item's `categories` list must have a
+corresponding `[package.metadata.battery-pack.categories.<name>]` entry.
+
+- **Test (feature)**: Feature with `categories = ["nonexistent"]` →
+  error `format.categories.defined`.
+- **Test (dependency)**: Dep with `categories = ["bogus"]` →
+  error `format.categories.defined`.
+- **Test (template)**: Template with `categories = ["bogus"]` →
+  error `format.categories.defined`.
+- **Test (partial)**: `categories = ["hal", "bogus"]` where `hal` exists →
+  error only for `"bogus"`.
+
+r[validate.exclusive-conflict-in-default]
+If two or more features belonging to the same `at-most-one` category are both
+listed in the `[features] default` array, emit an error.
+
+- **Test (error)**: Two features in `at-most-one` category, both in default →
+  error `format.features.exclusive-conflict`.
+- **Test (ok, any)**: Two features in `any` category, both in default → no error.
+- **Test (ok, one in default)**: Two exclusive features, only one in default →
+  no error.
+
+r[validate.empty-category-warns]
+A declared category that no item references produces a warning.
+
+- **Test**: Category `foo` declared, no feature/dep/template lists it →
+  warning `format.categories.empty`.
+
+r[validate.at-most-one-missing-title]
+A category with `pick = "at-most-one"` and no `title` produces a warning.
+
+- **Test**: Category with `pick = "at-most-one"`, no title → warning
+  `format.categories.pick-missing-title`.
+
+r[validate.feature-metadata-unknown]
+`[package.metadata.battery-pack.features.X]` where `X` does not appear as a
+key in `[features]` is an error.
+
+- **Test**: Metadata for `features.foo` where `foo` not in `[features]` →
+  error `format.features.unknown-feature`.
+
+r[validate.dep-metadata-unknown]
+`[package.metadata.battery-pack.dependencies.X]` where `X` does not appear
+in any dependency section is an error.
+
+- **Test**: Metadata for `dependencies.foo` where `foo` is not a dependency →
+  error `format.dependencies.unknown-dep`.
+
+r[validate.template-category-placeholder]
+A template placeholder using `options.category = "X"` where `X` is not a
+declared category is an error.
+
+- **Test**: `options.category = "nonexistent"` →
+  error `format.template.category-placeholder-mismatch`.
+
+---
+
+## Picker: selection behavior
+
+r[picker.radio-toggle-deselects-others]
+In a Radio section, toggling an unchecked item checks it and unchecks all
+other items in that section.
+
+- **Unit test**: Section with items A(checked), B, C. Toggle B →
+  A unchecked, B checked, C unchanged.
+
+r[picker.radio-toggle-allows-deselect]
+In a Radio section, toggling an already-checked item unchecks it (allows zero
+selections).
+
+- **Unit test**: Section with A(checked). Toggle A → nothing checked.
+
+r[picker.radio-backspace-clears]
+In a Radio section, pressing Backspace clears all selections in the current
+category.
+
+- **Unit test**: Section with A(checked). Backspace → nothing checked.
+
+r[picker.checkbox-toggle-independent]
+In a Checkbox section, toggling an item does not affect other items.
+
+- **Unit test**: Section with A(checked), B. Toggle B →
+  A still checked, B checked.
+
+r[picker.radio-section-toggle-noop]
+`toggle_current_section()` (`a` key) in a Radio section is a no-op.
+
+- **Unit test**: Radio section with A(checked). Press `a` →
+  A still checked, no change.
+
+r[picker.checkbox-section-toggle-selects-all]
+`toggle_current_section()` (`a` key) in a Checkbox section checks all items
+(existing behavior preserved).
+
+- **Unit test**: Checkbox section with A(checked), B, C. Section toggle →
+  all checked.
+
+r[picker.radio-pre-existing-multiple]
+If a Radio section is initialized with multiple items checked, the state is
+preserved honestly (no auto-deselection on load).
+
+- **Unit test**: Construct Radio section with A(checked), B(checked).
+  Assert `into_results()` shows both checked.
+
+r[picker.radio-pre-existing-toggle-clears-all-others]
+In a Radio section with multiple items pre-checked, toggling a new item
+clears all others.
+
+- **Unit test**: Radio section with A(checked), B(checked). Toggle C →
+  only C checked.
+
+r[picker.confirm-blocked-on-radio-conflict]
+`try_confirm()` returns an error when a Radio section has more than one
+item checked.
+
+- **Unit test**: Radio section with A(checked), B(checked). Call
+  `try_confirm()` → `Err("...")` containing the section title.
+
+r[picker.confirm-succeeds-on-valid-state]
+`try_confirm()` succeeds when all Radio sections have 0 or 1 selection.
+
+- **Unit test**: Radio section with A(checked). Call `try_confirm()` →
+  `Ok(results)`.
+
+---
+
+## Picker: navigation and collapsing
+
+r[picker.collapse-hides-from-navigation]
+Collapsing a section causes `move_down`/`move_up` to skip its items.
+
+- **Unit test**: Two sections. Collapse first. Cursor at top, move down →
+  lands in second section.
+
+r[picker.expand-restores-navigation]
+Expanding a collapsed section restores normal traversal through its items.
+
+- **Unit test**: Collapse then expand first section. move_down from header →
+  lands on first item.
+
+r[picker.collapsed-results-preserved]
+Collapsed sections' checked state is included in `into_results()`.
+
+- **Unit test**: Check item, collapse section, call `into_results()` →
+  item shows as checked.
+
+r[picker.left-arrow-collapses]
+Pressing Left on a section header collapses that section.
+
+- **Integration test** (key event simulation): Send Left on header →
+  section becomes collapsed.
+
+r[picker.right-arrow-expands]
+Pressing Right on a section header expands that section.
+
+- **Integration test**: Collapsed section, send Right → section expands.
+
+---
+
+## Picker: rendering
+
+r[picker.render-radio-bullets]
+Radio items render with `●` (checked) and `○` (unchecked) instead of
+`[x]`/`[ ]`.
+
+- **Unit test** (render snapshot): Radio section with one checked item →
+  output contains `●` and `○`.
+
+r[picker.render-checkbox-squares]
+Checkbox items continue to render with `[x]`/`[ ]`.
+
+- **Unit test** (render snapshot): Checkbox section → output contains
+  `[x]` and `[ ]`.
+
+r[picker.render-collapsed-chevron]
+Collapsed section headers render with `▶`; expanded with `▼`.
+
+- **Unit test** (render snapshot): Collapsed section → `▶` in output.
+
+r[picker.render-at-most-one-hint]
+Radio section headers include the text "(pick at most one)".
+
+- **Unit test** (render snapshot): Radio section header →
+  output contains `(pick at most one)`.
+
+r[picker.render-warning-banner]
+When a Radio section has >1 item checked on initial render, a warning line
+is displayed.
+
+- **Unit test** (render snapshot): Radio section with 2 checked →
+  output contains `⚠` warning text.
+
+r[picker.render-descriptions]
+When items have descriptions, they are shown alongside the item name.
+
+- **Unit test** (render snapshot): Item with description →
+  output contains the description text.
+
+---
+
+## CLI: interactive picker wiring
+
+r[cli.picker-categories-become-sections]
+When a battery pack has category definitions, the picker groups items by
+category — one section per category, with the category title as section header.
+
+- **Integration test**: Pack with `hal` (at-most-one) and `utils` (any) →
+  picker has sections titled "Hardware Abstraction Layer" and "Utilities".
+
+r[cli.picker-radio-for-at-most-one]
+Sections for `at-most-one` categories use `SelectionMode::Radio`.
+
+- **Integration test**: Pack with at-most-one category → section has Radio mode.
+
+r[cli.picker-checkbox-for-any]
+Sections for `any` categories use `SelectionMode::Checkbox`.
+
+- **Integration test**: Pack with `any` category → section has Checkbox mode.
+
+r[cli.picker-uncategorized-in-generic]
+Items not in any category appear in generic "Features" / "Dependencies"
+sections, exactly as today.
+
+- **Integration test**: Pack with some categorized and some uncategorized
+  features → uncategorized appear in "Features:" section.
+
+r[cli.picker-item-in-multiple-categories]
+An item belonging to multiple categories appears in each category's section.
+Selection state is shared: toggling the item in one section updates its state
+in all sections where it appears.
+
+- **Integration test**: Feature with `categories = ["quality", "ci"]` →
+  appears in both sections.
+- **Integration test**: Toggle item in "quality" section → also shown as
+  checked in "ci" section.
+
+r[cli.picker-category-item-order]
+Items within a category section appear in declaration order (the order their
+metadata entries appear in `Cargo.toml`).
+
+- **Integration test**: Features `stm32f4`, `nrf52840`, `esp32` declared in
+  that order, all in category `hal` → picker shows them in that order.
+
+r[cli.picker-deselection-removes-dep]
+When a user deselects an item in an at-most-one category (by selecting
+another), the deselected crate is removed from the project's `Cargo.toml`
+on confirm.
+
+- **Integration test**: Project has both `jemalloc` and `mimalloc` in
+  Cargo.toml. User selects `jemalloc` in picker. After confirm, `mimalloc`
+  is removed from Cargo.toml.
+
+r[cli.picker-pre-existing-conflict-shown]
+If the project already has multiple items from an `at-most-one` category
+installed, the picker opens with all of them checked and shows a warning.
+
+- **Integration test**: Project has `jemalloc` + `mimalloc`. Open picker →
+  both radio items shown as checked, warning banner visible.
+
+---
+
+## CLI: non-interactive validation
+
+r[cli.noninteractive-exclusive-conflict-error]
+When `-F` passes two features from the same `at-most-one` category,
+`cargo bp add` exits with an error naming both features and the category.
+
+- **Integration test**: `cargo bp add pack -F stm32f4 -F nrf52840` →
+  exit code 1, stderr contains "exclusive" and "hal".
+
+r[cli.noninteractive-any-category-ok]
+Two features from the same `any` category can be passed together without error.
+
+- **Integration test**: `cargo bp add pack -F http-trace -F http-timeout` →
+  success.
+
+r[cli.noninteractive-different-categories-ok]
+Features from different categories can always be combined.
+
+- **Integration test**: `cargo bp add pack -F stm32f4 -F embassy` → success.
+
+r[cli.noninteractive-all-features-bypasses]
+`--all-features` bypasses exclusive constraint checking.
+
+- **Integration test**: `cargo bp add pack --all-features` with multiple
+  exclusive features → success.
+
+r[cli.noninteractive-template-exclusive-error]
+When `-t` passes two templates from the same `at-most-one` category,
+`cargo bp add` exits with an error.
+
+- **Integration test**: `-t X -t Y` where both in at-most-one category →
+  exit code 1.
+
+---
+
+## CLI: `cargo bp show`
+
+r[cli.show-categories]
+`cargo bp show` displays categories with their member items grouped under
+the category title.
+
+- **Integration test** (snapshot): `cargo bp show` on a pack with categories →
+  output contains "Categories:" section with expected structure.
+
+r[cli.show-pick-mode-hint]
+At-most-one categories display "(pick at most one)" in show output.
+
+- **Integration test** (snapshot): Show output for at-most-one category →
+  contains hint text.
+
+r[cli.show-templates-in-categories]
+Templates assigned to categories appear under their category heading in
+`cargo bp show` output.
+
+- **Integration test** (snapshot): Pack with template in `quality` category →
+  show output lists template under "Code Quality" heading.
+
+---
+
+## CLI: `cargo bp validate`
+
+r[cli.validate-clean-pack]
+A battery pack with correct category metadata passes validation.
+
+- **Integration test**: Run `cargo bp validate` on fixture with valid
+  categories → exit code 0.
+
+r[cli.validate-reports-errors]
+A battery pack with invalid category references fails validation with the
+appropriate rule ID in the output.
+
+- **Integration test**: Run `cargo bp validate` on fixture with
+  `categories = ["nonexistent"]` → exit code 1, output contains
+  `format.categories.defined`.
+
+---
+
+## Template: category-linked placeholders
+
+r[template.options-category-derives-list]
+A placeholder with `options.category = "allocator"` has its options list
+derived from the set of items in that category.
+
+- **Unit test**: Spec with category `allocator` containing features
+  `jemalloc` and `mimalloc`. Resolve placeholder → options are
+  `["jemalloc", "mimalloc"]`.
+
+r[template.options-category-prefill-from-picker]
+If the user already selected an item from the category in the picker, the
+placeholder is pre-filled without prompting.
+
+- **Unit test**: Active features include `jemalloc` (in `allocator` category).
+  Resolve placeholder → value is `"jemalloc"`, no prompt.
+
+r[template.options-category-prompts-if-no-selection]
+If no item from the category was selected in the picker, the placeholder
+prompts the user (interactive) or uses the default (non-interactive).
+
+- **Unit test (non-interactive)**: No active feature in category, default is
+  `"jemalloc"` → value resolves to `"jemalloc"`.
+
+r[template.options-category-unknown-error]
+A placeholder referencing an undefined category produces a clear error.
+
+- **Unit test**: `options.category = "nonexistent"` → error message.
+
+r[template.options-category-picks-up-new-members]
+Adding a new feature to a category automatically includes it in the
+placeholder's options without editing `bp-template.toml`.
+
+- **Unit test**: Add feature `system` to `allocator` category → options list
+  now includes `"system"`.
+
+r[template.options-category-dep-uses-dep-name]
+When a category contains dependencies (not features), the option value is the
+dependency name (the key from `[dependencies]`).
+
+- **Unit test**: Category `allocator` contains dep `tikv-jemallocator`.
+  Placeholder options include `"tikv-jemallocator"`.
+
+---
+
+## Invariants
+
+r[invariant.pack-scoped-categories]
+Categories are scoped to the battery pack that defines them. Two different
+installed packs can both define a category with the same name without
+conflict — their constraints are enforced independently.
+
+- **Integration test**: Install two packs, both defining category `hal`
+  (at-most-one). Select one item from each pack's `hal` category → no error.
+
+r[invariant.battery-pack-toml-unchanged]
+The `battery-pack.toml` file format (which records installed packs and active
+features in user projects) is unchanged by this feature. Category metadata
+does not appear in `battery-pack.toml`.
+
+- **Integration test**: Run `cargo bp add pack -F stm32f4` where `stm32f4`
+  is in a category. Inspect `battery-pack.toml` → format matches existing
+  schema, no category fields present.
+
+r[invariant.noninteractive-dep-exclusive-conflict]
+When a dependency (not wrapped in a feature) belongs to an `at-most-one`
+category and the user requests multiple such deps non-interactively, it is
+an error.
+
+- **Integration test**: Pack has deps `tikv-jemallocator` and `mimalloc` both
+  in `at-most-one` category `allocator`. Non-interactive add of both → error.


### PR DESCRIPTION
Proposes extending battery pack metadata with categories that group features/deps/templates and express pick constraints (at-most-one vs any). Covers UI behavior, template integration, category-linked placeholders, error conditions, and impact on existing packs.