### PR TITLE
fix(ci): fix mdbook workflow to support battery-pack preprocessor

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -33,11 +33,12 @@ jobs:
       MDBOOK_VERSION: 0.4.36
     steps:
       - uses: actions/checkout@v4
-      - name: Install mdBook
+      - name: Install Rust
         run: |
-          curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf -y | sh
-          rustup update
-          cargo install --version ${MDBOOK_VERSION} mdbook
+          curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh -s -- -y
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - name: Install mdBook
+        run: cargo install --version ${MDBOOK_VERSION} mdbook
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -9,6 +9,9 @@ on:
   push:
     branches: ["main"]
 
+  # Build (but don't deploy) on PRs to catch breakage early
+  pull_request:
+
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -49,9 +52,9 @@ jobs:
         with:
           path: ./book
 
-  # Deployment job
+  # Deployment job (only on push to main, not PRs)
   deploy:
-    if: ${{ github.repository_owner == 'battery-pack-rs' }}
+    if: ${{ github.repository_owner == 'battery-pack-rs' && github.event_name == 'push' }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -1,58 +1,53 @@
-# Sample workflow for building and deploying a mdBook site to GitHub Pages
+# Build and deploy mdBook site to GitHub Pages
 #
-# To get started with mdBook see: https://rust-lang.github.io/mdBook/index.html
+# The battery-pack preprocessor (cargo run -p mdbook-battery-pack) is
+# built from the workspace and runs cargo check on each battery pack
+# to generate their documentation.
 #
 name: Deploy mdBook site to Pages
 
 on:
-  # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
 
   # Build (but don't deploy) on PRs to catch breakage early
   pull_request:
 
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
-  # Build job
   build:
     if: ${{ github.repository_owner == 'battery-pack-rs' }}
     runs-on: ubuntu-latest
     env:
       MDBOOK_VERSION: 0.4.36
     steps:
-      - uses: actions/checkout@v4
-      - name: Install Rust
-        run: |
-          curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh -s -- -y
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
       - name: Install mdBook
         run: cargo install --version ${MDBOOK_VERSION} mdbook
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
       - name: Build with mdBook
         run: mdbook build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: ./book
 
-  # Deployment job (only on push to main, not PRs)
   deploy:
     if: ${{ github.repository_owner == 'battery-pack-rs' && github.event_name == 'push' }}
     environment:
@@ -63,4 +58,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/book.toml
+++ b/book.toml
@@ -10,4 +10,4 @@ fold.enable = true
 fold.level = 0
 
 [preprocessor.battery-pack]
-command = "cargo mdbook-battery-pack"
+command = "cargo run -q -p mdbook-battery-pack --release --"

--- a/src/mdbook-battery-pack/src/main.rs
+++ b/src/mdbook-battery-pack/src/main.rs
@@ -53,9 +53,15 @@ fn main() -> Result<()> {
 
     // Discover all battery packs in the workspace.
     let packs = discover_battery_packs(&workspace_root);
+    eprintln!(
+        "mdbook-battery-pack: root={}, discovered {} packs",
+        workspace_root.display(),
+        packs.len()
+    );
 
     // Resolve out_dir paths for battery pack crates via `cargo check`.
     let out_dirs = resolve_out_dirs(&book, &packs, &workspace_root)?;
+    eprintln!("mdbook-battery-pack: resolved {} out_dirs", out_dirs.len());
 
     // Walk the book items and expand directives.
     // mdbook uses "items" (not "sections") as the top-level key.


### PR DESCRIPTION
The preprocessor is invoked via `cargo mdbook-battery-pack` (a cargo alias for `cargo run -p mdbook-battery-pack --release`), which requires the Rust toolchain on PATH. Fix the rustup install invocation and ensure cargo/bin is in GITHUB_PATH so mdbook can find cargo when it shells out to the preprocessor.