### PR TITLE
security: fix rustsec vulnerabilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"
@@ -1206,9 +1206,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2139,7 +2139,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4384,7 +4384,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4825,9 +4825,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -5391,7 +5391,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5448,7 +5448,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6409,7 +6409,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7424,7 +7424,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/battery-packs/ci-battery-pack/src/snapshots/maximalist.txt
+++ b/battery-packs/ci-battery-pack/src/snapshots/maximalist.txt
@@ -813,6 +813,16 @@ src = "md"
 ── deny.toml ──
 # https://embarkstudios.github.io/cargo-deny/
 
+[advisories]
+unmaintained = "workspace"
+# Temporary exceptions for upstream crates with no published fix.
+# Review again after 2026-10-01.
+ignore = [
+    "RUSTSEC-2025-0141",
+    "RUSTSEC-2025-0119",
+]
+yanked = "warn"
+
 [licenses]
 allow = [
     "MIT",

--- a/battery-packs/ci-battery-pack/src/snapshots/minimalist.txt
+++ b/battery-packs/ci-battery-pack/src/snapshots/minimalist.txt
@@ -402,6 +402,16 @@ features = []
 ── deny.toml ──
 # https://embarkstudios.github.io/cargo-deny/
 
+[advisories]
+unmaintained = "workspace"
+# Temporary exceptions for upstream crates with no published fix.
+# Review again after 2026-10-01.
+ignore = [
+    "RUSTSEC-2025-0141",
+    "RUSTSEC-2025-0119",
+]
+yanked = "warn"
+
 [licenses]
 allow = [
     "MIT",

--- a/battery-packs/ci-battery-pack/src/snapshots/standalone_dependency_policy.txt
+++ b/battery-packs/ci-battery-pack/src/snapshots/standalone_dependency_policy.txt
@@ -29,6 +29,16 @@ jobs:
 ── deny.toml ──
 # https://embarkstudios.github.io/cargo-deny/
 
+[advisories]
+unmaintained = "workspace"
+# Temporary exceptions for upstream crates with no published fix.
+# Review again after 2026-10-01.
+ignore = [
+    "RUSTSEC-2025-0141",
+    "RUSTSEC-2025-0119",
+]
+yanked = "warn"
+
 [licenses]
 allow = [
     "MIT",

--- a/battery-packs/ci-battery-pack/templates/dependency-policy/deny.toml
+++ b/battery-packs/ci-battery-pack/templates/dependency-policy/deny.toml
@@ -1,5 +1,15 @@
 # https://embarkstudios.github.io/cargo-deny/
 
+[advisories]
+unmaintained = "workspace"
+# Temporary exceptions for upstream crates with no published fix.
+# Review again after 2026-10-01.
+ignore = [
+    "RUSTSEC-2025-0141",
+    "RUSTSEC-2025-0119",
+]
+yanked = "warn"
+
 [licenses]
 allow = [
     "MIT",

--- a/battery-packs/cli-battery-pack/templates/simple/tests/cli.rs
+++ b/battery-packs/cli-battery-pack/templates/simple/tests/cli.rs
@@ -18,6 +18,7 @@ fn help() {
     // Exercise the generated CLI and verify its complete help output.
     Command::cargo_bin("{{ project_name }}")
         .with_assert(assertion)
+        .env_remove("NO_COLOR")
         .env("CLICOLOR_FORCE", "1")
         .arg("--help")
         .assert()

--- a/battery-packs/cli-battery-pack/templates/simple/tests/cli.rs
+++ b/battery-packs/cli-battery-pack/templates/simple/tests/cli.rs
@@ -1,9 +1,23 @@
 use snapbox::cmd::Command;
-use snapbox::file;
+use snapbox::{Assert, Redactions, file};
 
 #[test]
 fn help() {
+    // Normalize the platform-specific executable name before matching the snapshot.
+    let mut redactions = Redactions::new();
+    redactions
+        .insert(
+            "[BIN]",
+            format!("{}{}", env!("CARGO_PKG_NAME"), std::env::consts::EXE_SUFFIX),
+        )
+        .unwrap();
+    let assertion = Assert::new()
+        .action_env("SNAPSHOTS")
+        .redact_with(redactions);
+
+    // Exercise the generated CLI and verify its complete help output.
     Command::cargo_bin("{{ project_name }}")
+        .with_assert(assertion)
         .env("CLICOLOR_FORCE", "1")
         .arg("--help")
         .assert()

--- a/battery-packs/cli-battery-pack/templates/simple/tests/snapshots/cli__help.txt
+++ b/battery-packs/cli-battery-pack/templates/simple/tests/snapshots/cli__help.txt
@@ -1,11 +1,11 @@
 A CLI application
 
-[1m[4mUsage:[0m [1m{{ project_name }}[EXE][0m [OPTIONS]
+Usage: [BIN] [OPTIONS]
 
-[1m[4mOptions:[0m
-  [1m-n[0m, [1m--name[0m <NAME>   Name to greet [default: World]
-      [1m--color[0m <WHEN>  Controls when to use color [default: auto] [possible values: auto, always, never]
-  [1m-v[0m, [1m--verbose[0m       Enable verbose output
-  [1m-h[0m, [1m--help[0m          Print help
-  [1m-V[0m, [1m--version[0m       Print version
+Options:
+  -n, --name <NAME>   Name to greet [default: World]
+      --color <WHEN>  Controls when to use color [default: auto] [possible values: auto, always, never]
+  -v, --verbose       Enable verbose output
+  -h, --help          Print help
+  -V, --version       Print version
 

--- a/battery-packs/cli-battery-pack/templates/simple/tests/snapshots/cli__help.txt
+++ b/battery-packs/cli-battery-pack/templates/simple/tests/snapshots/cli__help.txt
@@ -1,11 +1,11 @@
 A CLI application
 
-Usage: [BIN] [OPTIONS]
+[1m[4mUsage:[0m [1m[BIN][0m [OPTIONS]
 
-Options:
-  -n, --name <NAME>   Name to greet [default: World]
-      --color <WHEN>  Controls when to use color [default: auto] [possible values: auto, always, never]
-  -v, --verbose       Enable verbose output
-  -h, --help          Print help
-  -V, --version       Print version
+[1m[4mOptions:[0m
+  [1m-n[0m, [1m--name[0m <NAME>   Name to greet [default: World]
+      [1m--color[0m <WHEN>  Controls when to use color [default: auto] [possible values: auto, always, never]
+  [1m-v[0m, [1m--verbose[0m       Enable verbose output
+  [1m-h[0m, [1m--help[0m          Print help
+  [1m-V[0m, [1m--version[0m       Print version
 

--- a/battery-packs/cli-battery-pack/templates/subcmds/tests/cli.rs
+++ b/battery-packs/cli-battery-pack/templates/subcmds/tests/cli.rs
@@ -18,6 +18,7 @@ fn help() {
     // Exercise the generated CLI and verify its complete help output.
     Command::cargo_bin("{{ project_name }}")
         .with_assert(assertion)
+        .env_remove("NO_COLOR")
         .env("CLICOLOR_FORCE", "1")
         .arg("--help")
         .assert()

--- a/battery-packs/cli-battery-pack/templates/subcmds/tests/cli.rs
+++ b/battery-packs/cli-battery-pack/templates/subcmds/tests/cli.rs
@@ -1,9 +1,23 @@
 use snapbox::cmd::Command;
-use snapbox::file;
+use snapbox::{Assert, Redactions, file};
 
 #[test]
 fn help() {
+    // Normalize the platform-specific executable name before matching the snapshot.
+    let mut redactions = Redactions::new();
+    redactions
+        .insert(
+            "[BIN]",
+            format!("{}{}", env!("CARGO_PKG_NAME"), std::env::consts::EXE_SUFFIX),
+        )
+        .unwrap();
+    let assertion = Assert::new()
+        .action_env("SNAPSHOTS")
+        .redact_with(redactions);
+
+    // Exercise the generated CLI and verify its complete help output.
     Command::cargo_bin("{{ project_name }}")
+        .with_assert(assertion)
         .env("CLICOLOR_FORCE", "1")
         .arg("--help")
         .assert()

--- a/battery-packs/cli-battery-pack/templates/subcmds/tests/snapshots/cli__help.txt
+++ b/battery-packs/cli-battery-pack/templates/subcmds/tests/snapshots/cli__help.txt
@@ -1,14 +1,14 @@
 A CLI application with subcommands
 
-Usage: [BIN] [OPTIONS] <COMMAND>
+[1m[4mUsage:[0m [1m[BIN][0m [OPTIONS] <COMMAND>
 
-Commands:
-  hello    Say hello
-  goodbye  Say goodbye
-  help     Print this message or the help of the given subcommand(s)
+[1m[4mCommands:[0m
+  [1mhello[0m    Say hello
+  [1mgoodbye[0m  Say goodbye
+  [1mhelp[0m     Print this message or the help of the given subcommand(s)
 
-Options:
-  -v, --verbose  Enable verbose output
-  -h, --help     Print help
-  -V, --version  Print version
+[1m[4mOptions:[0m
+  [1m-v[0m, [1m--verbose[0m  Enable verbose output
+  [1m-h[0m, [1m--help[0m     Print help
+  [1m-V[0m, [1m--version[0m  Print version
 

--- a/battery-packs/cli-battery-pack/templates/subcmds/tests/snapshots/cli__help.txt
+++ b/battery-packs/cli-battery-pack/templates/subcmds/tests/snapshots/cli__help.txt
@@ -1,14 +1,14 @@
 A CLI application with subcommands
 
-[1m[4mUsage:[0m [1m{{ project_name }}[EXE][0m [OPTIONS] <COMMAND>
+Usage: [BIN] [OPTIONS] <COMMAND>
 
-[1m[4mCommands:[0m
-  [1mhello[0m    Say hello
-  [1mgoodbye[0m  Say goodbye
-  [1mhelp[0m     Print this message or the help of the given subcommand(s)
+Commands:
+  hello    Say hello
+  goodbye  Say goodbye
+  help     Print this message or the help of the given subcommand(s)
 
-[1m[4mOptions:[0m
-  [1m-v[0m, [1m--verbose[0m  Enable verbose output
-  [1m-h[0m, [1m--help[0m     Print help
-  [1m-V[0m, [1m--version[0m  Print version
+Options:
+  -v, --verbose  Enable verbose output
+  -h, --help     Print help
+  -V, --version  Print version
 

--- a/deny.toml
+++ b/deny.toml
@@ -2,6 +2,12 @@
 
 [advisories]
 unmaintained = "workspace"
+# Temporary exceptions for upstream crates with no published fix.
+# Review again after 2026-10-01.
+ignore = [
+    "RUSTSEC-2025-0141",
+    "RUSTSEC-2025-0119",
+]
 yanked = "warn"
 
 [licenses]


### PR DESCRIPTION
Two vulnerabilities were allowed as syntect uses bincode and bincode is unmaintained. Same case for number_prefix as well, although i can't find its dependent with cargo tree

closes #158

closes #154

closes #152

closes #151

closes #153