### PR TITLE
perf(bphelper-cli): batch rustfmt into a single process per render

### DIFF
--- a/src/battery-pack/bphelper-cli/src/template_engine.rs
+++ b/src/battery-pack/bphelper-cli/src/template_engine.rs
@@ -313,38 +313,148 @@ fn render(
 
     // Normalize rendered Rust through rustfmt so generated output is formatting-stable regardless
     // of template whitespace. No-ops if rustfmt is missing or rejects the input.
-    for file in files.iter_mut().filter(|f| f.path.ends_with(".rs")) {
-        file.content = rustfmt_rust(std::mem::take(&mut file.content));
-    }
+    rustfmt_rust_files(&mut files);
 
     Ok(files)
 }
 
-/// Formats Rust source with rustfmt (edition 2024) over stdin/stdout, with no temporary files so
-/// it works for previews too. Returns the input unchanged if rustfmt is unavailable or fails, so
-/// generation never hard-depends on a rustfmt install.
-fn rustfmt_rust(source: String) -> String {
+/// Formats rendered Rust files with rustfmt (edition 2024). Returns all files unchanged if rustfmt
+/// is unavailable or fails, so generation never hard-depends on a rustfmt install.
+fn rustfmt_rust_files(files: &mut [RenderedFile]) {
+    rustfmt_rust_files_with(files, Path::new("rustfmt"));
+}
+
+fn rustfmt_rust_files_with(files: &mut [RenderedFile], rustfmt: &Path) {
+    use std::collections::HashSet;
+    use std::path::Component;
+    use std::process::{Command, Stdio};
+
+    // Select Rust sources before creating a temporary workspace or spawning rustfmt.
+    let rust_files: Vec<usize> = files
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, file)| file.path.ends_with(".rs").then_some(idx))
+        .collect();
+    if rust_files.is_empty() {
+        return;
+    }
+
+    // Preserve independent contents for duplicate rendered paths, which cannot share one temp file.
+    let mut rendered_paths = HashSet::with_capacity(rust_files.len());
+    if rust_files
+        .iter()
+        .any(|&idx| !rendered_paths.insert(files[idx].path.as_str()))
+    {
+        let mut formatted_files = Vec::with_capacity(rust_files.len());
+        for &idx in &rust_files {
+            let Some(formatted) = rustfmt_rust_source(&files[idx].content, rustfmt) else {
+                return;
+            };
+            formatted_files.push(formatted);
+        }
+        for (&idx, formatted) in rust_files.iter().zip(formatted_files) {
+            files[idx].content = formatted;
+        }
+        return;
+    }
+
+    // Materialize the rendered Rust in a tempdir so one rustfmt process can format every file.
+    let Ok(tempdir) = tempfile::tempdir() else {
+        return;
+    };
+    let mut paths = Vec::with_capacity(rust_files.len());
+    for &idx in &rust_files {
+        let rel_path = Path::new(&files[idx].path);
+        if !rel_path
+            .components()
+            .all(|component| matches!(component, Component::Normal(_)))
+        {
+            return;
+        }
+
+        let path = tempdir.path().join(rel_path);
+        if let Some(parent) = path.parent()
+            && std::fs::create_dir_all(parent).is_err()
+        {
+            return;
+        }
+        if std::fs::write(&path, &files[idx].content).is_err() {
+            return;
+        }
+        paths.push(path);
+    }
+
+    // Preserve the configuration that stdin-based formatting discovers from the caller's cwd.
+    let mut command = Command::new(rustfmt);
+    command.args(["--edition", "2024", "--quiet"]);
+    if let Some(config_path) = rustfmt_config_path() {
+        command.arg("--config-path").arg(config_path);
+    }
+
+    // Match stdin behavior by formatting explicit paths without resolving their child modules.
+    command.args(["--config", "skip_children=true"]);
+
+    // Read the formatted temp files back only after rustfmt succeeds for the whole batch.
+    let status = command
+        .args(&paths)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+    if !status.is_ok_and(|status| status.success()) {
+        return;
+    }
+
+    // Collect every result before modifying the originals so read failures are all-or-nothing.
+    let mut formatted_files = Vec::with_capacity(paths.len());
+    for path in &paths {
+        let Ok(formatted) = std::fs::read_to_string(path) else {
+            return;
+        };
+        formatted_files.push(formatted);
+    }
+
+    // Apply the complete successful batch to the corresponding rendered files.
+    for (&idx, formatted) in rust_files.iter().zip(formatted_files) {
+        files[idx].content = formatted;
+    }
+}
+
+fn rustfmt_config_path() -> Option<PathBuf> {
+    let current_dir = std::env::current_dir().ok()?;
+    rustfmt_config_path_from(&current_dir)
+}
+
+fn rustfmt_config_path_from(start: &Path) -> Option<PathBuf> {
+    // Match rustfmt's stdin lookup: nearest ancestor first, with the hidden filename preferred.
+    for directory in start.ancestors() {
+        for filename in [".rustfmt.toml", "rustfmt.toml"] {
+            let candidate = directory.join(filename);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+fn rustfmt_rust_source(source: &str, rustfmt: &Path) -> Option<String> {
     use std::io::{Read, Write};
     use std::process::{Command, Stdio};
 
-    let mut child = match Command::new("rustfmt")
+    // Format one source over pipes when duplicate rendered paths cannot share a temporary tree.
+    let mut child = Command::new(rustfmt)
         .args(["--edition", "2024", "--emit", "stdout", "--quiet"])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
         .spawn()
-    {
-        Ok(child) => child,
-        Err(_) => return source,
-    };
+        .ok()?;
 
-    // Feed stdin from another thread so a full stdout pipe can't deadlock the write.
+    // Feed stdin concurrently so a full stdout pipe cannot deadlock the write.
     let mut stdin = child.stdin.take().expect("stdin is piped");
-    let input = source.clone();
-    let writer = std::thread::spawn(move || {
-        let _ = stdin.write_all(input.as_bytes());
-    });
-
+    let input = source.to_owned();
+    let writer = std::thread::spawn(move || stdin.write_all(input.as_bytes()));
     let mut formatted = String::new();
     let read_ok = child
         .stdout
@@ -352,11 +462,12 @@ fn rustfmt_rust(source: String) -> String {
         .expect("stdout is piped")
         .read_to_string(&mut formatted)
         .is_ok();
-    let _ = writer.join();
+    let write_ok = writer.join().is_ok_and(|result| result.is_ok());
 
+    // Return output only when every pipe operation and rustfmt itself completed successfully.
     match child.wait() {
-        Ok(status) if status.success() && read_ok => formatted,
-        _ => source,
+        Ok(status) if status.success() && read_ok && write_ok => Some(formatted),
+        _ => None,
     }
 }
 fn prepare_render(

--- a/src/battery-pack/bphelper-cli/src/template_engine/tests.rs
+++ b/src/battery-pack/bphelper-cli/src/template_engine/tests.rs
@@ -28,6 +28,217 @@ fn test_resolve(
     resolve_placeholders(defs, &resolved, defines, variables, interactive_override)
 }
 
+#[cfg(unix)]
+fn fake_rustfmt(script_body: &str) -> (tempfile::TempDir, PathBuf, PathBuf) {
+    use std::os::unix::fs::PermissionsExt;
+
+    // Create an isolated executable and counter so tests never mutate process-wide PATH state.
+    let tempdir = tempfile::tempdir().unwrap();
+    let executable = tempdir.path().join("rustfmt");
+    let counter = tempdir.path().join("invocations");
+    let counter_path = counter.to_string_lossy();
+    assert!(!counter_path.contains('\''));
+    std::fs::write(
+        &executable,
+        format!("#!/bin/sh\ncounter='{counter_path}'\n{script_body}"),
+    )
+    .unwrap();
+
+    // Mark the script executable before passing its absolute path to the formatter helper.
+    let mut permissions = std::fs::metadata(&executable).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&executable, permissions).unwrap();
+
+    (tempdir, executable, counter)
+}
+
+#[cfg(unix)]
+fn rendered_file(path: &str, content: &str) -> RenderedFile {
+    RenderedFile {
+        path: path.to_string(),
+        content: content.to_string(),
+    }
+}
+
+// -- rustfmt batching --
+
+#[test]
+fn rustfmt_config_uses_nearest_ancestor_and_hidden_name() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let nested = tempdir.path().join("project/src");
+    let sibling = tempdir.path().join("other/src");
+    std::fs::create_dir_all(&nested).unwrap();
+    std::fs::create_dir_all(&sibling).unwrap();
+    std::fs::write(tempdir.path().join("rustfmt.toml"), "max_width = 100\n").unwrap();
+    std::fs::write(
+        tempdir.path().join("project/rustfmt.toml"),
+        "max_width = 80\n",
+    )
+    .unwrap();
+    std::fs::write(
+        tempdir.path().join("project/.rustfmt.toml"),
+        "max_width = 60\n",
+    )
+    .unwrap();
+
+    // The closest directory wins, and .rustfmt.toml wins when both names exist there.
+    assert_eq!(
+        rustfmt_config_path_from(&nested),
+        Some(tempdir.path().join("project/.rustfmt.toml"))
+    );
+    assert_eq!(
+        rustfmt_config_path_from(&sibling),
+        Some(tempdir.path().join("rustfmt.toml"))
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn rustfmt_formats_multiple_files_with_one_process() {
+    let (_tempdir, rustfmt, counter) = fake_rustfmt(
+        r#"
+printf '1\n' >> "$counter"
+case " $* " in
+    *" --config skip_children=true "*) ;;
+    *) exit 1 ;;
+esac
+for path in "$@"; do
+    case "$path" in
+        *.rs)
+            output="${path}.formatted"
+            { printf 'formatted:'; cat "$path"; } > "$output"
+            mv "$output" "$path"
+            ;;
+    esac
+done
+"#,
+    );
+    let mut files = vec![
+        rendered_file("src/lib.rs", "first"),
+        rendered_file("README.md", "documentation"),
+        rendered_file("src/main.rs", "second"),
+    ];
+
+    // Multiple unique Rust paths share one formatter process while non-Rust content is untouched.
+    rustfmt_rust_files_with(&mut files, &rustfmt);
+
+    assert_eq!(std::fs::read_to_string(counter).unwrap(), "1\n");
+    assert_eq!(files[0].content, "formatted:first");
+    assert_eq!(files[1].content, "documentation");
+    assert_eq!(files[2].content, "formatted:second");
+}
+
+#[cfg(unix)]
+#[test]
+fn rustfmt_formats_duplicate_paths_independently() {
+    let (_tempdir, rustfmt, counter) = fake_rustfmt(
+        r#"
+printf '1\n' >> "$counter"
+printf 'formatted:'
+cat
+"#,
+    );
+    let mut files = vec![
+        rendered_file("src/lib.rs", "first"),
+        rendered_file("src/lib.rs", "second"),
+    ];
+
+    // Duplicate destinations use independent stdin streams so neither entry overwrites the other.
+    rustfmt_rust_files_with(&mut files, &rustfmt);
+
+    assert_eq!(std::fs::read_to_string(counter).unwrap(), "1\n1\n");
+    assert_eq!(files[0].content, "formatted:first");
+    assert_eq!(files[1].content, "formatted:second");
+}
+
+#[cfg(unix)]
+#[test]
+fn rustfmt_skips_batches_without_rust_files() {
+    let (_tempdir, rustfmt, counter) = fake_rustfmt("printf '1\\n' >> \"$counter\"\nexit 0\n");
+    let mut files = vec![rendered_file("README.md", "documentation")];
+
+    // A non-Rust batch requires no temporary formatting process.
+    rustfmt_rust_files_with(&mut files, &rustfmt);
+
+    assert!(!counter.exists());
+    assert_eq!(files[0].content, "documentation");
+}
+
+#[cfg(unix)]
+#[test]
+fn rustfmt_failure_leaves_all_files_unchanged() {
+    let (_tempdir, rustfmt, counter) = fake_rustfmt(
+        r#"
+printf '1\n' >> "$counter"
+for path in "$@"; do
+    case "$path" in
+        *.rs) printf 'changed' > "$path" ;;
+    esac
+done
+exit 1
+"#,
+    );
+    let mut files = vec![
+        rendered_file("src/lib.rs", "first"),
+        rendered_file("src/main.rs", "second"),
+    ];
+
+    // A failed formatter may alter its temp files but cannot alter the rendered batch.
+    rustfmt_rust_files_with(&mut files, &rustfmt);
+
+    assert_eq!(std::fs::read_to_string(counter).unwrap(), "1\n");
+    assert_eq!(files[0].content, "first");
+    assert_eq!(files[1].content, "second");
+}
+
+#[cfg(unix)]
+#[test]
+fn rustfmt_read_failure_leaves_all_files_unchanged() {
+    let (_tempdir, rustfmt, counter) = fake_rustfmt(
+        r#"
+printf '1\n' >> "$counter"
+last_rust_file=
+for path in "$@"; do
+    case "$path" in
+        *.rs)
+            printf 'changed' > "$path"
+            last_rust_file="$path"
+            ;;
+    esac
+done
+rm "$last_rust_file"
+"#,
+    );
+    let mut files = vec![
+        rendered_file("src/lib.rs", "first"),
+        rendered_file("src/main.rs", "second"),
+    ];
+
+    // Read-back is transactional even when rustfmt exits successfully but output disappears.
+    rustfmt_rust_files_with(&mut files, &rustfmt);
+
+    assert_eq!(std::fs::read_to_string(counter).unwrap(), "1\n");
+    assert_eq!(files[0].content, "first");
+    assert_eq!(files[1].content, "second");
+}
+
+#[cfg(unix)]
+#[test]
+fn rustfmt_rejects_unsafe_paths_without_modifying_files() {
+    let (_tempdir, rustfmt, counter) = fake_rustfmt("printf '1\\n' >> \"$counter\"\nexit 0\n");
+    let mut files = vec![
+        rendered_file("src/lib.rs", "safe"),
+        rendered_file("../outside.rs", "unsafe"),
+    ];
+
+    // Reject the complete batch before spawning rustfmt if any destination can escape the tempdir.
+    rustfmt_rust_files_with(&mut files, &rustfmt);
+
+    assert!(!counter.exists());
+    assert_eq!(files[0].content, "safe");
+    assert_eq!(files[1].content, "unsafe");
+}
+
 // -- Config parsing --
 // [verify format.templates.engine]
 


### PR DESCRIPTION
## Summary

- Batch rustfmt formatting of rendered .rs files into a single process per render, instead of spawning one per file
- Preserve stdin-equivalent behavior by using --config skip_children=true (avoid resolving mod children from temp files) and --config-path (rediscover the caller's rustfmt.toml/.rustfmt.toml the same way stdin formatting did)
- Falls back to the previous per-file pipe approach for duplicate rendered paths (which can't share one temp file); still no-ops entirely on any rustfmt/temp-file failure so generation never hard-depends on rustfmt being installed

## Tests

- [x] cargo test -p bphelper-cli — new unit tests cover multi-file batching, duplicate paths, missing-rustfmt files, failure/read-failure rollback, and unsafe-path rejection
- [x] cargo test --all --workspace passes
- [x] cargo clippy --all-targets and cargo fmt --check clean
- [x] Manually verified against real rustfmt: skip_children=true prevents mod-resolution errors on temp files, and --config-path correctly picks up project rustfmt.toml/.rustfmt.toml with the same precedence as stdin formatting
- [x] Benchmarked: 30 files formatted individually (0.35s) vs. batched (0.014s), ~25x faster

Closes #184 