### PR TITLE
docs: add logo linking to the book at the top of the README

### DIFF
--- a/src/battery-pack/README.md
+++ b/src/battery-pack/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <a href="https://battery-pack-rs.github.io/battery-pack"><img src="https://raw.githubusercontent.com/battery-pack-rs/battery-pack/main/md/logo/battery-pack-logo.png" alt="Battery Pack logo" width="200"></a>
+</p>
+
 # battery-pack
 
 Curated crate bundles with docs, templates, and agentic skills.


### PR DESCRIPTION
like it says on the tin

[rendered](https://github.com/battery-pack-rs/battery-pack/blob/7ae0246bc4967fc7458a010a58379bad555a283a/src/battery-pack/README.md)