### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,7 +462,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "battery-pack"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "battery-pack",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "bphelper-cli"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "bphelper-manifest",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-bp"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/src/battery-pack/CHANGELOG.md
+++ b/src/battery-pack/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.6.0...battery-pack-v0.6.1) - 2026-07-25
+
+### Other
+
+- Merge pull request #160 from gme-muriuki/bp-managed-target-cfg
+- Merge branch 'main' into bp-managed-target-cfg
+
 ## [0.6.0](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.5.5...battery-pack-v0.6.0) - 2026-07-16
 
 ### Added

--- a/src/battery-pack/CHANGELOG.md
+++ b/src/battery-pack/CHANGELOG.md
@@ -9,10 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.1](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.6.0...battery-pack-v0.6.1) - 2026-07-25
 
+### Added
+
+- *(bp-managed)* resolve managed deps in target-gated tables ([#160](https://github.com/battery-pack-rs/battery-pack/pull/160) by @gme-muriuki)
+
 ### Other
 
-- Merge pull request #160 from gme-muriuki/bp-managed-target-cfg
-- Merge branch 'main' into bp-managed-target-cfg
+- *(tui)* modularize tui.rs into components and utils ([#181](https://github.com/battery-pack-rs/battery-pack/pull/181) by @shamnad-sherief)
 
 ## [0.6.0](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.5.5...battery-pack-v0.6.0) - 2026-07-16
 

--- a/src/battery-pack/Cargo.toml
+++ b/src/battery-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "battery-pack"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 description = "Curated crate bundles with docs, templates, and agentic skills"
 license = "MIT OR Apache-2.0"
@@ -22,7 +22,7 @@ cli = ["bphelper-cli"]
 
 [dependencies]
 bphelper-build = { path = "bphelper-build", version = "0.5.0", optional = true }
-bphelper-cli = { path = "bphelper-cli", version = "0.10.0", optional = true }
+bphelper-cli = { path = "bphelper-cli", version = "0.10.1", optional = true }
 bphelper-manifest = { path = "bphelper-manifest", version = "0.6.0" }
 anyhow.workspace = true
 

--- a/src/battery-pack/bphelper-cli/CHANGELOG.md
+++ b/src/battery-pack/bphelper-cli/CHANGELOG.md
@@ -9,10 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.10.1](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.10.0...bphelper-cli-v0.10.1) - 2026-07-25
 
+### Added
+
+- *(bp-managed)* resolve managed deps in target-gated tables ([#160](https://github.com/battery-pack-rs/battery-pack/pull/160) by @gme-muriuki)
+
 ### Other
 
-- Merge pull request #160 from gme-muriuki/bp-managed-target-cfg
-- Merge branch 'main' into bp-managed-target-cfg
+- *(tui)* modularize tui.rs into components and utils ([#181](https://github.com/battery-pack-rs/battery-pack/pull/181) by @shamnad-sherief)
 
 ## [0.10.0](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.9.0...bphelper-cli-v0.10.0) - 2026-07-16
 

--- a/src/battery-pack/bphelper-cli/CHANGELOG.md
+++ b/src/battery-pack/bphelper-cli/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.10.0...bphelper-cli-v0.10.1) - 2026-07-25
+
+### Other
+
+- Merge pull request #160 from gme-muriuki/bp-managed-target-cfg
+- Merge branch 'main' into bp-managed-target-cfg
+
 ## [0.10.0](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.9.0...bphelper-cli-v0.10.0) - 2026-07-16
 
 ### Added

--- a/src/battery-pack/bphelper-cli/Cargo.toml
+++ b/src/battery-pack/bphelper-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bphelper-cli"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2024"
 description = "CLI for creating and managing battery packs"
 license = "MIT OR Apache-2.0"

--- a/src/cargo-bp/CHANGELOG.md
+++ b/src/cargo-bp/CHANGELOG.md
@@ -9,10 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.1](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-v0.6.0...cargo-bp-v0.6.1) - 2026-07-25
 
+### Added
+
+- *(bp-managed)* resolve managed deps in target-gated tables ([#160](https://github.com/battery-pack-rs/battery-pack/pull/160) by @gme-muriuki)
+
 ### Other
 
-- Merge pull request #160 from gme-muriuki/bp-managed-target-cfg
-- Merge branch 'main' into bp-managed-target-cfg
+- *(tui)* modularize tui.rs into components and utils ([#181](https://github.com/battery-pack-rs/battery-pack/pull/181) by @shamnad-sherief)
 
 ## [0.6.0](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-v0.5.6...cargo-bp-v0.6.0) - 2026-07-16
 

--- a/src/cargo-bp/CHANGELOG.md
+++ b/src/cargo-bp/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-v0.6.0...cargo-bp-v0.6.1) - 2026-07-25
+
+### Other
+
+- Merge pull request #160 from gme-muriuki/bp-managed-target-cfg
+- Merge branch 'main' into bp-managed-target-cfg
+
 ## [0.6.0](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-v0.5.6...cargo-bp-v0.6.0) - 2026-07-16
 
 ### Added

--- a/src/cargo-bp/Cargo.toml
+++ b/src/cargo-bp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-bp"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 description = "CLI for creating and managing battery packs (cargo bp)"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `bphelper-cli`: 0.10.0 -> 0.10.1 (✓ API compatible changes)
* `battery-pack`: 0.6.0 -> 0.6.1 (✓ API compatible changes)
* `cargo-bp`: 0.6.0 -> 0.6.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `bphelper-cli`

<blockquote>

## [0.10.1](https://github.com/battery-pack-rs/battery-pack/compare/bphelper-cli-v0.10.0...bphelper-cli-v0.10.1) - 2026-07-25

### Other

- Merge pull request #160 from gme-muriuki/bp-managed-target-cfg
- Merge branch 'main' into bp-managed-target-cfg
</blockquote>

## `battery-pack`

<blockquote>

## [0.6.1](https://github.com/battery-pack-rs/battery-pack/compare/battery-pack-v0.6.0...battery-pack-v0.6.1) - 2026-07-25

### Other

- Merge pull request #160 from gme-muriuki/bp-managed-target-cfg
- Merge branch 'main' into bp-managed-target-cfg
</blockquote>

## `cargo-bp`

<blockquote>

## [0.6.1](https://github.com/battery-pack-rs/battery-pack/compare/cargo-bp-v0.6.0...cargo-bp-v0.6.1) - 2026-07-25

### Other

- Merge pull request #160 from gme-muriuki/bp-managed-target-cfg
- Merge branch 'main' into bp-managed-target-cfg
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).