### PR TITLE
Fix mdBook links and add link checking

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -43,6 +43,16 @@ jobs:
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
       - name: Build with mdBook
         run: mdbook build
+      - name: Check rendered links
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        with:
+          args: >-
+            --config lychee.toml
+            --root-dir "${{ github.workspace }}/book"
+            "${{ github.workspace }}/book/**/*.html"
+          fail: true
+          lycheeVersion: v0.24.2
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload artifact
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -51,7 +51,7 @@ jobs:
             --root-dir "${{ github.workspace }}/book"
             "${{ github.workspace }}/book/**/*.html"
           fail: true
-          lycheeVersion: v0.24.2
+          lycheeVersion: v0.23.0
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload artifact
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,6 @@ Before merging a release PR, review the generated changelog entries and edit the
 Trusted publishing cannot publish a crate that doesn't exist on crates.io yet. To add a new crate:
 
 1. Get a temporary crates.io token and run `cargo publish -p <crate-name>` manually.
-2. Set up [trusted publishing](https://doc.rust-lang.org/cargo/reference/registry-authentication.html#trusted-publishing) for the new crate on crates.io, pointing to the `release-plz.yml` workflow.
+2. Set up [trusted publishing](https://crates.io/docs/trusted-publishing) for the new crate on crates.io, pointing to the `release-plz.yml` workflow.
 3. Revoke the temporary token.
 4. If the new crate should appear in the `battery-pack` release notes, add it to `changelog_include` in `release-plz.toml`.

--- a/battery-packs/ci-battery-pack/README.md
+++ b/battery-packs/ci-battery-pack/README.md
@@ -75,7 +75,7 @@ After generating your project, set `ci-pass` as the required status check in bra
 
 ### release-plz
 
-1. [Configure trusted publishing](https://doc.rust-lang.org/cargo/reference/registry-authentication.html#trusted-publishing) on crates.io
+1. [Configure trusted publishing](https://crates.io/docs/trusted-publishing) on crates.io
 2. In repo settings → Actions → General, enable "Allow GitHub Actions to create and approve pull requests"
 
 Without `binary_release`, `GITHUB_TOKEN` works fine and no further setup is needed.
@@ -111,7 +111,7 @@ Review `deny.toml` before enforcing it; license policy is project-specific.
 
 Licensed under either of:
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+- [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+- [MIT license](https://opensource.org/license/mit)
 
 at your option.

--- a/battery-packs/ci-battery-pack/skills/trusted-publishing/SKILL.md
+++ b/battery-packs/ci-battery-pack/skills/trusted-publishing/SKILL.md
@@ -42,7 +42,7 @@ Go to your crate's settings on crates.io and add a trusted publisher:
 
 For new crates that don't exist on crates.io yet, use "Add a new crate" under your account settings.
 
-Docs: https://doc.rust-lang.org/cargo/reference/registry-authentication.html#trusted-publishing
+Docs: https://crates.io/docs/trusted-publishing
 
 ### 2. Enable PR creation
 

--- a/battery-packs/ci-battery-pack/src/snapshots/maximalist.txt
+++ b/battery-packs/ci-battery-pack/src/snapshots/maximalist.txt
@@ -602,7 +602,7 @@ jobs:
 # release-plz: automated releases to crates.io (https://release-plz.dev/docs)
 # Setup:
 # 1. Configure trusted publishing on crates.io
-#    https://doc.rust-lang.org/cargo/reference/registry-authentication.html#trusted-publishing
+#    https://crates.io/docs/trusted-publishing
 # 2. In repo Settings → Actions → General, enable
 #    "Allow GitHub Actions to create and approve pull requests"
 # 3. Create a fine-grained PAT (contents:write + pull-requests:write) and add
@@ -768,8 +768,8 @@ TODO: add description
 
 Licensed under either of:
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+- [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+- [MIT license](https://opensource.org/license/mit)
 
 at your option.
 ── _typos.toml ──

--- a/battery-packs/ci-battery-pack/src/snapshots/minimalist.txt
+++ b/battery-packs/ci-battery-pack/src/snapshots/minimalist.txt
@@ -277,7 +277,7 @@ jobs:
 # release-plz: automated releases to crates.io (https://release-plz.dev/docs)
 # Setup:
 # 1. Configure trusted publishing on crates.io
-#    https://doc.rust-lang.org/cargo/reference/registry-authentication.html#trusted-publishing
+#    https://crates.io/docs/trusted-publishing
 # 2. In repo Settings → Actions → General, enable
 #    "Allow GitHub Actions to create and approve pull requests"
 name: Release
@@ -389,8 +389,8 @@ TODO: add description
 
 Licensed under either of:
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+- [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+- [MIT license](https://opensource.org/license/mit)
 
 at your option.
 ── battery-pack.toml ──

--- a/battery-packs/ci-battery-pack/src/snapshots/standalone_trusted_publishing.txt
+++ b/battery-packs/ci-battery-pack/src/snapshots/standalone_trusted_publishing.txt
@@ -2,7 +2,7 @@
 # release-plz: automated releases to crates.io (https://release-plz.dev/docs)
 # Setup:
 # 1. Configure trusted publishing on crates.io
-#    https://doc.rust-lang.org/cargo/reference/registry-authentication.html#trusted-publishing
+#    https://crates.io/docs/trusted-publishing
 # 2. In repo Settings → Actions → General, enable
 #    "Allow GitHub Actions to create and approve pull requests"
 name: Release

--- a/battery-packs/ci-battery-pack/templates/full/README.md
+++ b/battery-packs/ci-battery-pack/templates/full/README.md
@@ -10,7 +10,7 @@
 
 Licensed under either of:
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+- [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+- [MIT license](https://opensource.org/license/mit)
 
 at your option.

--- a/battery-packs/ci-battery-pack/templates/trusted-publishing/.github/workflows/release.yml
+++ b/battery-packs/ci-battery-pack/templates/trusted-publishing/.github/workflows/release.yml
@@ -2,7 +2,7 @@
 # release-plz: automated releases to crates.io (https://release-plz.dev/docs)
 # Setup:
 # 1. Configure trusted publishing on crates.io
-#    https://doc.rust-lang.org/cargo/reference/registry-authentication.html#trusted-publishing
+#    https://crates.io/docs/trusted-publishing
 # 2. In repo Settings → Actions → General, enable
 #    "Allow GitHub Actions to create and approve pull requests"
 {%- if all or binary_release %}

--- a/battery-packs/ci-battery-pack/templates/trusted-publishing/bp-template.toml
+++ b/battery-packs/ci-battery-pack/templates/trusted-publishing/bp-template.toml
@@ -10,7 +10,7 @@ prompt = "Repository owner (org or user)"
 default = "OWNER"
 
 [[hints]]
-message = "Configure trusted publishing on crates.io: https://doc.rust-lang.org/cargo/reference/registry-authentication.html#trusted-publishing"
+message = "Configure trusted publishing on crates.io: https://crates.io/docs/trusted-publishing"
 
 [[hints]]
 message = "In repo Settings → Actions → General, enable 'Allow GitHub Actions to create and approve pull requests'"

--- a/battery-packs/cli-battery-pack/README.md
+++ b/battery-packs/cli-battery-pack/README.md
@@ -18,7 +18,7 @@ cargo bp add cli -F indicators
 
 Licensed under either of:
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+- [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+- [MIT license](https://opensource.org/license/mit)
 
 at your option.

--- a/battery-packs/error-battery-pack/README.md
+++ b/battery-packs/error-battery-pack/README.md
@@ -40,7 +40,7 @@ The skill files in `skills/` are adapted from an error handling guide originally
 
 Licensed under either of:
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+- [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+- [MIT license](https://opensource.org/license/mit)
 
 at your option.

--- a/battery-packs/logging-battery-pack/README.md
+++ b/battery-packs/logging-battery-pack/README.md
@@ -12,7 +12,7 @@ cargo bp add logging
 
 Licensed under either of:
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+- [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+- [MIT license](https://opensource.org/license/mit)
 
 at your option.

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,5 +1,5 @@
 # Validate rendered mdBook anchors and require directory links to contain an index page.
-include_fragments = "anchor-only"
+include_fragments = true
 index_files = ["index.html"]
 no_progress = true
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,11 @@
+# Validate rendered mdBook anchors and require directory links to contain an index page.
+include_fragments = "anchor-only"
+index_files = ["index.html"]
+no_progress = true
+
+# crates.io requires an explicit HTML accept header for automated link checks.
+header = { accept = "text/html" }
+
+# Keep external checks bounded while allowing transient failures to recover.
+max_retries = 3
+timeout = 30

--- a/md/getting-started.md
+++ b/md/getting-started.md
@@ -121,7 +121,7 @@ Some battery packs group crates into features you can opt into:
 cargo bp add cli -F indicators
 ```
 
-Others use categories to present alternatives — "pick one HAL for your chip family" or "pick an allocator". The interactive picker shows these as radio buttons (pick one) or checkboxes (pick any). See [Our Battery Packs](./battery-packs/README.md) for examples.
+Others use categories to present alternatives — "pick one HAL for your chip family" or "pick an allocator". The interactive picker shows these as radio buttons (pick one) or checkboxes (pick any). See [Our Battery Packs](./battery-packs/index.md) for examples.
 
 ## Start a new project from a template
 

--- a/md/intro.md
+++ b/md/intro.md
@@ -4,7 +4,7 @@
 
 # What is a Battery Pack?
 
-A battery pack is a curated set of crates arranged around a common theme. There's one for [building CLIs](./battery-packs/cli.md), one for [error handling](./battery-packs/errors.md), one for [setting up CI](./battery-packs/ci.md), one for [embedded development](./battery-packs/embedded.md), and more. You install `cargo bp` and then:
+A battery pack is a curated set of crates arranged around a common theme. There's one for [building CLIs](./battery-packs/cli.md), one for [error handling](./battery-packs/error.md), one for [setting up CI](./battery-packs/ci.md), one for [embedded development](./battery-packs/embedded.md), and more. You install `cargo bp` and then:
 
 ```bash
 cargo bp ls               # search crates.io for available battery packs
@@ -23,5 +23,5 @@ The key ideas:
 
 - **[Getting Started](./getting-started.md)** — install the CLI and use your first battery pack
 - **[Templates](./templates.md)** — scaffold projects and add CI workflows
-- **[Our Battery Packs](./battery-packs/README.md)** — what's available today
+- **[Our Battery Packs](./battery-packs/index.md)** — what's available today
 - **[Create Your Own](./creating.md)** — publish a battery pack for your domain

--- a/md/rfds/categories-and-alternatives/impl-plan.md
+++ b/md/rfds/categories-and-alternatives/impl-plan.md
@@ -1,6 +1,6 @@
 # Implementation Plan: Categories and Exclusive Picks
 
-TDD-driven implementation plan for the [Categories and Exclusive Picks RFD](./README.md).
+TDD-driven implementation plan for the [Categories and Exclusive Picks RFD](./index.md).
 
 ## Status
 

--- a/md/rfds/categories-and-alternatives/requirements.md
+++ b/md/rfds/categories-and-alternatives/requirements.md
@@ -1,6 +1,6 @@
 # Requirements: Categories and Exclusive Picks
 
-Testable requirements for the [Categories and Exclusive Picks RFD](./README.md).
+Testable requirements for the [Categories and Exclusive Picks RFD](./index.md).
 Each requirement has a unique ID (`r[...]`) and maps to one or more tests.
 
 ---

--- a/opinionated-battery-packs/backend-service-battery-pack/README.md
+++ b/opinionated-battery-packs/backend-service-battery-pack/README.md
@@ -23,4 +23,4 @@ cargo bp show backend-service              # crates, features, and templates
 cargo bp show backend-service -t service   # preview the rendered template
 ```
 
-See [skills/](skills/) for guidance on the observability, resilience, and performance choices these templates make.
+See the [backend service skills](https://github.com/battery-pack-rs/battery-pack/tree/main/opinionated-battery-packs/backend-service-battery-pack/skills) for guidance on the observability, resilience, and performance choices these templates make.

--- a/src/battery-pack/bphelper-build/src/lib.rs
+++ b/src/battery-pack/bphelper-build/src/lib.rs
@@ -5,9 +5,12 @@
 //! pure functions (`build_context`, `render_docs`) for testability,
 //! with `generate_docs` as the I/O entry point for build.rs.
 
-use bphelper_manifest::{BatteryPackSpec, PickMode, parse_battery_pack_from_path};
+use bphelper_manifest::{BatteryPackSpec, FeatureRef, PickMode, parse_battery_pack_from_path};
 use serde::Serialize;
-use std::{collections::BTreeMap, path::Path};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::Path,
+};
 
 // ============================================================================
 // Error type
@@ -126,6 +129,68 @@ pub struct PackageInfo {
 // Core rendering pipeline (pure functions)
 // ============================================================================
 
+/// Resolve a named Cargo feature to the visible crates it activates.
+fn feature_crate_names(spec: &BatteryPackSpec, feature_name: &str) -> Vec<String> {
+    // Restrict documentation links to crates that are visible to battery-pack users.
+    let visible_names: BTreeSet<&str> = spec.visible_crates().keys().copied().collect();
+    let mut visited_features = BTreeSet::new();
+    let mut crate_names = BTreeSet::new();
+
+    // Expand local feature aliases before returning stable, de-duplicated crate names.
+    collect_feature_crates(
+        spec,
+        feature_name,
+        &visible_names,
+        &mut visited_features,
+        &mut crate_names,
+    );
+    crate_names.into_iter().collect()
+}
+
+/// Recursively collect dependency names from one Cargo feature.
+fn collect_feature_crates<'a>(
+    spec: &'a BatteryPackSpec,
+    feature_name: &str,
+    visible_names: &BTreeSet<&'a str>,
+    visited_features: &mut BTreeSet<String>,
+    crate_names: &mut BTreeSet<String>,
+) {
+    // Stop repeated aliases defensively even though manifest validation rejects cycles.
+    if !visited_features.insert(feature_name.to_string()) {
+        return;
+    }
+
+    // Resolve bare local features recursively and dependency references directly.
+    if let Some(refs) = spec.features.get(feature_name) {
+        for feature_ref in refs {
+            match feature_ref {
+                FeatureRef::Feature(name) if spec.features.contains_key(name) => {
+                    collect_feature_crates(
+                        spec,
+                        name,
+                        visible_names,
+                        visited_features,
+                        crate_names,
+                    );
+                }
+                FeatureRef::Feature(name) | FeatureRef::Dep(name) => {
+                    if visible_names.contains(name.as_str()) {
+                        crate_names.insert(name.clone());
+                    }
+                }
+                FeatureRef::DepFeature { dep, .. } => {
+                    if visible_names.contains(dep.as_str()) {
+                        crate_names.insert(dep.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    // Let sibling branches expand the same alias independently while preventing cycles above.
+    visited_features.remove(feature_name);
+}
+
 /// Build the template context from a parsed spec, crate descriptions, and readme.
 ///
 /// This is a pure function with no I/O — all inputs are passed in.
@@ -151,10 +216,10 @@ pub fn build_context(
 
     let features = spec
         .features
-        .iter()
-        .map(|(name, refs)| FeatureEntry {
+        .keys()
+        .map(|name| FeatureEntry {
             name: name.clone(),
-            crates: refs.iter().map(|r| r.dep_name().to_string()).collect(),
+            crates: feature_crate_names(spec, name),
         })
         .collect();
 
@@ -168,11 +233,7 @@ pub fn build_context(
             // Collect features in this category.
             for (feat_name, meta) in &spec.feature_meta {
                 if meta.categories.contains(cat_name) {
-                    let mut crate_names: Vec<String> = spec
-                        .features
-                        .get(feat_name)
-                        .map(|refs| refs.iter().map(|r| r.dep_name().to_string()).collect())
-                        .unwrap_or_default();
+                    let mut crate_names = feature_crate_names(spec, feat_name);
                     // Put the crate matching the feature name first (it's the "primary" crate).
                     if let Some(pos) = crate_names.iter().position(|c| c == feat_name) {
                         crate_names.swap(0, pos);

--- a/src/battery-pack/bphelper-build/src/tests.rs
+++ b/src/battery-pack/bphelper-build/src/tests.rs
@@ -132,6 +132,30 @@ fn test_context_features() {
 }
 
 #[test]
+fn test_context_features_expand_local_aliases() {
+    // Parse the embedded pack whose HAL features include a local critical-section alias.
+    let manifest_path = fixtures_dir()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("opinionated-battery-packs/embedded-battery-pack/Cargo.toml");
+    let spec = parse_battery_pack_from_path(&manifest_path).unwrap();
+    let ctx = build_context(&spec, &BTreeMap::new(), "");
+
+    // Render only real crate names so generated crates.io links always have valid targets.
+    let stm32f0 = ctx
+        .features
+        .iter()
+        .find(|feature| feature.name == "stm32f0")
+        .unwrap();
+    assert_data_eq!(
+        stm32f0.crates.join(", "),
+        str!["cortex-m, cortex-m-rt, critical-section, embedded-hal, stm32f0xx-hal"]
+    );
+}
+
+#[test]
 // [verify docgen.vars.readme]
 fn test_context_readme() {
     let spec = parse_fixture("basic-battery-pack");


### PR DESCRIPTION
A number of links were broken. This PR makes a few changes but the big one is adding a link-checker on the generated code (mdbook-linkcheck2 was not working for some reason or another, I forget why).

Also:

* Use absolute links in our battery packs because the content is copied around. 
* Avoid using `README.md` because mdbook's renaming is buggy (see https://github.com/rust-lang/mdBook/issues/984).

